### PR TITLE
Ignore resume on cancelled continuation

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
+++ b/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
@@ -277,12 +277,16 @@ internal abstract class AbstractContinuation<in T>(
                 }
                 is CancelledContinuation -> {
                     /*
-                     * If continuation was cancelled, then all further updates (resumes or exceptions) must be
-                     * ignored, because cancellation is asynchronous and may race with resume/resumeWithException.
-                     * This race is normal.
+                     * If continuation was cancelled, then all further resumes must be
+                     * ignored, because cancellation is asynchronous and may race with resume.
+                     * Racy exception are reported so no exceptions are lost
                      *
                      * :todo: we should somehow remember the attempt to invoke resume and fail on the second attempt.
                      */
+                    if (proposedUpdate is CompletedExceptionally) {
+                        handleException(proposedUpdate.cause)
+                    }
+
                     return
                 }
                 else -> error("Already resumed, but proposed with update $proposedUpdate")

--- a/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
+++ b/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
@@ -272,15 +272,17 @@ internal abstract class AbstractContinuation<in T>(
                         }
                     }
                 }
-
                 is NotCompleted -> {
                     if (updateStateToFinal(state, proposedUpdate, resumeMode)) return
                 }
                 is CancelledContinuation -> {
-                    if (proposedUpdate is NotCompleted || proposedUpdate is CompletedExceptionally) {
-                        error("Unexpected update, state: $state, update: $proposedUpdate")
-                    }
-                    // Coroutine is dispatched normally (e.g.via `delay()`) after cancellation
+                    /*
+                     * If continuation was cancelled, then all further updates (resumes or exceptions) must be
+                     * ignored, because cancellation is asynchronous and may race with resume/resumeWithException.
+                     * This race is normal.
+                     *
+                     * :todo: we should somehow remember the attempt to invoke resume and fail on the second attempt.
+                     */
                     return
                 }
                 else -> error("Already resumed, but proposed with update $proposedUpdate")

--- a/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.experimental
+
+import kotlin.coroutines.experimental.*
+import kotlin.test.*
+
+class CancellableContinuationTest : TestBase() {
+    @Test
+    fun testResumeWithExceptionAndResumeWithException() = runTest {
+        var continuation: Continuation<Unit>? = null
+        val job = launch(coroutineContext) {
+            try {
+                expect(2)
+                suspendCancellableCoroutine<Unit> { c ->
+                    continuation = c
+                }
+            } catch (e: TestException) {
+                expect(3)
+            }
+        }
+        expect(1)
+        yield()
+        continuation!!.resumeWithException(TestException())
+        yield()
+        assertFailsWith<IllegalStateException> { continuation!!.resumeWithException(TestException()) }
+        job.join()
+        finish(4)
+    }
+
+    @Test
+    fun testResumeAndResumeWithException() = runTest {
+        var continuation: Continuation<Unit>? = null
+        val job = launch(coroutineContext) {
+            expect(2)
+            suspendCancellableCoroutine<Unit> { c ->
+                continuation = c
+            }
+            expect(3)
+        }
+        expect(1)
+        yield()
+        continuation!!.resume(Unit)
+        job.join()
+        assertFailsWith<IllegalStateException> { continuation!!.resumeWithException(TestException()) }
+        finish(4)
+    }
+
+    @Test
+    fun testResumeAndResume() = runTest {
+        var continuation: Continuation<Unit>? = null
+        val job = launch(coroutineContext) {
+            expect(2)
+            suspendCancellableCoroutine<Unit> { c ->
+                continuation = c
+            }
+            expect(3)
+        }
+        expect(1)
+        yield()
+        continuation!!.resume(Unit)
+        job.join()
+        assertFailsWith<IllegalStateException> { continuation!!.resume(Unit) }
+        finish(4)
+    }
+
+    /**
+     * Cancelling outer job may, in practise, race with attempt to resume continuation and resumes
+     * should be ignored. Here suspended coroutine is cancelled but then resumed with exception.
+     */
+    @Test
+    fun testCancelAndResumeWithException() = runTest {
+        var continuation: Continuation<Unit>? = null
+        val job = launch(coroutineContext) {
+            try {
+                expect(2)
+                suspendCancellableCoroutine<Unit> { c ->
+                    continuation = c
+                }
+            } catch (e: JobCancellationException) {
+                expect(3)
+            }
+        }
+        expect(1)
+        yield()
+        job.cancel() // Cancel job
+        yield()
+        continuation!!.resumeWithException(TestException()) // Should not fail
+        finish(4)
+    }
+
+    /**
+     * Cancelling outer job may, in practise, race with attempt to resume continuation and resumes
+     * should be ignored. Here suspended coroutine is cancelled but then resumed with exception.
+     */
+    @Test
+    fun testCancelAndResume() = runTest {
+        var continuation: Continuation<Unit>? = null
+        val job = launch(coroutineContext) {
+            try {
+                expect(2)
+                suspendCancellableCoroutine<Unit> { c ->
+                    continuation = c
+                }
+            } catch (e: JobCancellationException) {
+                expect(3)
+            }
+        }
+        expect(1)
+        yield()
+        job.cancel() // Cancel job
+        yield()
+        continuation!!.resume(Unit) // Should not fail
+        finish(4)
+    }
+
+    private class TestException : Exception()
+}

