### PR TITLE
corrected return-type of EventLoop pseudo ctor

### DIFF
--- a/core/kotlinx-coroutines-core/src/EventLoop.kt
+++ b/core/kotlinx-coroutines-core/src/EventLoop.kt
@@ -55,7 +55,7 @@ public interface EventLoop {
  * ```
  */
 @Suppress("FunctionName")
-public fun EventLoop(thread: Thread = Thread.currentThread(), parentJob: Job? = null): CoroutineDispatcher =
+public fun EventLoop(thread: Thread = Thread.currentThread(), parentJob: Job? = null): EventLoop =
     EventLoopImpl(thread).apply {
         if (parentJob != null) initParentJob(parentJob)
     }

--- a/core/kotlinx-coroutines-core/src/EventLoop.kt
+++ b/core/kotlinx-coroutines-core/src/EventLoop.kt
@@ -18,7 +18,7 @@ import kotlin.jvm.*
  * It may optionally implement [Delay] interface and support time-scheduled tasks. It is used by [runBlocking] to
  * continue processing events when invoked from the event dispatch thread.
  */
-public interface EventLoop {
+public interface EventLoop: ContinuationInterceptor {
     /**
      * Processes next event in this event loop.
      *


### PR DESCRIPTION
without exposing `processNextEvent` the returned value from `EventLoop()` is not very useful!