### PR TITLE
Remove unnecassary call to Observable::take.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fun main(args: Array<String>) {
         for (org in listOf("Kotlin", "ReactiveX")) {
             // `awaitSingle()` call here is a suspension point,
             // i.e. coroutine's code stops on it until request is not completed
-            val repos = github.orgRepos(org).take(5).awaitSingle().joinToString()
+            val repos = github.orgRepos(org).awaitSingle().joinToString()
 
             println("$org: $repos")
         }


### PR DESCRIPTION
Retrofit calls `onNext` only once, so there is no reason to limit it to 5.
If you want only 5 elements from the `List<Repo>`,
then you need to `flatMapIterable`, `take` and `toList`, but
it makes more sense to do that via Kotlin collections functions after `awaitSingle`.