--- a/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+@file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED") // KT-21913
 
 package kotlinx.coroutines.experimental
 
@@ -71,7 +72,7 @@ class CancellableContinuationTest : TestBase() {
      * should be ignored. Here suspended coroutine is cancelled but then resumed with exception.
      */
     @Test
-    fun testCancelAndResumeWithException() = runTest {
+    fun testCancelAndResumeWithException() = runTest(unhandled = listOf({e -> e is TestException})) {
         var continuation: Continuation<Unit>? = null
         val job = launch(coroutineContext) {
             try {

--- a/core/kotlinx-coroutines-core/test/CancellableContinuationExceptionHandlingTest.kt
+++ b/core/kotlinx-coroutines-core/test/CancellableContinuationExceptionHandlingTest.kt
@@ -215,53 +215,6 @@ class CancellableContinuationExceptionHandlingTest : TestBase() {
         }
     }
 
-    @Test
-    fun testMultipleCancellations() = runTest {
-        var continuation: Continuation<Unit>? = null
-
-        val job = launch(coroutineContext) {
-            try {
-                expect(2)
-                suspendCancellableCoroutine<Unit> { c ->
-                    continuation = c
-                }
-            } catch (e: IOException) {
-                expect(3)
-            }
-        }
-
-        expect(1)
-        yield()
-        continuation!!.resumeWithException(IOException())
-        yield()
-        assertFailsWith<IllegalStateException> { continuation!!.resumeWithException(ClosedChannelException()) }
-        try {
-            job.join()
-        } finally {
-            finish(4)
-        }
-    }
-
-    @Test
-    fun testResumeAndCancel() = runTest {
-        var continuation: Continuation<Unit>? = null
-
-        val job = launch(coroutineContext) {
-            expect(2)
-            suspendCancellableCoroutine<Unit> { c ->
-                continuation = c
-            }
-            expect(3)
-        }
-
-        expect(1)
-        yield()
-        continuation!!.resume(Unit)
-        job.join()
-        assertFailsWith<IllegalStateException> { continuation!!.resumeWithException(ClosedChannelException()) }
-        finish(4)
-    }
-
     private fun wrapperDispatcher(context: CoroutineContext): CoroutineContext {
         val dispatcher = context[ContinuationInterceptor] as CoroutineDispatcher
         return object : CoroutineDispatcher() {

--- a/reactive/kotlinx-coroutines-rx1/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-rx1/test/IntegrationTest.kt
@@ -32,7 +32,7 @@ class IntegrationTest(
         @JvmStatic
         fun params(): Collection<Array<Any>> = Ctx.values().flatMap { ctx ->
             listOf(false, true).map { delay ->
-                arrayOf<Any>(ctx, delay)
+                arrayOf(ctx, delay)
             }
         }
     }
@@ -115,6 +115,34 @@ class IntegrationTest(
         val channel = observable.openSubscription()
         checkNumbers(n, channel.asObservable(ctx(coroutineContext)))
         channel.cancel()
+    }
+
+    @Test
+    fun testCancelWithoutValue() = runTest {
+        val job = launch(coroutineContext, parent = Job(), start = CoroutineStart.UNDISPATCHED) {
+            rxObservable<String>(coroutineContext) {
+                yield()
+                expectUnreached()
+            }.awaitFirst()
+        }
+
+        job.cancel()
+        job.join()
+    }
+
+    @Test
+    fun testEmptySingle() = runTest(unhandled = listOf({e -> e is NoSuchElementException})) {
+        expect(1)
+        val job = launch(coroutineContext, parent = Job(), start = CoroutineStart.UNDISPATCHED) {
+            rxObservable<String>(coroutineContext) {
+                yield()
+                expect(2)
+                // Nothing to emit
+            }.awaitFirst()
+        }
+
+        job.join()
+        finish(3)
     }
 
     private suspend fun checkNumbers(n: Int, observable: Observable<Int>) {


### PR DESCRIPTION
Here is a problem that every code that uses `suspendCancellableCoroutine` faces.

There is a race between cancellation of outer job and invocation of resume on a cancellable continuation and this race cannot be worked around by the code that uses `suspendCancellableCoroutine` function. Thus resume attempt on a cancelled continuation shall be simply ignored.

Fixes #450