### PR TITLE
reactor.core.Cancellation is removed from project reactor from 3.1.0.M1

### DIFF
--- a/reactive/kotlinx-coroutines-reactor/src/main/kotlin/kotlinx/coroutines/experimental/reactor/Mono.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/main/kotlin/kotlinx/coroutines/experimental/reactor/Mono.kt
@@ -43,7 +43,7 @@ fun <T> mono(
     val newContext = newCoroutineContext(context)
     val coroutine = MonoCoroutine(newContext, sink)
     coroutine.initParentJob(context[Job])
-    sink.setCancellation(coroutine)
+    sink.onDispose(coroutine)
     block.startCoroutine(coroutine, coroutine)
 }
 


### PR DESCRIPTION
reactor.core.Cancellation is removed from project reactor from 3.1.0.M1

kotlinx.coroutines.experimental.reactor.mono will throw ClassNotFoundException

so in the next versions , we need to use Disposable as replacement and set method from setCancellation to onDispose 