### PR TITLE
Invoke exception handler for actor on cancellation even when channel …

### DIFF
--- a/core/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/channels/Actor.kt
+++ b/core/kotlinx-coroutines-core/src/main/kotlin/kotlinx/coroutines/experimental/channels/Actor.kt
@@ -163,8 +163,9 @@ private open class ActorCoroutine<E>(
     active: Boolean
 ) : ChannelCoroutine<E>(parentContext, channel, active), ActorScope<E>, ActorJob<E> {
     override fun onCancellation(cause: Throwable?) {
-        if (!_channel.cancel(cause) && cause != null)
-            handleCoroutineException(context, cause)
+        _channel.cancel(cause)
+        // Always propagate the exception, don't wait for actor senders
+        if (cause != null) handleCoroutineException(context, cause)
     }
 }
 
@@ -178,7 +179,7 @@ private class LazyActorCoroutine<E>(
         block.startCoroutineCancellable(this, this)
     }
 
-    suspend override fun send(element: E) {
+    override suspend fun send(element: E) {
         start()
         return super.send(element)
     }
@@ -197,4 +198,3 @@ private class LazyActorCoroutine<E>(
         super.onSend.registerSelectClause2(select, param, block)
     }
 }
-

--- a/core/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/channels/ActorTest.kt
+++ b/core/kotlinx-coroutines-core/src/test/kotlin/kotlinx/coroutines/experimental/channels/ActorTest.kt
@@ -146,4 +146,20 @@ class ActorTest(private val capacity: Int) : TestBase() {
 
         finish(3)
     }
+
+    @Test
+    fun testThrowingActor() = runTest(unhandled = listOf({e -> e is IllegalArgumentException})) {
+        val parent = Job()
+        val actor = actor<Int>(context = coroutineContext, parent = parent) {
+            channel.consumeEach {
+                expect(1)
+                throw IllegalArgumentException()
+            }
+        }
+
+        actor.send(1)
+        parent.cancel()
+        parent.join()
+        finish(2)
+    }
 }


### PR DESCRIPTION
…was successfully closed, so exceptions thrown by actor are always reported

Fixes #368