### PR TITLE
Updated the guide fan-out section to use channel iterator

### DIFF
--- a/core/kotlinx-coroutines-core/src/test/kotlin/guide/example-channel-06.kt
+++ b/core/kotlinx-coroutines-core/src/test/kotlin/guide/example-channel-06.kt
@@ -29,8 +29,8 @@ fun produceNumbers() = produce<Int> {
 }
 
 fun launchProcessor(id: Int, channel: ReceiveChannel<Int>) = launch {
-    channel.consumeEach {
-        println("Processor #$id received $it")
+    for (msg in channel) {
+        println("Processor #$id received $msg")
     }    
 }
 

--- a/coroutines-guide.md
+++ b/coroutines-guide.md
@@ -1531,8 +1531,8 @@ received number:
 
 ```kotlin
 fun launchProcessor(id: Int, channel: ReceiveChannel<Int>) = launch {
-    channel.consumeEach {
-        println("Processor #$id received $it")
+    for (msg in channel) {
+        println("Processor #$id received $msg")
     }    
 }
 ```


### PR DESCRIPTION
The `consumeEach` function has a warning about multiple consumption but the `iterator` uses `receive()` in the end, so I think it's a better way to handle this.

See discussion around #167 