### PR TITLE
Closeable with suspendable aClose, and suspendable use extension.

### DIFF
--- a/core/kotlinx-coroutines-io/src/main/kotlin/kotlinx/coroutines/experimental/io/Closeable.kt
+++ b/core/kotlinx-coroutines-io/src/main/kotlin/kotlinx/coroutines/experimental/io/Closeable.kt
@@ -1,0 +1,26 @@
+package kotlinx.coroutines.experimental.io
+
+interface Closeable {
+    suspend fun aClose()
+}
+
+suspend inline fun <T : Closeable?, R> T.use(block: (T) -> R): R {
+    var exception: Throwable? = null
+    try {
+        return block(this)
+    } catch (e: Throwable) {
+        exception = e
+        throw e
+    } finally {
+        when {
+            this == null -> {}
+            exception == null -> aClose()
+            else ->
+                try {
+                    aClose()
+                } catch (closeException: Throwable) {
+                    exception.addSuppressed(closeException)
+                }
+        }
+    }
+}

--- a/core/kotlinx-coroutines-io/src/test/kotlin/kotlinx/coroutines/experimental/io/CloseableTest.kt
+++ b/core/kotlinx-coroutines-io/src/test/kotlin/kotlinx/coroutines/experimental/io/CloseableTest.kt
@@ -1,0 +1,44 @@
+package kotlinx.coroutines.experimental.io
+
+import kotlinx.coroutines.experimental.TestBase
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Test
+import org.junit.Assert.*
+
+class CloseableTest : TestBase() {
+
+    class TestCloseable: Closeable {
+        internal var closed = false
+        override suspend fun aClose() {
+            closed = true
+        }
+        fun throwing(): Unit = throw RuntimeException()
+        fun notThrowing() {}
+    }
+
+    @Test
+    fun testNoExceptionThrown() = runBlocking {
+        TestCloseable().let {
+            it.use {
+                it.notThrowing()
+            }
+            assertTrue(it.closed)
+        }
+    }
+
+    @Test
+    fun testExceptionThrown() = runBlocking {
+        TestCloseable().let {
+            try {
+                it.use {
+                    it.throwing()
+                }
+                fail()
+            }
+            catch (e: RuntimeException) {
+                assertTrue(it.closed)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Closeable interface similar to java.io.Closeable, but with a suspendable aClose method.
I used the name aClose to be consistant with aRead and aWrite on channels.
I've added simple tests as well that check that the aClose method is called, whether an exception is thrown or not.
