### PR TITLE
added note about FIFO order of `Mutex.lock()`

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/sync/Mutex.kt
+++ b/common/kotlinx-coroutines-core-common/src/main/kotlin/kotlinx/coroutines/experimental/sync/Mutex.kt
@@ -68,6 +68,8 @@ public interface Mutex {
      * This function can be used in [select] invocation with [onLock] clause.
      * Use [tryLock] to try acquire lock without waiting.
      *
+     * This function is fair; suspended callers are resumed in first-in-first-out order.
+     *
      * @param owner Optional owner token for debugging. When `owner` is specified (non-null value) and this mutex
      *        is already locked with the same token (same identity), this function throws [IllegalStateException].
      */


### PR DESCRIPTION
- Note that the OpenJDK [documents locks as "fair" when they release "the longest waiting thread"](https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/concurrent/locks/ReentrantLock.java#L55)