### PR TITLE
[WIP] Coroutine debugging improvements

### DIFF
--- a/binary-compatibility-validator/build.gradle
+++ b/binary-compatibility-validator/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 
     testArtifacts project(':kotlinx-coroutines-core')
+    testArtifacts project(':kotlinx-coroutines-debug')
 
     testArtifacts project(':kotlinx-coroutines-reactive')
     testArtifacts project(':kotlinx-coroutines-reactor')

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -64,10 +64,12 @@ public final class kotlinx/coroutines/CancellableContinuation$DefaultImpls {
 	public static synthetic fun tryResume$default (Lkotlinx/coroutines/CancellableContinuation;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class kotlinx/coroutines/CancellableContinuationImpl : java/lang/Runnable, kotlinx/coroutines/CancellableContinuation {
+public final class kotlinx/coroutines/CancellableContinuationImpl : java/lang/Runnable, kotlin/coroutines/jvm/internal/CoroutineStackFrame, kotlinx/coroutines/CancellableContinuation {
 	public fun <init> (Lkotlin/coroutines/Continuation;I)V
 	public fun completeResume (Ljava/lang/Object;)V
+	public fun getCallerFrame ()Lkotlin/coroutines/jvm/internal/CoroutineStackFrame;
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getStackTraceElement ()Ljava/lang/StackTraceElement;
 	public fun getSuccessfulResult (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun initCancellability ()V
 	public fun invokeOnCompletion (ZZLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-debug.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-debug.txt
@@ -1,0 +1,26 @@
+public final class kotlinx/coroutines/CoroutineState {
+	public fun <init> (Lkotlin/coroutines/Continuation;Ljava/util/List;)V
+	public final fun getCoroutine ()Lkotlin/coroutines/Continuation;
+	public final fun getCreationStackTrace ()Ljava/util/List;
+	public final fun getState ()Lkotlinx/coroutines/State;
+	public final fun suspensionStackTrace ()Ljava/util/List;
+}
+
+public final class kotlinx/coroutines/DebugProbes {
+	public static final field INSTANCE Lkotlinx/coroutines/DebugProbes;
+	public final fun dumpCoroutines (Ljava/io/PrintStream;)V
+	public static synthetic fun dumpCoroutines$default (Lkotlinx/coroutines/DebugProbes;Ljava/io/PrintStream;ILjava/lang/Object;)V
+	public final fun dumpCoroutinesState ()Ljava/util/List;
+	public final fun install ()V
+	public final fun uninstall ()V
+	public final fun withDebugProbes (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class kotlinx/coroutines/State : java/lang/Enum {
+	public static final field CREATED Lkotlinx/coroutines/State;
+	public static final field RUNNING Lkotlinx/coroutines/State;
+	public static final field SUSPENDED Lkotlinx/coroutines/State;
+	public static fun valueOf (Ljava/lang/String;)Lkotlinx/coroutines/State;
+	public static fun values ()[Lkotlinx/coroutines/State;
+}
+

--- a/common/kotlinx-coroutines-core-common/src/Builders.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/Builders.common.kt
@@ -248,7 +248,8 @@ private class RunCompletion<in T>(
     override val context: CoroutineContext,
     delegate: Continuation<T>,
     resumeMode: Int
-) : AbstractContinuation<T>(delegate, resumeMode) {
-
+) : AbstractContinuation<T>(delegate, resumeMode) , CoroutineStackFrame {
+    override val callerFrame: CoroutineStackFrame? = delegate as CoroutineStackFrame?
+    override fun getStackTraceElement(): StackTraceElement? = null
     override val useCancellingState: Boolean get() = true
 }

--- a/common/kotlinx-coroutines-core-common/src/CancellableContinuation.kt
+++ b/common/kotlinx-coroutines-core-common/src/CancellableContinuation.kt
@@ -261,9 +261,14 @@ private class DisposeOnCancel(private val handle: DisposableHandle) : CancelHand
 internal class CancellableContinuationImpl<in T>(
     delegate: Continuation<T>,
     resumeMode: Int
-) : AbstractContinuation<T>(delegate, resumeMode), CancellableContinuation<T>, Runnable {
+) : AbstractContinuation<T>(delegate, resumeMode), CancellableContinuation<T>, Runnable, CoroutineStackFrame {
 
     public override val context: CoroutineContext = delegate.context
+
+    override val callerFrame: CoroutineStackFrame?
+        get() = delegate as? CoroutineStackFrame
+
+    override fun getStackTraceElement(): StackTraceElement? = null
 
     override fun initCancellability() {
         initParentJobInternal(delegate.context[Job])

--- a/common/kotlinx-coroutines-core-common/src/JobSupport.kt
+++ b/common/kotlinx-coroutines-core-common/src/JobSupport.kt
@@ -956,7 +956,7 @@ internal open class JobSupport constructor(active: Boolean) : Job, SelectClause0
             val state = this.state
             if (state !is Incomplete) {
                 // already complete -- just return result
-                if (state is CompletedExceptionally) throw state.cause
+                if (state is CompletedExceptionally) throw recoverStackTrace(state.cause)
                 return state
 
             }
@@ -971,7 +971,7 @@ internal open class JobSupport constructor(active: Boolean) : Job, SelectClause0
             val state = this.state
             check(state !is Incomplete)
             if (state is CompletedExceptionally)
-                cont.resumeWithException(state.cause)
+                cont.resumeWithStackTrace(state.cause)
             else
                 cont.resume(state)
         })

--- a/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
@@ -174,8 +174,8 @@ public abstract class AbstractSendChannel<E> : SendChannel<E> {
             result === OFFER_SUCCESS -> true
             // We should check for closed token on offer as well, otherwise offer won't be linearizable
             // in the face of concurrent close()
-            result === OFFER_FAILED ->  throw closedForSend?.sendException ?: return false
-            result is Closed<*> -> throw result.sendException
+            result === OFFER_FAILED ->  throw closedForSend?.sendException?.also { recoverStackTrace(it) } ?: return false
+            result is Closed<*> -> throw recoverStackTrace(result.sendException)
             else -> error("offerInternal returned $result")
         }
     }
@@ -192,7 +192,7 @@ public abstract class AbstractSendChannel<E> : SendChannel<E> {
                 }
                 is Closed<*> -> {
                     helpClose(enqueueResult)
-                    cont.resumeWithException(enqueueResult.sendException)
+                    cont.resumeWithStackTrace(enqueueResult.sendException)
                     return@sc
                 }
             }
@@ -206,7 +206,7 @@ public abstract class AbstractSendChannel<E> : SendChannel<E> {
                 offerResult === OFFER_FAILED -> continue@loop
                 offerResult is Closed<*> -> {
                     helpClose(offerResult)
-                    cont.resumeWithException(offerResult.sendException)
+                    cont.resumeWithStackTrace(offerResult.sendException)
                     return@sc
                 }
                 else -> error("offerInternal returned $offerResult")
@@ -405,7 +405,7 @@ public abstract class AbstractSendChannel<E> : SendChannel<E> {
                 when {
                     enqueueResult === ALREADY_SELECTED -> return
                     enqueueResult === ENQUEUE_FAILED -> {} // retry
-                    enqueueResult is Closed<*> -> throw enqueueResult.sendException
+                    enqueueResult is Closed<*> -> throw recoverStackTrace(enqueueResult.sendException)
                     else -> error("performAtomicIfNotSelected(TryEnqueueSendDesc) returned $enqueueResult")
                 }
             } else {
@@ -417,7 +417,7 @@ public abstract class AbstractSendChannel<E> : SendChannel<E> {
                         block.startCoroutineUnintercepted(receiver = this, completion = select.completion)
                         return
                     }
-                    offerResult is Closed<*> -> throw offerResult.sendException
+                    offerResult is Closed<*> -> throw recoverStackTrace(offerResult.sendException)
                     else -> error("offerSelectInternal returned $offerResult")
                 }
             }
@@ -571,7 +571,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
 
     @Suppress("UNCHECKED_CAST")
     private fun receiveResult(result: Any?): E {
-        if (result is Closed<*>) throw result.receiveException
+        if (result is Closed<*>) throw recoverStackTrace(result.receiveException)
         return result as E
     }
 
@@ -587,7 +587,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
             // hm... something is not right. try to poll
             val result = pollInternal()
             if (result is Closed<*>) {
-                cont.resumeWithException(result.receiveException)
+                cont.resumeWithStackTrace(result.receiveException)
                 return@sc
             }
             if (result !== POLL_FAILED) {
@@ -617,7 +617,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
     @Suppress("UNCHECKED_CAST")
     private fun receiveOrNullResult(result: Any?): E? {
         if (result is Closed<*>) {
-            if (result.closeCause != null) throw result.closeCause
+            if (result.closeCause != null) throw recoverStackTrace(result.closeCause)
             return null
         }
         return result as E
@@ -638,7 +638,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
                 if (result.closeCause == null)
                     cont.resume(null)
                 else
-                    cont.resumeWithException(result.closeCause)
+                    cont.resumeWithStackTrace(result.closeCause)
                 return@sc
             }
             if (result !== POLL_FAILED) {
@@ -751,7 +751,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
                 when {
                     pollResult === ALREADY_SELECTED -> return
                     pollResult === POLL_FAILED -> {} // retry
-                    pollResult is Closed<*> -> throw pollResult.receiveException
+                    pollResult is Closed<*> -> throw recoverStackTrace(pollResult.receiveException)
                     else -> {
                         block.startCoroutineUnintercepted(pollResult as E, select.completion)
                         return
@@ -791,7 +791,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
                                 block.startCoroutineUnintercepted(null, select.completion)
                             return
                         } else
-                            throw pollResult.closeCause
+                            throw recoverStackTrace(pollResult.closeCause)
                     }
                     else -> {
                         // selected successfully
@@ -850,7 +850,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
 
         private fun hasNextResult(result: Any?): Boolean {
             if (result is Closed<*>) {
-                if (result.closeCause != null) throw result.receiveException
+                if (result.closeCause != null) recoverStackTrace(throw result.receiveException)
                 return false
             }
             return true
@@ -871,7 +871,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
                     if (result.closeCause == null)
                         cont.resume(false)
                     else
-                        cont.resumeWithException(result.receiveException)
+                        cont.resumeWithStackTrace(result.receiveException)
                     return@sc
                 }
                 if (result !== POLL_FAILED) {
@@ -884,7 +884,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
         @Suppress("UNCHECKED_CAST")
         override suspend fun next(): E {
             val result = this.result
-            if (result is Closed<*>) throw result.receiveException
+            if (result is Closed<*>) throw recoverStackTrace(result.receiveException)
             if (result !== POLL_FAILED) {
                 this.result = POLL_FAILED
                 return result as E
@@ -904,7 +904,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
             if (closed.closeCause == null && nullOnClose)
                 cont.resume(null)
             else
-                cont.resumeWithException(closed.receiveException)
+                cont.resumeWithStackTrace(closed.receiveException)
         }
         override fun toString(): String = "ReceiveElement[$cont,nullOnClose=$nullOnClose]"
     }
@@ -939,7 +939,7 @@ public abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E> 
             val token = if (closed.closeCause == null)
                 cont.tryResume(false)
             else
-                cont.tryResumeWithException(closed.receiveException)
+                cont.tryResumeWithException(recoverStackTrace(closed.receiveException, cont))
             if (token != null) {
                 iterator.result = closed
                 cont.completeResume(token)
@@ -1052,7 +1052,7 @@ public class SendElement(
 ) : LockFreeLinkedListNode(), Send {
     override fun tryResumeSend(idempotent: Any?): Any? = cont.tryResume(Unit, idempotent)
     override fun completeResumeSend(token: Any) = cont.completeResume(token)
-    override fun resumeSendClosed(closed: Closed<*>) = cont.resumeWithException(closed.sendException)
+    override fun resumeSendClosed(closed: Closed<*>) = cont.resumeWithStackTrace(closed.sendException)
     override fun toString(): String = "SendElement($pollResult)[$cont]"
 }
 

--- a/common/kotlinx-coroutines-core-common/src/internal/Exceptions.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/internal/Exceptions.common.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+/**
+ * Tries to recover stacktrace for given [exception] and [continuation].
+ * Stacktrace recovery tries to restore [continuation] stack frames using its debug metadata with [CoroutineStackFrame] API
+ * and then reflectively instantiate exception of given type with original exception as a cause and
+ * sets new stacktrace for wrapping exception.
+ * Some frames may be missing due to tail-call elimination.
+ *
+ * Works only on JVM with enabled debug-mode
+ */
+internal expect fun <E: Throwable> recoverStackTrace(exception: E, continuation: Continuation<*>): E
+
+/**
+ * Tries to recover stacktrace for given [exception]. Used in non-suspendable points of awaiting.
+ * Stacktrace recovery tries to instantiate exception of given type with original exception as a cause.
+ * Wrapping exception will have proper stacktrace as it's instantiated in the right context.
+ *
+ * Works only on JVM with enabled debug-mode
+ */
+internal expect fun <E: Throwable> recoverStackTrace(exception: E): E
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Continuation<*>.resumeWithStackTrace(exception: Throwable) = resumeWith(Result.failure(recoverStackTrace(exception, this)))
+
+expect class StackTraceElement
+
+internal expect interface CoroutineStackFrame {
+    public val callerFrame: CoroutineStackFrame?
+    public fun getStackTraceElement(): StackTraceElement?
+}

--- a/common/kotlinx-coroutines-core-common/test/TestBase.common.kt
+++ b/common/kotlinx-coroutines-core-common/test/TestBase.common.kt
@@ -20,3 +20,6 @@ public expect open class TestBase constructor() {
         block: suspend CoroutineScope.() -> Unit
     )
 }
+
+// Specific exception which stacktrace cannot be recovered by our machinery
+class TestException(message: String) : Exception(message)

--- a/core/kotlinx-coroutines-core/src/internal/Exceptions.kt
+++ b/core/kotlinx-coroutines-core/src/internal/Exceptions.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlinx.coroutines.*
+import java.util.*
+import kotlin.coroutines.*
+
+internal actual fun <E : Throwable> recoverStackTrace(exception: E): E {
+    if (!DEBUG || exception is CancellationException) {
+        return exception
+    }
+
+    val copy = tryCopyException(exception) ?: return exception
+    return copy.sanitizeStackTrace()
+}
+
+private fun <E : Throwable> E.sanitizeStackTrace(): E {
+    val size = stackTrace.size
+
+    var lastIntrinsic = -1
+    for (i in 0 until size) {
+        val name = stackTrace[i].className
+        if ("kotlinx.coroutines.internal.ExceptionsKt" == name) {
+            lastIntrinsic = i
+        }
+    }
+
+    val startIndex = lastIntrinsic + 1
+    val trace = Array(size - lastIntrinsic) {
+        if (it == 0) {
+            artificialFrame("Current coroutine stacktrace")
+        } else {
+            stackTrace[startIndex + it - 1]
+        }
+    }
+
+    stackTrace = trace
+    return this
+}
+
+internal actual fun <E : Throwable> recoverStackTrace(exception: E, continuation: Continuation<*>): E {
+    if (!DEBUG || exception is CancellationException || continuation !is CoroutineStackFrame) {
+        return exception
+    }
+
+    val stacktrace = createStackTrace(continuation)
+    if (stacktrace.isEmpty()) return exception
+    val newException = tryCopyException(exception) ?: return exception
+    stacktrace.add(0, artificialFrame("Current coroutine stacktrace"))
+    newException.stackTrace = stacktrace.toTypedArray()
+    return newException
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <E : Throwable> tryCopyException(exception: E): E? {
+    /*
+     * Try to reflectively find constructor(), constructor(message, cause) or constructor(cause).
+     * First thing which comes in mind is why we should do it at all? Exceptions are share between coroutines,
+     * so we can't safely modify their stacktraces, thus making copy is our only hope
+     */
+    var newException: E? = null
+    try {
+        for (constructor in exception.javaClass.constructors.sortedByDescending { it.parameterTypes.size }) {
+            val parameters = constructor.parameterTypes
+            if (parameters.size == 2 && parameters[0] == String::class.java && parameters[1] == Throwable::class.java) {
+                newException = constructor.newInstance(exception.message, exception) as E
+            } else if (parameters.size == 1 && parameters[0] == Throwable::class.java) {
+                newException = constructor.newInstance(exception) as E
+            } else if (parameters.isEmpty()) {
+                newException = (constructor.newInstance() as E).also { it.initCause(exception) }
+            }
+
+            if (newException != null) {
+                break
+            }
+        }
+    } catch (e: Exception) {
+        // Do nothing
+    }
+    return newException
+}
+
+private fun createStackTrace(continuation: CoroutineStackFrame): ArrayList<StackTraceElement> {
+    val stack = ArrayList<StackTraceElement>()
+    continuation.getStackTraceElement()?.let { stack.add(it) }
+
+    var last = continuation
+    while (true) {
+        last = (last as? CoroutineStackFrame)?.callerFrame ?: break
+        last.getStackTraceElement()?.let { stack.add(it) }
+    }
+    return stack
+}
+
+
+public fun artificialFrame(message: String) = java.lang.StackTraceElement("\b\b\b($message", "\b", "\b", -1)
+
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+actual typealias CoroutineStackFrame = kotlin.coroutines.jvm.internal.CoroutineStackFrame
+
+actual typealias StackTraceElement = java.lang.StackTraceElement

--- a/core/kotlinx-coroutines-core/test/exceptions/StackTraceRecoveryTest.kt
+++ b/core/kotlinx-coroutines-core/test/exceptions/StackTraceRecoveryTest.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.exceptions
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import org.junit.Test
+import java.io.*
+import java.util.concurrent.*
+import kotlin.test.*
+
+class StackTraceRecoveryTest : TestBase() {
+
+    @Test
+    fun testAsync() = runTest {
+        fun createDeferred(depth: Int): Deferred<*> {
+            return if (depth == 0) {
+                async(coroutineContext) {
+                    throw ExecutionException(null)
+                }
+            } else {
+                createDeferred(depth - 1)
+            }
+        }
+
+        val deferred = createDeferred(3)
+        val traces = listOf(
+            "java.util.concurrent.ExecutionException\n" +
+                    "\t(Current coroutine stacktrace)\n" +
+                    "\tat kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)\n" +
+                    "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest.oneMoreNestedMethod(StackTraceRecoveryTest.kt:49)\n" +
+                    "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nestedMethod(StackTraceRecoveryTest.kt:44)\n" +
+                    "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest\$testAsync\$1.invokeSuspend(StackTraceRecoveryTest.kt:17)\n",
+            "Caused by: java.util.concurrent.ExecutionException\n" +
+                    "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testAsync\$1\$1\$1.invokeSuspend(StackTraceRecoveryTest.kt:21)\n" +
+                    "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n"
+        )
+        nestedMethod(deferred, traces)
+        deferred.join()
+    }
+
+    @Test
+    fun testCompletedAsync() = runTest {
+        val deferred = async(coroutineContext) {
+            throw ExecutionException(null)
+        }
+
+        deferred.join()
+        val stacktrace = listOf(
+            "java.util.concurrent.ExecutionException\n" +
+                    "\t(Current coroutine stacktrace)\n" +
+                    "\tat kotlinx.coroutines.JobSupport.awaitInternal\$kotlinx_coroutines_core_main(JobSupport.kt:959)\n" +
+                    "\tat kotlinx.coroutines.DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)\n" +
+                    "\tat kotlinx.coroutines.DeferredCoroutine.await(Deferred.kt)\n" +
+                    "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest.oneMoreNestedMethod(StackTraceRecoveryTest.kt:66)\n" +
+                    "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest.nestedMethod(StackTraceRecoveryTest.kt:60)\n" +
+                    "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testCompletedAsync\$1.invokeSuspend(StackTraceRecoveryTest.kt:56)\n" +
+                    "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n" +
+                    "\tat kotlinx.coroutines.DispatchedTask\$DefaultImpls.run(Dispatched.kt:146)\n" +
+                    "\tat kotlinx.coroutines.AbstractContinuation.run(AbstractContinuation.kt:19)\n" +
+                    "\tat kotlinx.coroutines.EventLoopBase.processNextEvent(EventLoop.kt:140)",
+            "Caused by: java.util.concurrent.ExecutionException\n" +
+                    "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testCompletedAsync\$1\$deferred\$1.invokeSuspend(StackTraceRecoveryTest.kt:44)\n" +
+                    "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)"
+        )
+        nestedMethod(deferred, stacktrace)
+    }
+
+    private suspend fun nestedMethod(deferred: Deferred<*>, traces: List<String>) {
+        oneMoreNestedMethod(deferred, traces)
+        assertTrue(true) // Prevent tail-call optimization
+    }
+
+    private suspend fun oneMoreNestedMethod(deferred: Deferred<*>, traces: List<String>) {
+        try {
+            deferred.await()
+            expectUnreached()
+        } catch (e: ExecutionException) {
+            verifyStackTrace(e, traces)
+        }
+    }
+
+    @Test
+    fun testReceiveFromChannel() = runTest {
+        val channel = Channel<Int>()
+        val job = launch {
+            expect(2)
+            channel.close(IllegalArgumentException())
+        }
+
+        expect(1)
+        channelNestedMethod(
+            channel, listOf(
+                "java.lang.IllegalArgumentException\n" +
+                        "\t(Current coroutine stacktrace)\n" +
+                        "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest.channelNestedMethod(StackTraceRecoveryTest.kt:110)\n" +
+                        "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest\$testReceiveFromChannel\$1.invokeSuspend(StackTraceRecoveryTest.kt:89)",
+                "Caused by: java.lang.IllegalArgumentException\n" +
+                        "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testReceiveFromChannel\$1\$job\$1.invokeSuspend(StackTraceRecoveryTest.kt:93)\n" +
+                        "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n" +
+                        "\tat kotlinx.coroutines.DispatchedTask\$DefaultImpls.run(Dispatched.kt:152)"
+            )
+        )
+        expect(3)
+        job.join()
+        finish(4)
+    }
+
+    @Test
+    fun testReceiveFromClosedChannel() = runTest {
+        val channel = Channel<Int>()
+        channel.close(IllegalArgumentException())
+        channelNestedMethod(
+            channel, listOf(
+                "java.lang.IllegalArgumentException\n" +
+                        "\t(Current coroutine stacktrace)\n" +
+                        "\tat kotlinx.coroutines.channels.AbstractChannel.receiveResult(AbstractChannel.kt:574)\n" +
+                        "\tat kotlinx.coroutines.channels.AbstractChannel.receive(AbstractChannel.kt:567)\n" +
+                        "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest.channelNestedMethod(StackTraceRecoveryTest.kt:117)\n" +
+                        "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testReceiveFromClosedChannel\$1.invokeSuspend(StackTraceRecoveryTest.kt:111)\n" +
+                        "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)",
+                "Caused by: java.lang.IllegalArgumentException\n" +
+                        "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testReceiveFromClosedChannel\$1.invokeSuspend(StackTraceRecoveryTest.kt:110)"
+            )
+        )
+    }
+
+    private suspend fun channelNestedMethod(channel: Channel<Int>, traces: List<String>) {
+        try {
+            channel.receive()
+            expectUnreached()
+        } catch (e: IllegalArgumentException) {
+            verifyStackTrace(e, traces)
+        }
+    }
+
+    @Test
+    fun testWithContext() = runTest {
+        val deferred = async(start = CoroutineStart.LAZY) {
+            throw TestException()
+        }
+
+        outerMethod(deferred, listOf(
+            "kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$TestException\n" +
+                "\t(Current coroutine stacktrace)\n" +
+                "\tat kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)\n" +
+                "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest.innerMethod(StackTraceRecoveryTest.kt:158)\n" +
+                "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest\$outerMethod\$2.invokeSuspend(StackTraceRecoveryTest.kt:151)\n" +
+                "\tat kotlinx/coroutines/BuildersKt__Builders_commonKt\$withContext\$2.invokeSuspend(Builders.common.kt:140)\n" +
+                "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest.outerMethod(StackTraceRecoveryTest.kt:150)\n" +
+                "\tat kotlinx/coroutines/exceptions/StackTraceRecoveryTest\$testWithContext\$1.invokeSuspend(StackTraceRecoveryTest.kt:141)\n",
+            "Caused by: kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$TestException\n" +
+                "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryTest\$testWithContext\$1\$deferred\$1.invokeSuspend(StackTraceRecoveryTest.kt:143)\n" +
+                "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n"))
+        deferred.join()
+    }
+
+    private suspend fun outerMethod(deferred: Deferred<Nothing>, traces: List<String>) {
+        withContext(Dispatchers.IO) {
+            innerMethod(deferred, traces)
+        }
+
+        assertTrue(true)
+    }
+
+    private suspend fun innerMethod(deferred: Deferred<Nothing>, traces: List<String>) {
+        try {
+            deferred.await()
+        } catch (e: TestException) {
+            verifyStackTrace(e, traces)
+        }
+    }
+
+    private fun verifyStackTrace(e: Throwable, traces: List<String>) {
+        val stacktrace = toStackTrace(e)
+        traces.forEach {
+            assertTrue(
+                stacktrace.trimStackTrace().contains(it.trimStackTrace()),
+                "\nExpected trace element:\n$it\n\nActual stacktrace:\n$stacktrace"
+            )
+        }
+
+        val causes = stacktrace.count("Caused by")
+        assertNotEquals(0, causes)
+        assertEquals(causes, traces.map { it.count("Caused by") }.sum())
+    }
+
+    private fun toStackTrace(t: Throwable): String {
+        val sw = StringWriter() as Writer
+        t.printStackTrace(PrintWriter(sw))
+        return sw.toString()
+    }
+
+
+    private fun String.trimStackTrace(): String {
+        return applyBackspace(trimIndent().replace(Regex(":[0-9]+"), "")
+            .replace("kotlinx_coroutines_core", "") // yay source sets
+            .replace("kotlinx_coroutines_core_main", ""))
+    }
+
+    private fun applyBackspace(line: String): String {
+        val array = line.toCharArray()
+        val stack = CharArray(array.size)
+        var stackSize = -1
+        for (c in array) {
+            if (c != '\b') {
+                stack[++stackSize] = c
+            } else {
+                --stackSize
+            }
+        }
+
+        return String(stack, 0, stackSize)
+    }
+
+    private fun String.count(substring: String): Int = split(substring).size - 1
+
+    class TestException : Exception()
+}

--- a/core/kotlinx-coroutines-core/test/exceptions/SuppresionTests.kt
+++ b/core/kotlinx-coroutines-core/test/exceptions/SuppresionTests.kt
@@ -24,11 +24,11 @@ class SuppresionTests : TestBase() {
         }
 
         expect(1)
-        deferred.cancel(IOException())
+        deferred.cancel(TestException("Message"))
 
         try {
             deferred.await()
-        } catch (e: IOException) {
+        } catch (e: TestException) {
             checkException<ArithmeticException>(e.suppressed()[0])
             finish(3)
         }

--- a/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
+++ b/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
@@ -274,7 +274,7 @@ class TestCoroutineContextTest {
     @Test
     fun testExceptionHandlingWithLaunchingChildCoroutines() = withTestContext(injectedContext) {
         val delay = 1000L
-        val expectedError = IllegalAccessError("hello")
+        val expectedError = TestException("hello")
         val expectedValue = 12
 
         launch {
@@ -304,7 +304,7 @@ class TestCoroutineContextTest {
     @Test
     fun testExceptionHandlingWithAsyncAndWaitForException() = withTestContext(injectedContext) {
         val delay = 1000L
-        val expectedError = IllegalAccessError("hello")
+        val expectedError = TestException("hello")
         val expectedValue = 12
 
         val result = async {
@@ -335,7 +335,7 @@ class TestCoroutineContextTest {
     @Test
     fun testExceptionHandlingWithRunBlockingAndWaitForException() = withTestContext(injectedContext) {
         val delay = 1000L
-        val expectedError = IllegalAccessError("hello")
+        val expectedError = TestException("hello")
         val expectedValue = 12
 
         try {

--- a/core/kotlinx-coroutines-debug/build.gradle
+++ b/core/kotlinx-coroutines-debug/build.gradle
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+dependencies {
+    compile "net.bytebuddy:byte-buddy:$byte_buddy_version"
+    compile "net.bytebuddy:byte-buddy-agent:$byte_buddy_version"
+}

--- a/core/kotlinx-coroutines-debug/src/CoroutineState.kt
+++ b/core/kotlinx-coroutines-debug/src/CoroutineState.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.coroutines.internal.*
+import kotlin.coroutines.*
+
+/**
+ * Class describing coroutine state.
+ */
+public class CoroutineState(public val coroutine: Continuation<*>, public val creationStackTrace: List<StackTraceElement>) {
+
+    internal constructor(coroutine: Continuation<*>, creationStackTrace: List<StackTraceElement>,
+                         state: State, lastObservedFrame: Continuation<*>?): this(coroutine, creationStackTrace) {
+        _state = state
+        this.lastObservedFrame = lastObservedFrame
+    }
+
+    internal var _state: State = State.CREATED
+
+    /**
+     * Last observer state of the coroutine.
+     */
+    public val state: State get() = _state
+
+    internal var lastObservedFrame: Continuation<*>? = null
+
+    /**
+     * Last observed (suspension-point) stacktrace of the coroutine observed on its
+     * suspension or resumption point.
+     * It means that for [running][State.RUNNING] coroutines resulting stacktrace is inaccurate and
+     * reflects stacktrace of the resumption point, not the current stacktrace
+     */
+    public fun suspensionStackTrace(): List<StackTraceElement> {
+        var frame: CoroutineStackFrame? = lastObservedFrame as? CoroutineStackFrame ?: return emptyList()
+        val result = ArrayList<StackTraceElement>()
+        while (frame != null) {
+            frame.getStackTraceElement()?.let { result.add(it) }
+            frame = frame.callerFrame
+        }
+
+        return result
+    }
+}
+
+/**
+ * Current state of the coroutine.
+ */
+public enum class State {
+    CREATED,
+    RUNNING,
+    SUSPENDED
+}

--- a/core/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/core/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("unused")
+
+package kotlinx.coroutines
+
+import kotlinx.coroutines.internal.*
+import kotlinx.coroutines.internal.CoroutineStackFrame
+import net.bytebuddy.*
+import net.bytebuddy.agent.*
+import net.bytebuddy.dynamic.loading.*
+import java.lang.management.*
+import java.util.*
+import kotlin.collections.ArrayList
+import kotlin.coroutines.*
+
+/**
+ * Debug probes support.
+ *
+ * Debug probes is a dynamic attach mechanism, which installs multiple hooks into [Continuation] machinery.
+ * It significantly slows down all coroutine-related code, but in return provides a lot of debug information, including
+ * asynchronous stack-traces and coroutine dumps (similar to [ThreadMXBean.dumpAllThreads] and `jstack`.
+ *
+ * Installed hooks:
+ *
+ * * `probeCoroutineResumed` is invoked on every [Continuation.resume].
+ * * `probeCoroutineSuspended` is invoked on every continuation suspension.
+ * * `probeCoroutineCreated` is invoked on every coroutine creation using stdlib intrinsics.
+ *
+ * Overhead:
+ *  * Every created continuation is stored in a weak hash map, thus adding additional GC pressure
+ *  * On every created continuation, stacktrace of the current thread is dumped
+ *  * On every `resume` and `suspend`, [WeakHashMap] is updated under a global lock
+ *
+ * **WARNING: DO NOT USE DEBUG PROBES IN PRODUCTION ENVIRONMENT**
+ */
+public object DebugProbes {
+    private val traces = WeakHashMap<Continuation<*>, Array<StackTraceElement>>()
+    private var installed: Boolean = false
+
+    /**
+     * Installs a [DebugProbes] instead of no-op stdlib probes by redefining
+     * debug probes class using the same class loader.
+     *
+     * **WARNING: DO NOT USE DEBUG PROBES IN PRODUCTION ENVIRONMENT**
+     * Subsequent invocations of this method have no effect.
+     */
+    @Synchronized
+    public fun install() {
+        if (installed) {
+            return
+        }
+
+        installed = true
+        ByteBuddyAgent.install()
+        val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
+        val cl2 = Class.forName("kotlinx.coroutines.DebugProbesKt")
+
+        ByteBuddy()
+            .redefine(cl2)
+            .name(cl.name)
+            .make()
+            .load(cl.classLoader, ClassReloadingStrategy.fromInstalledAgent())
+    }
+
+    /**
+     * Uninstall debug probes
+     */
+    @Synchronized
+    public fun uninstall() {
+        if (!installed) {
+            return
+        }
+
+        traces.clear()
+        ByteBuddyAgent.install()
+        val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
+        val cl2 = Class.forName("kotlinx.coroutines.NoOpProbesKt")
+
+        ByteBuddy()
+            .redefine(cl2)
+            .name(cl.name)
+            .make()
+            .load(cl.classLoader, ClassReloadingStrategy.fromInstalledAgent())
+    }
+
+    /**
+     * Invokes given block of code with installed debug probes and unistall probes in the end.
+     * **NOTE:** this method is not composable, it will uninstall debug probes even if they were installed
+     * prior to method invocation
+     */
+    public inline fun withDebugProbes(block: () -> Unit) {
+        install()
+        try {
+            block()
+        } finally {
+            uninstall()
+        }
+    }
+
+
+    public fun dumpCoroutines(): String = TODO("Not implemented")
+
+    @Synchronized
+    internal fun probeCoroutineResumed(frame: Continuation<*>) {
+    }
+
+    @Synchronized
+    internal fun probeCoroutineSuspended(frame: Continuation<*>) {
+    }
+
+    @Synchronized
+    internal fun <T> probeCoroutineCreated(completion: kotlin.coroutines.Continuation<T>): kotlin.coroutines.Continuation<T> {
+        val stacktrace = sanitizedStackTrace(Exception())
+        traces[completion] = stacktrace
+
+        // TODO create lazy proxy and reverse stacktrace on demand
+        val frames = ArrayList<CoroutineStackFrame?>(stacktrace.size)
+        for ((index, frame) in stacktrace.reversed().withIndex()) {
+            frames += object : CoroutineStackFrame {
+                override val callerFrame: CoroutineStackFrame?
+                    get() = if (index == 0) null else frames[index - 1]
+
+                override fun getStackTraceElement(): StackTraceElement = frame
+            }
+        }
+
+        return object : Continuation<T> by completion, CoroutineStackFrame by frames.last()!! {}
+    }
+
+    private fun <T : Throwable> sanitizedStackTrace(throwable: T): Array<StackTraceElement> {
+        val stackTrace = throwable.stackTrace
+        val size = stackTrace.size
+
+        var lastIntrinsic = -1
+        for (i in 0 until size) {
+            val name = stackTrace[i].className
+            if ("kotlin.coroutines.jvm.internal.DebugProbesKt" == name) {
+                lastIntrinsic = i
+            }
+        }
+
+        val startIndex = lastIntrinsic + 1
+        return Array(size - lastIntrinsic) {
+            if (it == 0) {
+                artificialFrame("Coroutine creation callsite")
+            } else {
+                stackTrace[startIndex + it - 1]
+            }
+        }
+    }
+}
+
+// Stubs which are injected as coroutine probes. Require direct match of signatures
+internal fun probeCoroutineResumed(frame: Continuation<*>) = DebugProbes.probeCoroutineResumed(frame)
+internal fun probeCoroutineSuspended(frame: Continuation<*>) = DebugProbes.probeCoroutineSuspended(frame)
+internal fun <T> probeCoroutineCreated(completion: kotlin.coroutines.Continuation<T>): kotlin.coroutines.Continuation<T> =
+    DebugProbes.probeCoroutineCreated(completion)

--- a/core/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/core/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -39,6 +39,7 @@ import kotlin.coroutines.*
  */
 public object DebugProbes {
 
+    private const val ARTIFICIAL_FRAME_MESSAGE = "Coroutine creation stacktrace"
     private val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
     private val capturedCoroutines = WeakHashMap<ArtificialStackFrame<*>, CoroutineState>()
     private var installed: Boolean = false
@@ -117,18 +118,17 @@ public object DebugProbes {
     public fun dumpCoroutines(out: PrintStream = System.out): Unit {
         // Avoid inference with other out/err invocations
         val resultingString = buildString {
-            append("Coroutines dump ${dateFormat.format(System.currentTimeMillis())}:\n")
+            append("Coroutines dump ${dateFormat.format(System.currentTimeMillis())}")
 
             capturedCoroutines.forEach { key, value ->
                 val state = if (value.state == State.RUNNING)
                     "${value.state} (Last suspension stacktrace, not an actual stacktrace)"
                 else value.state.toString()
 
-                append("\nCoroutine $key, state: $state")
+                append("\n\nCoroutine $key, state: $state")
                 if (value.lastObservedFrame == null) {
-                    append("\n\tat ${artificialFrame("Coroutine creation callsite")}")
+                    append("\n\tat ${artificialFrame(ARTIFICIAL_FRAME_MESSAGE)}")
                     printStackTrace(value.creationStackTrace)
-
                 } else {
                     printStackTrace(value.suspensionStackTrace())
                 }
@@ -233,7 +233,7 @@ public object DebugProbes {
         val startIndex = lastIntrinsic + 1
         return Array(size - lastIntrinsic) {
             if (it == 0) {
-                artificialFrame("Coroutine creation callsite")
+                artificialFrame(ARTIFICIAL_FRAME_MESSAGE)
             } else {
                 stackTrace[startIndex + it - 1]
             }

--- a/core/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/core/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -7,11 +7,12 @@
 package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
-import kotlinx.coroutines.internal.CoroutineStackFrame
 import net.bytebuddy.*
 import net.bytebuddy.agent.*
 import net.bytebuddy.dynamic.loading.*
+import java.io.*
 import java.lang.management.*
+import java.text.*
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.coroutines.*
@@ -21,7 +22,7 @@ import kotlin.coroutines.*
  *
  * Debug probes is a dynamic attach mechanism, which installs multiple hooks into [Continuation] machinery.
  * It significantly slows down all coroutine-related code, but in return provides a lot of debug information, including
- * asynchronous stack-traces and coroutine dumps (similar to [ThreadMXBean.dumpAllThreads] and `jstack`.
+ * asynchronous stack-traces and coroutine dumps (similar to [ThreadMXBean.dumpAllThreads] and `jstack` via [DebugProbes.dumpCoroutines].
  *
  * Installed hooks:
  *
@@ -30,14 +31,16 @@ import kotlin.coroutines.*
  * * `probeCoroutineCreated` is invoked on every coroutine creation using stdlib intrinsics.
  *
  * Overhead:
- *  * Every created continuation is stored in a weak hash map, thus adding additional GC pressure
- *  * On every created continuation, stacktrace of the current thread is dumped
- *  * On every `resume` and `suspend`, [WeakHashMap] is updated under a global lock
+ *  * Every created continuation is stored in a weak hash map, thus adding additional GC pressure.
+ *  * On every created continuation, stacktrace of the current thread is dumped.
+ *  * On every `resume` and `suspend`, [WeakHashMap] is updated under a global lock.
  *
- * **WARNING: DO NOT USE DEBUG PROBES IN PRODUCTION ENVIRONMENT**
+ * **WARNING: DO NOT USE DEBUG PROBES IN PRODUCTION ENVIRONMENT.**
  */
 public object DebugProbes {
-    private val traces = WeakHashMap<Continuation<*>, Array<StackTraceElement>>()
+
+    private val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+    private val capturedCoroutines = WeakHashMap<ArtificialStackFrame<*>, CoroutineState>()
     private var installed: Boolean = false
 
     /**
@@ -74,7 +77,8 @@ public object DebugProbes {
             return
         }
 
-        traces.clear()
+        installed = false
+        capturedCoroutines.clear()
         ByteBuddyAgent.install()
         val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
         val cl2 = Class.forName("kotlinx.coroutines.NoOpProbesKt")
@@ -100,21 +104,87 @@ public object DebugProbes {
         }
     }
 
-
-    public fun dumpCoroutines(): String = TODO("Not implemented")
-
+    /**
+     * Returns all alive coroutine states.
+     * Resulting collection represents consistent snapshot of all alive coroutines at the moment of invocation.
+     */
     @Synchronized
-    internal fun probeCoroutineResumed(frame: Continuation<*>) {
+    public fun dumpCoroutinesState(): List<CoroutineState> = capturedCoroutines.entries.map {
+        CoroutineState(it.key, it.value.creationStackTrace,  it.value._state, it.value.lastObservedFrame)
     }
 
     @Synchronized
-    internal fun probeCoroutineSuspended(frame: Continuation<*>) {
+    public fun dumpCoroutines(out: PrintStream = System.out): Unit {
+        // Avoid inference with other out/err invocations
+        val resultingString = buildString {
+            append("Coroutines dump ${dateFormat.format(System.currentTimeMillis())}:\n")
+
+            capturedCoroutines.forEach { key, value ->
+                val state = if (value.state == State.RUNNING)
+                    "${value.state} (Last suspension stacktrace, not an actual stacktrace)"
+                else value.state.toString()
+
+                append("\nCoroutine $key, state: $state")
+                if (value.lastObservedFrame == null) {
+                    append("\n\tat ${artificialFrame("Coroutine creation callsite")}")
+                    printStackTrace(value.creationStackTrace)
+
+                } else {
+                    printStackTrace(value.suspensionStackTrace())
+                }
+            }
+        }
+
+        out.println(resultingString)
+    }
+
+    private fun StringBuilder.printStackTrace(frames: List<StackTraceElement>) {
+        frames.forEach { frame ->
+            append("\n\tat $frame")
+        }
     }
 
     @Synchronized
-    internal fun <T> probeCoroutineCreated(completion: kotlin.coroutines.Continuation<T>): kotlin.coroutines.Continuation<T> {
+    internal fun probeCoroutineResumed(frame: Continuation<*>) = updateState(frame, State.RUNNING)
+
+    @Synchronized
+    internal fun probeCoroutineSuspended(frame: Continuation<*>) = updateState(frame, State.SUSPENDED)
+
+    /*
+     * Updates coroutine state.
+     * TODO this method is currently racy:
+     *
+     * ```
+     * suspendCoroutineUninterceptedOrReturn<Int> {
+     *   publish(it)
+     *   ready.compareAndSet(false, true)
+     *   COROUTINE_SUSPENDED
+     * }
+     *
+     * fun onPublishInAnotherThread(continuation: Continuation<*>) {
+     *   continuation.resume(Result.success(...))
+     * }
+     * ```
+     */
+    private fun updateState(frame: Continuation<*>, state: State) {
+        val owner = frame.owner() ?: return
+        val coroutineState = capturedCoroutines[owner] ?: return
+        coroutineState._state = state
+        coroutineState.lastObservedFrame = frame
+    }
+
+    private fun Continuation<*>.owner(): ArtificialStackFrame<*>? {
+        var frame = this as? CoroutineStackFrame ?: return null
+        while (true) {
+            if (frame is ArtificialStackFrame<*>) return frame
+            val completion = frame.callerFrame ?: return null
+            frame = completion
+        }
+    }
+
+    @Synchronized
+    internal fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> {
         val stacktrace = sanitizedStackTrace(Exception())
-        traces[completion] = stacktrace
 
         // TODO create lazy proxy and reverse stacktrace on demand
         val frames = ArrayList<CoroutineStackFrame?>(stacktrace.size)
@@ -127,7 +197,25 @@ public object DebugProbes {
             }
         }
 
-        return object : Continuation<T> by completion, CoroutineStackFrame by frames.last()!! {}
+        val result = ArtificialStackFrame(completion, frames.last()!!)
+        capturedCoroutines[result] = CoroutineState(completion, stacktrace.slice(1 until stacktrace.size))
+        return result
+    }
+
+    @Synchronized
+    private fun probeCoroutineCompleted(coroutine: ArtificialStackFrame<*>) {
+        capturedCoroutines.remove(coroutine)
+    }
+
+    private class ArtificialStackFrame<T>(val delegate: Continuation<T>, frame: CoroutineStackFrame) :
+        Continuation<T> by delegate, CoroutineStackFrame by frame {
+
+        override fun resumeWith(result: Result<T>) {
+            probeCoroutineCompleted(this)
+            delegate.resumeWith(result)
+        }
+
+        override fun toString(): String = delegate.toString()
     }
 
     private fun <T : Throwable> sanitizedStackTrace(throwable: T): Array<StackTraceElement> {

--- a/core/kotlinx-coroutines-debug/src/NoOpProbes.kt
+++ b/core/kotlinx-coroutines-debug/src/NoOpProbes.kt
@@ -2,7 +2,7 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("unused")
+@file:Suppress("unused", "UNUSED_PARAMETER")
 
 package kotlinx.coroutines
 

--- a/core/kotlinx-coroutines-debug/src/NoOpProbes.kt
+++ b/core/kotlinx-coroutines-debug/src/NoOpProbes.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("unused")
+
+package kotlinx.coroutines
+
+import kotlin.coroutines.*
+
+@JvmName("probeCoroutineResumed")
+internal fun probeCoroutineResumedNoOp(frame: Continuation<*>) = Unit
+@JvmName("probeCoroutineSuspended")
+internal fun probeCoroutineSuspendedNoOp(frame: Continuation<*>) = Unit
+@JvmName("probeCoroutineCreated")
+internal fun <T> probeCoroutineCreatedNoOp(completion: kotlin.coroutines.Continuation<T>): kotlin.coroutines.Continuation<T> = completion

--- a/core/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
+++ b/core/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
@@ -37,7 +37,7 @@ class CoroutinesDumpTest {
                 "\tat kotlinx/coroutines/CoroutinesDumpTest.sleepingNestedMethod(CoroutinesDumpTest.kt:95)\n" +
                 "\tat kotlinx/coroutines/CoroutinesDumpTest.sleepingOuterMethod(CoroutinesDumpTest.kt:88)\n" +
                 "\tat kotlinx/coroutines/CoroutinesDumpTest\$testSuspendedCoroutine\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:29)\n" +
-            "\t(Coroutine creation callsite)\n" +
+            "\t(Coroutine creation stacktrace)\n" +
                 "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
                 "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
                 "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n")
@@ -55,7 +55,7 @@ class CoroutinesDumpTest {
         verifyDump(
             "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: RUNNING (Last suspension stacktrace, not an actual stacktrace)\n" +
                     "\tat kotlinx/coroutines/CoroutinesDumpTest\$testRunningCoroutine\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:49)\n" +
-             "\t(Coroutine creation callsite)\n" +
+             "\t(Coroutine creation stacktrace)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
                     "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
                     "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
@@ -79,7 +79,7 @@ class CoroutinesDumpTest {
                    "\tat kotlinx/coroutines/CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt:111)\n" +
                    "\tat kotlinx/coroutines/CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt:106)\n" +
                    "\tat kotlinx/coroutines/CoroutinesDumpTest\$testRunningCoroutineWihSuspensionPoint\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:71)\n" +
-           "\t(Coroutine creation callsite)\n" +
+           "\t(Coroutine creation stacktrace)\n" +
                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
@@ -142,15 +142,14 @@ class CoroutinesDumpTest {
         DebugProbes.dumpCoroutines(PrintStream(baos))
         val trace = baos.toString().split("\n\n")
         if (traces.isEmpty()) {
-            assertEquals(2, trace.size)
+            assertEquals(1, trace.size)
             assertTrue(trace[0].startsWith("Coroutines dump"))
-            assertTrue(trace[1].isBlank())
             return
         }
 
         trace.withIndex().drop(1).forEach { (index, value) ->
-            val expected = traces[index - 1].applyBackspace().split("\n\t(Coroutine creation callsite)\n", limit = 2)
-            val actual = value.applyBackspace().split("\n\t(Coroutine creation callsite)\n", limit = 2)
+            val expected = traces[index - 1].applyBackspace().split("\n\t(Coroutine creation stacktrace)\n", limit = 2)
+            val actual = value.applyBackspace().split("\n\t(Coroutine creation stacktrace)\n", limit = 2)
             assertEquals(expected.size, actual.size)
 
             expected.withIndex().forEach { (index, trace) ->

--- a/core/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
+++ b/core/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import org.junit.*
+import org.junit.Test
+import java.io.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class CoroutinesDumpTest {
+
+    private val monitor = Any()
+
+    @Before
+    fun setUp() {
+        DebugProbes.install()
+    }
+
+    @After
+    fun tearDown() {
+        DebugProbes.uninstall()
+    }
+
+    @Test
+    fun testSuspendedCoroutine() = synchronized(monitor) {
+        val deferred = GlobalScope.async {
+            sleepingOuterMethod()
+        }
+
+        awaitCoroutine()
+        Thread.sleep(100)  // Let delay be invoked
+        verifyDump(
+            "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: SUSPENDED\n" +
+                "\tat kotlinx/coroutines/CoroutinesDumpTest.sleepingNestedMethod(CoroutinesDumpTest.kt:95)\n" +
+                "\tat kotlinx/coroutines/CoroutinesDumpTest.sleepingOuterMethod(CoroutinesDumpTest.kt:88)\n" +
+                "\tat kotlinx/coroutines/CoroutinesDumpTest\$testSuspendedCoroutine\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:29)\n" +
+            "\t(Coroutine creation callsite)\n" +
+                "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
+                "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
+                "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n")
+        deferred.cancel()
+        runBlocking { deferred.join() }
+    }
+
+    @Test
+    fun testRunningCoroutine() = synchronized(monitor) {
+        val deferred = GlobalScope.async {
+            activeMethod(suspend = false)
+        }
+
+        awaitCoroutine()
+        verifyDump(
+            "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: RUNNING (Last suspension stacktrace, not an actual stacktrace)\n" +
+                    "\tat kotlinx/coroutines/CoroutinesDumpTest\$testRunningCoroutine\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:49)\n" +
+             "\t(Coroutine creation callsite)\n" +
+                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
+                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
+                    "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)\n" +
+                    "\tat kotlinx.coroutines.DeferredKt.async(Deferred.kt:156)\n" +
+                    "\tat kotlinx.coroutines.DeferredKt.async\$default(Deferred.kt:148)\n" +
+                    "\tat kotlinx.coroutines.CoroutinesDumpTest.testRunningCoroutine(CoroutinesDumpTest.kt:49)")
+        deferred.cancel()
+        runBlocking { deferred.join() }
+    }
+
+    @Test
+    fun testRunningCoroutineWihSuspensionPoint() = synchronized(monitor) {
+        val deferred = GlobalScope.async {
+            activeMethod(suspend = true)
+        }
+
+        awaitCoroutine()
+        verifyDump(
+           "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: RUNNING (Last suspension stacktrace, not an actual stacktrace)\n" +
+                   "\tat kotlinx/coroutines/CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt:111)\n" +
+                   "\tat kotlinx/coroutines/CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt:106)\n" +
+                   "\tat kotlinx/coroutines/CoroutinesDumpTest\$testRunningCoroutineWihSuspensionPoint\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:71)\n" +
+           "\t(Coroutine creation callsite)\n" +
+                   "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
+                   "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
+                   "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
+                   "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)\n" +
+                   "\tat kotlinx.coroutines.DeferredKt.async(Deferred.kt:156)\n" +
+                   "\tat kotlinx.coroutines.DeferredKt.async\$default(Deferred.kt:148)\n" +
+                   "\tat kotlinx.coroutines.CoroutinesDumpTest.testRunningCoroutineWihSuspensionPoint(CoroutinesDumpTest.kt:71)")
+        deferred.cancel()
+        runBlocking { deferred.join() }
+    }
+
+    @Test
+    fun testFinishedCoroutineRemoved() = synchronized(monitor) {
+        val deferred = GlobalScope.async {
+            activeMethod(suspend = true)
+        }
+
+        awaitCoroutine()
+        deferred.cancel()
+        runBlocking { deferred.join() }
+        verifyDump()
+    }
+
+    private suspend fun activeMethod(suspend: Boolean) {
+        nestedActiveMethod(suspend)
+        delay(1)
+    }
+
+    private suspend fun nestedActiveMethod(suspend: Boolean) {
+        if (suspend) delay(1)
+        notifyTest()
+        while (coroutineContext[Job]!!.isActive) {
+            Thread.sleep(100)
+        }
+    }
+
+    private suspend fun sleepingOuterMethod() {
+        sleepingNestedMethod()
+        delay(1)
+    }
+
+    private suspend fun sleepingNestedMethod() {
+        delay(1)
+        notifyTest()
+        delay(Long.MAX_VALUE)
+    }
+
+    private fun awaitCoroutine() {
+        (monitor as Object).wait()
+    }
+
+    private fun notifyTest() {
+        synchronized(monitor) {
+            (monitor as Object).notify()
+        }
+    }
+
+    private fun verifyDump(vararg traces: String) {
+        val baos = ByteArrayOutputStream()
+        DebugProbes.dumpCoroutines(PrintStream(baos))
+        val trace = baos.toString().split("\n\n")
+        if (traces.isEmpty()) {
+            assertEquals(2, trace.size)
+            assertTrue(trace[0].startsWith("Coroutines dump"))
+            assertTrue(trace[1].isBlank())
+            return
+        }
+
+        trace.withIndex().drop(1).forEach { (index, value) ->
+            val expected = traces[index - 1].applyBackspace().split("\n\t(Coroutine creation callsite)\n", limit = 2)
+            val actual = value.applyBackspace().split("\n\t(Coroutine creation callsite)\n", limit = 2)
+            assertEquals(expected.size, actual.size)
+
+            expected.withIndex().forEach { (index, trace) ->
+                val actualTrace = actual[index].trimStackTrace().sanitizeAddresses()
+                val expectedTrace = trace.trimStackTrace().sanitizeAddresses()
+                assertTrue(actualTrace.startsWith(expectedTrace), "Actual trace:\n${actual[index]}, \nexpected:\n$trace")
+            }
+        }
+    }
+
+    private fun String.sanitizeAddresses(): String {
+        val index = indexOf("coroutine#")
+        val next = indexOf(',', index)
+        if (index == -1 || next == -1) return this
+        return substring(0, index) + substring(next, length)
+    }
+}

--- a/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
+++ b/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
@@ -44,7 +44,7 @@ class DebugProbesTest : TestBase() {
                         "\tat kotlinx/coroutines/DebugProbesTest.oneMoreNestedMethod(DebugProbesTest.kt:71)\n" +
                         "\tat kotlinx/coroutines/DebugProbesTest.nestedMethod(DebugProbesTest.kt:66)\n" +
                         "\tat kotlinx/coroutines/DebugProbesTest\$testAsyncWithProbes\$1\$1.invokeSuspend(DebugProbesTest.kt:43)\n" +
-                        "\t(Coroutine creation callsite)\n" +
+                        "\t(Coroutine creation stacktrace)\n" +
                         "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
                         "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
                         "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +

--- a/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
+++ b/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package kotlinx.coroutines
+
+import org.junit.Test
+import java.io.*
+import java.util.concurrent.*
+import kotlin.test.*
+
+class DebugProbesTest : TestBase() {
+
+    private fun CoroutineScope.createDeferred(): Deferred<*> = async {
+        throw ExecutionException(null)
+    }
+
+    @Test
+    fun testAsync() = runTest {
+
+        val deferred = createDeferred()
+        val traces = listOf(
+            "java.util.concurrent.ExecutionException\n" +
+                    "\t(Current coroutine stacktrace)\n" +
+                    "\tat kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)\n" +
+                    "\tat kotlinx/coroutines/DebugProbesTest.oneMoreNestedMethod(DebugProbesTest.kt:49)\n" +
+                    "\tat kotlinx/coroutines/DebugProbesTest.nestedMethod(DebugProbesTest.kt:44)\n" +
+                    "\tat kotlinx/coroutines/DebugProbesTest\$testAsync\$1.invokeSuspend(DebugProbesTest.kt:17)\n" +
+                    "Caused by: java.util.concurrent.ExecutionException\n" +
+                    "\tat kotlinx.coroutines.DebugProbesTest\$createDeferred\$1.invokeSuspend(DebugProbesTest.kt:16)\n" +
+                    "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n"
+        )
+        nestedMethod(deferred, traces)
+        deferred.join()
+    }
+
+    @Test
+    fun testAsyncWithProbes() = DebugProbes.withDebugProbes {
+        runTest {
+            val deferred = createDeferred()
+            val traces = listOf(
+                "java.util.concurrent.ExecutionException\n" +
+                        "\t(Current coroutine stacktrace)\n" +
+                        "\tat kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)\n" +
+                        "\tat kotlinx/coroutines/DebugProbesTest.oneMoreNestedMethod(DebugProbesTest.kt:71)\n" +
+                        "\tat kotlinx/coroutines/DebugProbesTest.nestedMethod(DebugProbesTest.kt:66)\n" +
+                        "\tat kotlinx/coroutines/DebugProbesTest\$testAsyncWithProbes\$1\$1.invokeSuspend(DebugProbesTest.kt:43)\n" +
+                        "\t(Coroutine creation callsite)\n" +
+                        "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
+                        "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
+                        "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
+                        "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)\n" +
+                        "\tat kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:45)\n" +
+                        "\tat kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)\n" +
+                        "\tat kotlinx.coroutines.TestBase.runTest(TestBase.kt:138)\n" +
+                        "\tat kotlinx.coroutines.TestBase.runTest\$default(TestBase.kt:19)\n" +
+                        "\tat kotlinx.coroutines.DebugProbesTest.testAsyncWithProbes(DebugProbesTest.kt:38)",
+                "Caused by: java.util.concurrent.ExecutionException\n" +
+                        "\tat kotlinx.coroutines.DebugProbesTest\$createDeferred\$1.invokeSuspend(DebugProbesTest.kt:16)\n" +
+                        "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)\n")
+            nestedMethod(deferred, traces)
+            deferred.join()
+        }
+    }
+
+
+    private suspend fun nestedMethod(deferred: Deferred<*>, traces: List<String>) {
+        oneMoreNestedMethod(deferred, traces)
+        assertTrue(true) // Prevent tail-call optimization
+    }
+
+    private suspend fun oneMoreNestedMethod(deferred: Deferred<*>, traces: List<String>) {
+        try {
+            deferred.await()
+            expectUnreached()
+        } catch (e: ExecutionException) {
+            verifyStackTrace(e, traces)
+        }
+    }
+
+    private fun verifyStackTrace(e: Throwable, traces: List<String>) {
+        val stacktrace = toStackTrace(e)
+        traces.forEach {
+            assertTrue(stacktrace.trimStackTrace().contains(it.trimStackTrace()),
+                "\nExpected trace element:\n$it\n\nActual stacktrace:\n$stacktrace")
+        }
+
+        val causes = stacktrace.count("Caused by")
+        assertNotEquals(0, causes)
+        assertEquals(causes, traces.map { it.count("Caused by") }.sum())
+    }
+
+    private fun toStackTrace(t: Throwable): String {
+        val sw = StringWriter() as Writer
+        t.printStackTrace(PrintWriter(sw))
+        return sw.toString()
+    }
+
+
+    private fun String.trimStackTrace(): String {
+        return applyBackspace(trimIndent().replace(Regex(":[0-9]+"), ""))
+    }
+
+    private fun applyBackspace(line: String): String {
+        val array = line.toCharArray()
+        val stack = CharArray(array.size)
+        var stackSize = -1
+        for (c in array) {
+            if (c != '\b') {
+                stack[++stackSize] = c
+            } else {
+                --stackSize
+            }
+        }
+
+        return String(stack, 0, stackSize)
+    }
+
+    private fun String.count(substring: String): Int = split(substring).size - 1
+}

--- a/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
+++ b/core/kotlinx-coroutines-debug/test/DebugProbesTest.kt
@@ -95,25 +95,24 @@ class DebugProbesTest : TestBase() {
         return sw.toString()
     }
 
-
-    private fun String.trimStackTrace(): String {
-        return applyBackspace(trimIndent().replace(Regex(":[0-9]+"), ""))
-    }
-
-    private fun applyBackspace(line: String): String {
-        val array = line.toCharArray()
-        val stack = CharArray(array.size)
-        var stackSize = -1
-        for (c in array) {
-            if (c != '\b') {
-                stack[++stackSize] = c
-            } else {
-                --stackSize
-            }
-        }
-
-        return String(stack, 0, stackSize)
-    }
-
     private fun String.count(substring: String): Int = split(substring).size - 1
+}
+
+public fun String.trimStackTrace(): String {
+    return trimIndent().replace(Regex(":[0-9]+"), "").applyBackspace()
+}
+
+public fun String.applyBackspace(): String {
+    val array = toCharArray()
+    val stack = CharArray(array.size)
+    var stackSize = -1
+    for (c in array) {
+        if (c != '\b') {
+            stack[++stackSize] = c
+        } else {
+            --stackSize
+        }
+    }
+
+    return String(stack, 0, stackSize)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kotlin
-version=0.26.0-rc13-SNAPSHOT
+version=0.26.0-rc13
 group=org.jetbrains.kotlinx
 kotlin_version=1.3.0-rc-6
 kotlin_native_version=0.9
@@ -7,6 +7,7 @@ kotlin_native_version=0.9
 # Dependencies
 junit_version=4.12
 atomicFU_version=0.11.6
+byte_buddy_version=1.8.22
 html_version=0.6.8
 lincheck_version=1.9
 dokka_version=0.9.16-rdev-2-mpp-hacks

--- a/js/kotlinx-coroutines-core-js/src/internal/Exceptions.kt
+++ b/js/kotlinx-coroutines-core-js/src/internal/Exceptions.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+internal actual fun <E: Throwable> recoverStackTrace(exception: E, continuation: Continuation<*>): E = exception
+internal actual fun <E: Throwable> recoverStackTrace(exception: E): E = exception
+
+internal actual interface CoroutineStackFrame {
+    public actual val callerFrame: CoroutineStackFrame?
+    public actual fun getStackTraceElement(): StackTraceElement?
+}
+
+actual typealias StackTraceElement = Any

--- a/native/kotlinx-coroutines-core-native/src/internal/Exceptions.kt
+++ b/native/kotlinx-coroutines-core-native/src/internal/Exceptions.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+internal actual fun <E: Throwable> recoverStackTrace(exception: E, continuation: Continuation<*>): E = exception
+internal actual fun <E: Throwable> recoverStackTrace(exception: E): E = exception

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ module('binary-compatibility-validator')
 module('common/kotlinx-coroutines-core-common')
 
 module('core/kotlinx-coroutines-core')
+module('core/kotlinx-coroutines-debug')
 
 module('integration/kotlinx-coroutines-guava')
 module('integration/kotlinx-coroutines-jdk8')
@@ -45,3 +46,4 @@ module('js/js-stub')
 module('js/example-frontend-js')
 
 module('native/kotlinx-coroutines-core-native')
+


### PR DESCRIPTION
This PR provides two features to improve coroutine debugging experience: 

**Stacktrace recovery in `JobSupport` and `Channel`**
If debug mode is enabled, thrown exceptions are wrapped into an exception of the same type, but with current *suspension* stacktrace (or current stacktrace if coroutine is active and throws an exception without suspension, e.g. awaiting already completed deferred).

For example, for this piece of code:
```
val deferred = GlobalScope.async { delay(1000L); throw TestException() }

fun nested() = nested2() 
fun nested2() = nested3()
fun nested3() = deferred.await()
```

Before this patch
```
kotlinx.coroutines.TestException 
    at kotlinx.coroutines.exceptions.StackTraceRecoveryTest$testAsync$1$1$1.invokeSuspend(StackTraceRecoveryTest.kt:21)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
    ...
```
will be thrown.


After this patch:
```
kotlinx.coroutines.TestException 
    (Current coroutine stacktrace)
    at kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested3(StackTraceRecoveryTest.kt:49)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested2(StackTraceRecoveryTest.kt:44)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested(StackTraceRecoveryTest.kt:44)
Caused by: kotlinx.coroutines.TestException 
    at kotlinx.coroutines.exceptions.StackTraceRecoveryTest$testAsync$1$1$1.invokeSuspend(StackTraceRecoveryTest.kt:21)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
    ...
```

**Debug probes agent**

Dynamically attached agent, available from `kolinx-coroutines-debug` module and available via `DebugProbes` API.
It provides two features:
1) Capturing stacktrace on coroutine creation and adding it to the recovered stacktrace.
Following previous example, stacktrace will be augmented with creation trace:
```
kotlinx.coroutines.TestException 
    (Current coroutine stacktrace)
    at kotlinx/coroutines/DeferredCoroutine.await\$suspendImpl(Deferred.kt:234)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested3(StackTraceRecoveryTest.kt:49)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested2(StackTraceRecoveryTest.kt:44)
    at kotlinx/coroutines/exceptions/StackTraceRecoveryTest.nested(StackTraceRecoveryTest.kt:44)
    (Coroutine creation stacktrace)
    at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)
    at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)
    at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)
    at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)
    at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:45)
    at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
    at kotlinx.coroutines.TestBase.runTest(TestBase.kt:138)
    at kotlinx.coroutines.TestBase.runTest\$default(TestBase.kt:19)
    at kotlinx.coroutines.StackTraceRecoveryTest.testAsync(DebugProbesTest.kt:38)
Caused by: kotlinx.coroutines.TestException 
    at kotlinx.coroutines.exceptions.StackTraceRecoveryTest$testAsync$1$1$1.invokeSuspend(StackTraceRecoveryTest.kt:21)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
    ...
```

2) Dumping all alive coroutines with captured stacktraces via `DebugProbes.dumpCoroutines()` similar to `jstack`

Example of `DebugProbes.dumpCoroutines` result: 

```
Coroutines dump 2018/09/17 15:23:58:

Coroutine "coroutine#1":DeferredCoroutine{Active}@2bea5ab4, state: SUSPENDED
	at kotlinx/coroutines/CoroutinesDumpTest$createSuspendedCoroutine$1.invokeSuspend(CoroutinesDumpTest.kt:29)
	(Coroutine creation callsite)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)
	at kotlinx.coroutines.DeferredKt.async(Deferred.kt:156)
	at kotlinx.coroutines.DeferredKt.async$default(Deferred.kt:148)
	at kotlinx.coroutines.CoroutinesDumpTest.createSuspendedCoroutine(CoroutinesDumpTest.kt:29)
	at kotlinx.coroutines.CoroutinesDumpTest.dumpExample(CoroutinesDumpTest.kt:14)

Coroutine "coroutine#2":DeferredCoroutine{Active}@74294adb, state: RUNNING (Last suspension stacktrace, not an actual stacktrace)
	at kotlinx/coroutines/CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt:47)
	at kotlinx/coroutines/CoroutinesDumpTest$createActiveCoroutine$1.invokeSuspend(CoroutinesDumpTest.kt:22)
	(Coroutine creation callsite)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)
	at kotlinx.coroutines.DeferredKt.async(Deferred.kt:156)
	at kotlinx.coroutines.DeferredKt.async$default(Deferred.kt:148)
	at kotlinx.coroutines.CoroutinesDumpTest.createActiveCoroutine(CoroutinesDumpTest.kt:22)
	at kotlinx.coroutines.CoroutinesDumpTest.dumpExample(CoroutinesDumpTest.kt:15)kt:22)
	at kotlinx.coroutines.CoroutinesDumpTest.dumpExample(CoroutinesDumpTest.kt:15)
```

