### PR TITLE
Version 0.25.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change log for kotlinx.coroutines
 
+## Version 0.25.2
+
+* Distribution no longer uses multi-version jar which is not supported on Android (see #510).
+* JS version of the library does not depend on AtomicFu anymore:
+  All the atomic boxes in JS are fully erased.
+
 ## Version 0.25.0
 
 * Major rework on exception-handling and cancellation in coroutines (see #333, #452 and #451):

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Download](https://api.bintray.com/packages/kotlin/kotlinx/kotlinx.coroutines/images/download.svg?version=0.25.0) ](https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/0.25.0)
+[![Download](https://api.bintray.com/packages/kotlin/kotlinx/kotlinx.coroutines/images/download.svg?version=0.25.2) ](https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/0.25.2)
 
 Library support for Kotlin coroutines with [multiplatform](#multiplatform) support.
 This is a companion version for Kotlin 1.2.61 release.
@@ -63,7 +63,7 @@ Add dependencies (you can also add other modules that you need):
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
     <artifactId>kotlinx-coroutines-core</artifactId>
-    <version>0.25.0</version>
+    <version>0.25.2</version>
 </dependency>
 ```
 
@@ -80,7 +80,7 @@ And make sure that you use the latest Kotlin version:
 Add dependencies (you can also add other modules that you need):
 
 ```groovy
-implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.25.0'
+implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.25.2'
 ```
 
 And make sure that you use the latest Kotlin version:
@@ -113,7 +113,7 @@ Add [`kotlinx-coroutines-android`](ui/kotlinx-coroutines-android)
 module as dependency when using `kotlinx.coroutines` on Android:
 
 ```groovy
-implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.25.0'
+implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.25.2'
 ```
 
 This gives you access to Android [UI](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-android/kotlinx.coroutines.experimental.android/-u-i.html)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,7 +68,7 @@ To release new `<version>` of `kotlinx-coroutines`:
    `git fetch` 
    
 8. Merge release from `master`:<br>
-   `git merge master`
+   `git merge origin/master`
    
 9. Push updates to `develop`:<br>
    `git push`      

--- a/benchmarks/src/jmh/kotlin/benchmarks/ForkJoinBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/ForkJoinBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks
 
 import benchmarks.ForkJoinBenchmark.Companion.BATCH_SIZE

--- a/benchmarks/src/jmh/kotlin/benchmarks/LaunchBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/LaunchBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks
 
 import kotlinx.coroutines.experimental.launch

--- a/benchmarks/src/jmh/kotlin/benchmarks/ParametrizedDispatcherBase.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/ParametrizedDispatcherBase.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks
 
 import benchmarks.actors.CORES_COUNT

--- a/benchmarks/src/jmh/kotlin/benchmarks/StatefulAwaitsBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/StatefulAwaitsBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks
 
 import kotlinx.coroutines.experimental.*

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/ConcurrentStatefulActorBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/ConcurrentStatefulActorBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import benchmarks.ParametrizedDispatcherBase

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/CycledActorsBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/CycledActorsBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import benchmarks.ParametrizedDispatcherBase

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongActorBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongActorBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import benchmarks.*

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongAkkaBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongAkkaBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import akka.actor.ActorRef

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongWithBlockingContext.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/PingPongWithBlockingContext.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import kotlinx.coroutines.experimental.*

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/StatefulActorAkkaBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/StatefulActorAkkaBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import akka.actor.ActorRef

--- a/benchmarks/src/jmh/kotlin/benchmarks/actors/StatefulActorBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/actors/StatefulActorBenchmark.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package benchmarks.actors
 
 import benchmarks.ParametrizedDispatcherBase

--- a/core/kotlinx-coroutines-core/src/CoroutineContext.kt
+++ b/core/kotlinx-coroutines-core/src/CoroutineContext.kt
@@ -81,7 +81,7 @@ public const val IO_PARALLELISM_PROPERTY_NAME = "kotlinx.coroutines.io.paralleli
  * "`kotlinx.coroutines.io.parallelism`" ([IO_PARALLELISM_PROPERTY_NAME]) system property.
  * It defaults to the limit of 64 threads or the number of cores (whichever is larger).
  */
-public val IO by lazy {
+public val IO: CoroutineDispatcher by lazy {
     BackgroundDispatcher.blocking(systemProp(IO_PARALLELISM_PROPERTY_NAME, 64.coerceAtLeast(AVAILABLE_PROCESSORS)))
 }
 

--- a/core/kotlinx-coroutines-core/src/internal/ThreadContext.kt
+++ b/core/kotlinx-coroutines-core/src/internal/ThreadContext.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.internal
 
 import kotlinx.coroutines.experimental.*

--- a/core/kotlinx-coroutines-core/test/ThreadLocalTest.kt
+++ b/core/kotlinx-coroutines-core/test/ThreadLocalTest.kt
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
 
 package kotlinx.coroutines.experimental
 

--- a/core/kotlinx-coroutines-core/test/WithDefaultContextTest.kt
+++ b/core/kotlinx-coroutines-core/test/WithDefaultContextTest.kt
@@ -1,17 +1,5 @@
 /*
- * Copyright 2016-2017 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.experimental

--- a/core/kotlinx-coroutines-core/test/WithTimeoutJvmTest.kt
+++ b/core/kotlinx-coroutines-core/test/WithTimeoutJvmTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import kotlinx.coroutines.experimental.*
 import kotlinx.coroutines.experimental.exceptions.*
 import java.io.*

--- a/core/kotlinx-coroutines-core/test/channels/ChannelLinearizabilityTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/ChannelLinearizabilityTest.kt
@@ -1,9 +1,6 @@
 /*
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-/*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
- */
 
 package kotlinx.coroutines.experimental.channels
 

--- a/core/kotlinx-coroutines-core/test/channels/InvokeOnCloseStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/InvokeOnCloseStressTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package channels
+package kotlinx.coroutines.experimental.channels
 
 import kotlinx.coroutines.experimental.*
 import kotlinx.coroutines.experimental.channels.*

--- a/core/kotlinx-coroutines-core/test/scheduling/BlockingCoroutineDispatcherRaceStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/BlockingCoroutineDispatcherRaceStressTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.scheduling
 
 import kotlinx.coroutines.experimental.*

--- a/core/kotlinx-coroutines-core/test/scheduling/BlockingCoroutineDispatcherTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/BlockingCoroutineDispatcherTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.scheduling
 
 import kotlinx.coroutines.experimental.*

--- a/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerShrinkTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerShrinkTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.scheduling
 
 import kotlinx.coroutines.experimental.*

--- a/core/kotlinx-coroutines-core/test/scheduling/LimitingCoroutineDispatcherStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/LimitingCoroutineDispatcherStressTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.scheduling
 
 import kotlinx.atomicfu.*

--- a/core/kotlinx-coroutines-core/test/scheduling/LimitingDispatcherTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/LimitingDispatcherTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.experimental.scheduling
 
 import kotlinx.coroutines.experimental.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kotlin
-version = 0.25.0-SNAPSHOT
+version = 0.25.2-SNAPSHOT
 group = org.jetbrains.kotlinx
 kotlin_version=1.2.61
 kotlin_native_version=0.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,25 +1,24 @@
-#
-# Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
-#
-
+# Kotlin
 version = 0.25.0-SNAPSHOT
 group = org.jetbrains.kotlinx
+kotlin_version=1.2.61
+kotlin_native_version=0.8.2
 
-kotlin_version = 1.2.61
-kotlin_native_version = 0.8.2
-junit_version = 4.12
-atomicFU_version = 0.11.3
-html_version = 0.6.8
+# Dependencies
+junit_version=4.12
+atomicFU_version=0.11.3
+html_version=0.6.8
 lincheck_version=1.9
-dokka_version = 0.9.16-rdev-2-mpp-hacks
-bintray_version = 1.8.2-SNAPSHOT
+dokka_version=0.9.16-rdev-2-mpp-hacks
+bintray_version=1.8.2-SNAPSHOT
 
-gradle_node_version = 1.2.0
-node_version = 8.9.3
-npm_version = 5.7.1
-mocha_version = 4.1.0
-mocha_headless_chrome_version = 1.8.2
-mocha_teamcity_reporter_version = 2.2.2
-source_map_support_version = 0.5.3
+# JS
+gradle_node_version=1.2.0
+node_version=8.9.3
+npm_version=5.7.1
+mocha_version=4.1.0
+mocha_headless_chrome_version=1.8.2
+mocha_teamcity_reporter_version=2.2.2
+source_map_support_version=0.5.3
 
 kotlin.incremental.multiplatform=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin_native_version=0.8.2
 
 # Dependencies
 junit_version=4.12
-atomicFU_version=0.11.3
+atomicFU_version=0.11.4
 html_version=0.6.8
 lincheck_version=1.9
 dokka_version=0.9.16-rdev-2-mpp-hacks

--- a/gradle/atomicfu-js.gradle
+++ b/gradle/atomicfu-js.gradle
@@ -2,6 +2,9 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+apply plugin: 'kotlinx-atomicfu'
+
 dependencies {
-    compile "org.jetbrains.kotlinx:atomicfu-js:$atomicFU_version"
+    compileOnly "org.jetbrains.kotlinx:atomicfu-js:$atomicFU_version"
+    testCompile "org.jetbrains.kotlinx:atomicfu-js:$atomicFU_version"
 }

--- a/js/kotlinx-coroutines-core-js/npm/package.json
+++ b/js/kotlinx-coroutines-core-js/npm/package.json
@@ -20,9 +20,6 @@
     "JavaScript",
     "JetBrains"
   ],
-  "dependencies": {
-    "kotlinx-atomicfu": "$atomicFU_version"
-  },
   "peerDependencies": {
     $kotlinDependency
   }

--- a/native/README.md
+++ b/native/README.md
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-native:0.25.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-native:0.25.2'
 }
 
 sourceSets {

--- a/native/kotlinx-coroutines-core-native/src/EventLoop.kt
+++ b/native/kotlinx-coroutines-core-native/src/EventLoop.kt
@@ -53,7 +53,7 @@ internal abstract class EventLoopBase: CoroutineDispatcher(), Delay, EventLoop {
     // null | CLOSED_EMPTY | task | Queue<Runnable>
     private val _queue = atomic<Any?>(null)
 
-    // Allocated only only once
+    // Allocated only once
     private val _delayed = atomic<ThreadSafeHeap<DelayedTask>?>(null)
 
     protected abstract val isCompleted: Boolean

--- a/ui/coroutines-guide-ui.md
+++ b/ui/coroutines-guide-ui.md
@@ -161,7 +161,7 @@ Add dependencies on `kotlinx-coroutines-android` module to the `dependencies { .
 `app/build.gradle` file:
 
 ```groovy
-compile "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.25.0"
+compile "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.25.2"
 ```
 
 Coroutines are experimental feature in Kotlin.

--- a/ui/kotlinx-coroutines-android/animation-app/app/build.gradle
+++ b/ui/kotlinx-coroutines-android/animation-app/app/build.gradle
@@ -4,9 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "org.jetbrains.kotlinx.animation"
-        minSdkVersion 15
+        minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
@@ -21,12 +22,12 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.android.support:design:27.1.1'
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     testImplementation 'junit:junit:4.12'

--- a/ui/kotlinx-coroutines-android/animation-app/build.gradle
+++ b/ui/kotlinx-coroutines-android/animation-app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/ui/kotlinx-coroutines-android/animation-app/gradle.properties
+++ b/ui/kotlinx-coroutines-android/animation-app/gradle.properties
@@ -19,5 +19,5 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.coroutines=enable
 
 kotlin_version = 1.2.61
-coroutines_version = 0.25.0
+coroutines_version = 0.25.2
 

--- a/ui/kotlinx-coroutines-android/animation-app/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/kotlinx-coroutines-android/animation-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 08 11:05:03 CEST 2018
+#Sat Aug 25 19:20:16 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/ui/kotlinx-coroutines-android/example-app/app/build.gradle
+++ b/ui/kotlinx-coroutines-android/example-app/app/build.gradle
@@ -22,13 +22,14 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.android.support:design:27.1.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:design:27.1.1'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/ui/kotlinx-coroutines-android/example-app/build.gradle
+++ b/ui/kotlinx-coroutines-android/example-app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/ui/kotlinx-coroutines-android/example-app/gradle.properties
+++ b/ui/kotlinx-coroutines-android/example-app/gradle.properties
@@ -19,5 +19,5 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.coroutines=enable
 
 kotlin_version = 1.2.61
-coroutines_version = 0.25.0
+coroutines_version = 0.25.2
 

--- a/ui/kotlinx-coroutines-android/example-app/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/kotlinx-coroutines-android/example-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 08 03:14:27 CEST 2018
+#Sat Aug 25 19:20:16 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
* Distribution no longer uses multi-version jar which is not supported on Android (see #510).
* JS version of the library does not depend on AtomicFu anymore:
  All the atomic boxes in JS are fully erased.
