### PR TITLE
Update Maven Central link to a more useful search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is a companion version for Kotlin 1.2.0 release.
 
 The libraries are published to [kotlinx](https://bintray.com/kotlin/kotlinx/kotlinx.coroutines) bintray repository,
 linked to [JCenter](https://bintray.com/bintray/jcenter?filterByPkgName=kotlinx.coroutines) and 
-pushed to [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.jetbrains.kotlinx%20a%3Akotlinx-coroutines).
+pushed to [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.jetbrains.kotlinx%20a%3Akotlinx-coroutines*).
 
 ### Maven
 


### PR DESCRIPTION
It links to a much more useful search page, showing the sub-packages, too.