### PR TITLE
Class for exposing dispatcher's executor

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -86,10 +86,12 @@ public abstract class kotlinx/coroutines/experimental/CloseableCoroutineDispatch
 	public fun <init> ()V
 }
 
-public final class kotlinx/coroutines/experimental/CommonPool : kotlinx/coroutines/experimental/CoroutineDispatcher {
+public final class kotlinx/coroutines/experimental/CommonPool : kotlinx/coroutines/experimental/ExecutorCoroutineDispatcher {
 	public static final field DEFAULT_PARALLELISM_PROPERTY_NAME Ljava/lang/String;
 	public static final field INSTANCE Lkotlinx/coroutines/experimental/CommonPool;
+	public fun close ()V
 	public fun dispatch (Lkotlin/coroutines/experimental/CoroutineContext;Ljava/lang/Runnable;)V
+	public fun getExecutor ()Ljava/util/concurrent/Executor;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -269,12 +271,6 @@ public final class kotlinx/coroutines/experimental/DispatchedTask$DefaultImpls {
 	public static fun run (Lkotlinx/coroutines/experimental/DispatchedTask;)V
 }
 
-public final class kotlinx/coroutines/experimental/DisposableFutureHandle : kotlinx/coroutines/experimental/DisposableHandle {
-	public fun <init> (Ljava/util/concurrent/Future;)V
-	public fun dispose ()V
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class kotlinx/coroutines/experimental/DisposableHandle {
 	public abstract fun dispose ()V
 }
@@ -294,7 +290,12 @@ public final class kotlinx/coroutines/experimental/EventLoopKt {
 	public static synthetic fun EventLoop$default (Ljava/lang/Thread;Lkotlinx/coroutines/experimental/Job;ILjava/lang/Object;)Lkotlinx/coroutines/experimental/CoroutineDispatcher;
 }
 
-public abstract class kotlinx/coroutines/experimental/ExecutorCoroutineDispatcherBase : kotlinx/coroutines/experimental/CloseableCoroutineDispatcher, kotlinx/coroutines/experimental/Delay {
+public abstract class kotlinx/coroutines/experimental/ExecutorCoroutineDispatcher : kotlinx/coroutines/experimental/CloseableCoroutineDispatcher, java/io/Closeable {
+	public fun <init> ()V
+	public abstract fun getExecutor ()Ljava/util/concurrent/Executor;
+}
+
+public abstract class kotlinx/coroutines/experimental/ExecutorCoroutineDispatcherBase : kotlinx/coroutines/experimental/ExecutorCoroutineDispatcher, kotlinx/coroutines/experimental/Delay {
 	public fun <init> ()V
 	public fun close ()V
 	public fun delay (JLjava/util/concurrent/TimeUnit;Lkotlin/coroutines/experimental/Continuation;)Ljava/lang/Object;
@@ -308,7 +309,8 @@ public abstract class kotlinx/coroutines/experimental/ExecutorCoroutineDispatche
 
 public final class kotlinx/coroutines/experimental/ExecutorsKt {
 	public static final fun asCoroutineDispatcher (Ljava/util/concurrent/Executor;)Lkotlinx/coroutines/experimental/CoroutineDispatcher;
-	public static final fun asCoroutineDispatcher (Ljava/util/concurrent/ExecutorService;)Lkotlinx/coroutines/experimental/CloseableCoroutineDispatcher;
+	public static final synthetic fun asCoroutineDispatcher (Ljava/util/concurrent/ExecutorService;)Lkotlinx/coroutines/experimental/CloseableCoroutineDispatcher;
+	public static final fun asCoroutineDispatcher (Ljava/util/concurrent/ExecutorService;)Lkotlinx/coroutines/experimental/ExecutorCoroutineDispatcher;
 	public static final fun toCoroutineDispatcher (Ljava/util/concurrent/Executor;)Lkotlinx/coroutines/experimental/CoroutineDispatcher;
 }
 
@@ -423,8 +425,9 @@ public final class kotlinx/coroutines/experimental/ScheduledKt {
 	public static synthetic fun withTimeoutOrNull$default (JLjava/util/concurrent/TimeUnit;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/experimental/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class kotlinx/coroutines/experimental/ThreadPoolDispatcher : kotlinx/coroutines/experimental/ExecutorCoroutineDispatcherBase, java/io/Closeable {
+public final class kotlinx/coroutines/experimental/ThreadPoolDispatcher : kotlinx/coroutines/experimental/ExecutorCoroutineDispatcherBase {
 	public fun close ()V
+	public fun getExecutor ()Ljava/util/concurrent/Executor;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/kotlinx-coroutines-core/src/CommonPool.kt
+++ b/core/kotlinx-coroutines-core/src/CommonPool.kt
@@ -21,7 +21,7 @@ import kotlin.coroutines.experimental.*
  * pool is created. This is to work around the fact that ForkJoinPool creates threads that cannot perform
  * privileged actions.
  */
-object CommonPool : CoroutineDispatcher() {
+object CommonPool : ExecutorCoroutineDispatcher() {
 
     /**
      * Name of the property that controls default parallelism level of [CommonPool].
@@ -30,6 +30,9 @@ object CommonPool : CoroutineDispatcher() {
      * `Runtime.getRuntime().availableProcessors()` is not aware of container constraints and will return the real number of cores.
      */
     public const val DEFAULT_PARALLELISM_PROPERTY_NAME = "kotlinx.coroutines.default.parallelism"
+
+    override val executor: Executor
+        get() = pool ?: getOrCreatePoolSync()
 
     // Equals to -1 if not explicitly specified
     private val requestedParallelism = run<Int> {
@@ -132,4 +135,6 @@ object CommonPool : CoroutineDispatcher() {
     }
 
     override fun toString(): String = "CommonPool"
+
+    override fun close(): Unit = error("Close cannot be invoked on CommonPool")
 }

--- a/core/kotlinx-coroutines-core/src/ThreadPoolDispatcher.kt
+++ b/core/kotlinx-coroutines-core/src/ThreadPoolDispatcher.kt
@@ -4,11 +4,9 @@
 
 package kotlinx.coroutines.experimental
 
-import java.io.Closeable
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.*
 
 /**
  * Creates a new coroutine execution context using a single thread with built-in [yield] and [delay] support.
@@ -63,10 +61,10 @@ internal class PoolThread(
 public class ThreadPoolDispatcher internal constructor(
     private val nThreads: Int,
     private val name: String
-) : ExecutorCoroutineDispatcherBase(), Closeable {
+) : ExecutorCoroutineDispatcherBase() {
     private val threadNo = AtomicInteger()
 
-    internal override val executor: ScheduledExecutorService = Executors.newScheduledThreadPool(nThreads) { target ->
+    override val executor: Executor = Executors.newScheduledThreadPool(nThreads) { target ->
         PoolThread(this, target, if (nThreads == 1) name else name + "-" + threadNo.incrementAndGet())
     }
 
@@ -74,7 +72,7 @@ public class ThreadPoolDispatcher internal constructor(
      * Closes this dispatcher -- shuts down all threads in this pool and releases resources.
      */
     public override fun close() {
-        executor.shutdown()
+        (executor as ExecutorService).shutdown()
     }
 
     override fun toString(): String = "ThreadPoolDispatcher[$nThreads, $name]"

--- a/core/kotlinx-coroutines-core/src/scheduling/CoroutineScheduler.kt
+++ b/core/kotlinx-coroutines-core/src/scheduling/CoroutineScheduler.kt
@@ -62,7 +62,7 @@ internal class CoroutineScheduler(
     private val maxPoolSize: Int,
     private val idleWorkerKeepAliveNs: Long = IDLE_WORKER_KEEP_ALIVE_NS,
     private val schedulerName: String = DEFAULT_SCHEDULER_NAME
-) : Closeable {
+) : Executor, Closeable {
     init {
         require(corePoolSize >= MIN_SUPPORTED_POOL_SIZE) {
             "Core pool size $corePoolSize should be at least $MIN_SUPPORTED_POOL_SIZE"
@@ -289,6 +289,8 @@ internal class CoroutineScheduler(
         private const val PARKED_VERSION_MASK = CREATED_MASK.inv()
         private const val PARKED_VERSION_INC = 1L shl BLOCKING_SHIFT
     }
+
+    override fun execute(command: Runnable) = dispatch(command)
 
     override fun close() = shutdown(1000L)
 

--- a/core/kotlinx-coroutines-core/test/guide/test/TestUtil.kt
+++ b/core/kotlinx-coroutines-core/test/guide/test/TestUtil.kt
@@ -100,7 +100,7 @@ private fun shutdownDispatcherPools(timeout: Long) {
     for (i in 0 until n) {
         val thread = threads[i]
         if (thread is PoolThread)
-            thread.dispatcher.executor.apply {
+            (thread.dispatcher.executor as ExecutorService).apply {
                 shutdown()
                 awaitTermination(timeout, TimeUnit.MILLISECONDS)
                 shutdownNow().forEach { DefaultExecutor.execute(it) }


### PR DESCRIPTION
Introducing `ExecutorCoroutineDispatche`r instead of `CloseableCoroutineDispatcher` (ABI breaking change)
Remove deprecated for long enough methods

Also, I like the idea to make `ThreadPoolDispatcher` internal and return `ExecutorCoroutineDispatcher` everywhere instead, but it will break a lot of existing ABI (though, maybe it's not that relevant)