### PR TITLE
Add OSGI support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,11 @@ configure(subprojects.findAll { !internal.contains(it.name) && it.name != 'kotli
     }
 }
 
+// configure OSGI manifest
+configure(subprojects.findAll { !internal.contains(it.name) && platformOf(it) == 'jvm' }) {
+    apply from: rootProject.file("gradle/osgi.gradle")
+}
+
 // --------------- Configure sub-projects that are published ---------------
 
 // todo: native is not published yet

--- a/core/kotlinx-coroutines-core/build.gradle
+++ b/core/kotlinx-coroutines-core/build.gradle
@@ -7,6 +7,13 @@ dependencies {
     testCompile "com.esotericsoftware:kryo:4.0.0"
 }
 
+jar {
+    manifest {
+        instruction 'Import-Package', '!kotlinx.coroutines.*, !kotlinx.atomicfu.*, *'
+        instruction 'Export-Package', '!kotlinx.coroutines.internal, !kotlinx.coroutines.scheduling, *'
+    }
+}
+
 task checkJdk16() {
     // only fail w/o JDK_16 when actually trying to compile, not during project setup phase
     doLast {

--- a/gradle/osgi.gradle
+++ b/gradle/osgi.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'osgi'
+
+jar {
+    manifest {
+        instruction 'Bundle-Vendor', 'JetBrains'
+        license 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    }
+}


### PR DESCRIPTION
Add OSGI meta data to coroutines-core, so the jar can be used as an OSGI bundle.

Please let me know, if there is more meta data desired, e.g. bundle-description.