### PR TITLE
Allow to change the default dispatcher

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/CommonCoroutineDispatcher.kt
+++ b/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/CommonCoroutineDispatcher.kt
@@ -17,6 +17,7 @@
 package kotlinx.coroutines.experimental
 
 import kotlin.coroutines.experimental.*
+import kotlin.jvm.Volatile
 
 public expect abstract class CoroutineDispatcher constructor() : AbstractCoroutineContextElement, ContinuationInterceptor {
     public open fun isDispatchNeeded(context: CoroutineContext): Boolean
@@ -32,6 +33,7 @@ public expect val DefaultDefaultDispatcher: CoroutineDispatcher
 
 private fun getDefaultDefaultDispatcherHelper() = DefaultDefaultDispatcher
 
+@Volatile
 var DefaultDispatcherProvider: () -> CoroutineDispatcher = { getDefaultDefaultDispatcherHelper() }
 
 @Suppress("PropertyName")

--- a/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/CommonCoroutineDispatcher.kt
+++ b/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/CommonCoroutineDispatcher.kt
@@ -28,5 +28,11 @@ public expect interface Runnable {
     public fun run()
 }
 
+public expect val DefaultDefaultDispatcher: CoroutineDispatcher
+
+private fun getDefaultDefaultDispatcherHelper() = DefaultDefaultDispatcher
+
+var DefaultDispatcherProvider: () -> CoroutineDispatcher = { getDefaultDefaultDispatcherHelper() }
+
 @Suppress("PropertyName")
-public expect val DefaultDispatcher: CoroutineDispatcher
+public val DefaultDispatcher: CoroutineDispatcher get() = DefaultDispatcherProvider()

--- a/core/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineContext.kt
+++ b/core/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineContext.kt
@@ -72,7 +72,7 @@ public typealias Here = Unconfined
  * It is currently equal to [CommonPool], but the value is subject to change in the future.
  */
 @Suppress("PropertyName")
-public actual val DefaultDispatcher: CoroutineDispatcher = CommonPool
+public actual val DefaultDefaultDispatcher: CoroutineDispatcher = CommonPool
 
 /**
  * Creates context for the new coroutine. It installs [DefaultDispatcher] when no other dispatcher nor

--- a/js/kotlinx-coroutines-core-js/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineContext.kt
+++ b/js/kotlinx-coroutines-core-js/src/main/kotlin/kotlinx/coroutines/experimental/CoroutineContext.kt
@@ -44,7 +44,7 @@ private const val UNDEFINED = "undefined"
  * [launch], [async], etc if no dispatcher nor any other [ContinuationInterceptor] is specified in their context.
  */
 @Suppress("PropertyName", "UnsafeCastFromDynamic")
-public actual val DefaultDispatcher: CoroutineDispatcher = when {
+public actual val DefaultDefaultDispatcher: CoroutineDispatcher = when {
     // Check if we are running under ReactNative. We have to use NodeDispatcher under it.
     // The problem is that ReactNative has a `window` object with `addEventListener`, but it does not  really work.
     // For details see https://github.com/Kotlin/kotlinx.coroutines/issues/236


### PR DESCRIPTION
I want to upgrade my libraries to use kotlinx.coroutines. But my main concern, and the only thing that is blocking me at this point, is that right now `launch` blocks (and anything using the 
`DefaultDispatcher` as default), by default use a ThreadPool on the JVM.

Use case: In my case I use a Node.JS/JS approach for building common projects:  the application login runs in a single thread. That prevents having to think about synchronizing non async primitives in the final user code and provides consistency between JS and JVM targets.

This behaviour might not be what people want, but what some people will want. So my proposal here is to allow to change the default dispatcher so people doing libraries or final code can chose what to do without forcing final users to specify always a dispatcher that is also prone to error.

On my side I would want to implement something like this:

```
fun main(args: Array<String>) = EventLoop {
    ...
}

// Or call this something like `SingleThread`?
fun EventLoop(callback: suspend () -> Unit) {
    val eventLoop = EventLoop()
    temporalSetDefaultDispatcher(eventLoop) {
        callback.startCoroutine(object : Continuation<Unit> {
            override val context: CoroutineContext = eventLoop
            override fun resume(value: Unit) = Unit
            override fun resumeWithException(exception: Throwable) = println(exception)
        })
        eventLoop.execute() // Loop in JVM targets
    }
}

inline fun temporalSetDefaultDispatcher(temporalDispatcher: CoroutineDispatcher, block: () -> Unit) {
    val oldDispatcher = DefaultDispatcherProvider
    DefaultDispatcherProvider = { temporalDispatcher }
    try {
        block()
    } finally {
        DefaultDispatcherProvider = oldDispatcher
    }
}
```

Note: EventLoop implements CoroutineDispatcher and Delay. Though Delay right now not provides a common interface and it is problematic for people trying to implement it in common code (not just calling delay).

I put a provider instead of just a simple global variable so I could later change it per thread. For example by being able to provide a default EventLoop per thread instead of only one global.
