### PR TITLE
Fix error that fail to dispose handler when job is in SINGLE/SINGLE+ state

### DIFF
--- a/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/Job.kt
+++ b/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/Job.kt
@@ -638,7 +638,7 @@ public open class JobSupport(active: Boolean) : AbstractCoroutineContextElement(
             when (state) {
                 // SINGE/SINGLE+ state -- one completion handler
                 is JobNode<*> -> {
-                    if (state !== this) return // a different job node --> we were already removed
+                    if (state !== node) return // a different job node --> we were already removed
                     // try remove and revert back to empty state
                     if (STATE.compareAndSet(this, state, EmptyActive)) return
                 }

--- a/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/JobTest.kt
+++ b/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/JobTest.kt
@@ -127,7 +127,7 @@ class JobTest : TestBase() {
         var fireCount = 0
         for (i in 0 until n) job.invokeOnCompletion { fireCount++ }.dispose()
     }
-    
+
     @Test
     fun testCancelledParent() {
         val parent = Job()
@@ -135,5 +135,26 @@ class JobTest : TestBase() {
         check(!parent.isActive)
         val child = Job(parent)
         check(!child.isActive)
+    }
+
+    @Test
+    fun testDisposeSingleHandler() {
+        val job = Job()
+        var fireCount = 0
+        val handler = job.invokeOnCompletion { fireCount++ }
+        handler.dispose()
+        job.cancel()
+        assertEquals(0, fireCount)
+    }
+
+    @Test
+    fun testDisposeMultipleHandler() {
+        val job = Job()
+        val handlerCount = 10
+        var fireCount = 0
+        val handlers = Array(handlerCount) { job.invokeOnCompletion { fireCount++ } }
+        handlers.forEach { it.dispose() }
+        job.cancel()
+        assertEquals(0, fireCount)
     }
 }


### PR DESCRIPTION
When disposing a handler, the corresponding job node will be removed from job's state.

When job is in SINGLE/SINGLE+ state, we compare state with the job node to ensure we remove the correct job node. However, the origin code compares state with the job itself, which is always false, causing the job node still stays in job's state.

This pull request aims to fix the bug described above. The corresponding unit tests are also added (`testDisposeSingleHandler` will fail before fixed).