### PR TITLE
Basic CoroutineExceptionHandler implementation.

### DIFF
--- a/kotlinx-coroutines-core/README.md
+++ b/kotlinx-coroutines-core/README.md
@@ -100,6 +100,7 @@ Select expression to perform multiple suspending operations simultaneously until
 [suspendCancellableCoroutine]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/suspend-cancellable-coroutine.html
 [NonCancellable]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-non-cancellable/index.html
 [newCoroutineContext]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/new-coroutine-context.html
+[CoroutineExceptionHandler]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-coroutine-exception-handler/index.html
 <!--- INDEX kotlinx.coroutines.experimental.sync -->
 [kotlinx.coroutines.experimental.sync.Mutex]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental.sync/-mutex/index.html
 [kotlinx.coroutines.experimental.sync.Mutex.lock]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental.sync/-mutex/lock.html

--- a/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineExceptionHandler.kt
+++ b/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineExceptionHandler.kt
@@ -16,6 +16,7 @@
 
 package kotlinx.coroutines.experimental
 
+import kotlin.coroutines.experimental.AbstractCoroutineContextElement
 import kotlin.coroutines.experimental.CoroutineContext
 
 
@@ -51,7 +52,17 @@ public interface CoroutineExceptionHandler : CoroutineContext.Element {
     /**
      * Key for [CoroutineExceptionHandler] instance in the coroutine context.
      */
-    companion object Key : CoroutineContext.Key<CoroutineExceptionHandler>
+    companion object Key : CoroutineContext.Key<CoroutineExceptionHandler> {
+        /**
+         * Creates new [CoroutineExceptionHandler] instance.
+         * @param handler a function which handles exception thrown by a coroutine
+         */
+        public operator inline fun invoke(crossinline handler: (CoroutineContext, Throwable) -> Unit): CoroutineExceptionHandler =
+            object: AbstractCoroutineContextElement(Key), CoroutineExceptionHandler {
+                override fun handleException(context: CoroutineContext, exception: Throwable) =
+                    handler.invoke(context, exception)
+            }
+    }
 
     /**
      * Handles uncaught [exception] in the given [context]. It is invoked

--- a/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/CoroutineExceptionHandlerTest.kt
+++ b/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/CoroutineExceptionHandlerTest.kt
@@ -1,0 +1,28 @@
+package kotlinx.coroutines.experimental
+
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class CoroutineExceptionHandlerTest {
+    @Test
+    fun testCoroutineExceptionHandlerCreator() {
+        val latch = CountDownLatch(1)
+        var coroutineException: Throwable? = null
+
+        val handler = CoroutineExceptionHandler { _, ex ->
+            coroutineException = ex
+            latch.countDown()
+        }
+
+        launch(CommonPool + handler) {
+            throw TestException()
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+
+        check(coroutineException is TestException)
+    }
+}
+
+private class TestException: RuntimeException()


### PR DESCRIPTION
Currently there is no `CoroutineExceptionHandler` implementation. It'd be useful to have even a simple one.

With this PR it is possible to create a basic `CoroutineExceptionHandler` with this simple code:

```kotlin
val handler = CoroutineExceptionHandler { _, ex ->
    println("Got exception: ${ex.message}")
}

launch(CommonPool + handler) {
    // do sth
    // the exception thrown here will be handled by the println above
}
```

See also `CoroutineExceptionHandlerTest`.