### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add Bintray JCenter repository:
 
 ```groovy
 repositories {
-    `maven { url "https://kotlin.bintray.com/kotlinx/" }` 
+    maven { url "https://kotlin.bintray.com/kotlinx/" }
 }
 ```
 


### PR DESCRIPTION
rm extraneous backticks in gradle code