### PR TITLE
kotlinx-coroutines-android: set android dependency scope to provided …

### DIFF
--- a/ui/kotlinx-coroutines-android/pom.xml
+++ b/ui/kotlinx-coroutines-android/pom.xml
@@ -52,6 +52,7 @@
             <groupId>com.google.android</groupId>
             <artifactId>android</artifactId>
             <version>2.3.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…to eliminate warnings when using it in android project