### PR TITLE
Avoid `moreTest` task on `gradle build -x test` build

### DIFF
--- a/core/kotlinx-coroutines-core/build.gradle
+++ b/core/kotlinx-coroutines-core/build.gradle
@@ -32,7 +32,7 @@ task jdk16Test(type: Test, dependsOn: testClasses) {
 
 task moreTest(dependsOn: [lockFreedomTest, jdk16Test])
 
-build.dependsOn moreTest
+test.dependsOn moreTest
 
 task testsJar(type: Jar, dependsOn: testClasses) {
     classifier = 'tests'


### PR DESCRIPTION
Allow build without test if `JDK_16` environment variable is not set ( #291)