### PR TITLE
Aligned to RxJava2 contract - Observable and Single returns non nulla…

### DIFF
--- a/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
@@ -5,9 +5,11 @@
 package kotlinx.coroutines.experimental.rx2
 
 import io.reactivex.*
-import kotlinx.coroutines.experimental.*
-import kotlinx.coroutines.experimental.channels.*
-import kotlin.coroutines.experimental.*
+import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.Job
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlin.coroutines.experimental.CoroutineContext
 
 /**
  * Converts this job to the hot reactive completable that signals
@@ -44,7 +46,7 @@ public fun <T> Deferred<T?>.asMaybe(context: CoroutineContext): Maybe<T> = Globa
  *
  * @param context -- the coroutine context from which the resulting single is going to be signalled
  */
-public fun <T> Deferred<T>.asSingle(context: CoroutineContext): Single<T> = GlobalScope.rxSingle(context) {
+public fun <T : Any> Deferred<T>.asSingle(context: CoroutineContext): Single<T> = GlobalScope.rxSingle(context) {
     this@asSingle.await()
 }
 
@@ -56,7 +58,7 @@ public fun <T> Deferred<T>.asSingle(context: CoroutineContext): Single<T> = Glob
  *
  * @param context -- the coroutine context from which the resulting observable is going to be signalled
  */
-public fun <T> ReceiveChannel<T>.asObservable(context: CoroutineContext): Observable<T> = GlobalScope.rxObservable(context) {
+public fun <T : Any> ReceiveChannel<T>.asObservable(context: CoroutineContext): Observable<T> = GlobalScope.rxObservable(context) {
     for (t in this@asObservable)
         send(t)
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -35,7 +35,7 @@ import kotlin.coroutines.experimental.*
  * @param context context of the coroutine.
  * @param block the coroutine code.
  */
-public fun <T> CoroutineScope.rxObservable(
+public fun <T : Any> CoroutineScope.rxObservable(
     context: CoroutineContext = EmptyCoroutineContext,
     block: suspend ProducerScope<T>.() -> Unit
 ): Observable<T> = Observable.create { subscriber ->
@@ -54,7 +54,7 @@ public fun <T> CoroutineScope.rxObservable(
     replaceWith = ReplaceWith("GlobalScope.rxObservable(context, block)",
         imports = ["kotlinx.coroutines.experimental.GlobalScope", "kotlinx.coroutines.experimental.rx2.rxObservable"])
 )
-public fun <T> rxObservable(
+public fun <T : Any> rxObservable(
     context: CoroutineContext = Dispatchers.Default,
     parent: Job? = null,
     block: suspend ProducerScope<T>.() -> Unit

--- a/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.experimental.*
  * @param context context of the coroutine.
  * @param block the coroutine code.
  */
-public fun <T> CoroutineScope.rxSingle(
+public fun <T : Any> CoroutineScope.rxSingle(
     context: CoroutineContext = EmptyCoroutineContext,
     block: suspend CoroutineScope.() -> T
 ): Single<T> = Single.create { subscriber ->
@@ -46,7 +46,7 @@ public fun <T> CoroutineScope.rxSingle(
     replaceWith = ReplaceWith("GlobalScope.rxSingle(context, block)",
         imports = ["kotlinx.coroutines.experimental.GlobalScope", "kotlinx.coroutines.experimental.rx2.rxSingle"])
 )
-public fun <T> rxSingle(
+public fun <T : Any> rxSingle(
     context: CoroutineContext = Dispatchers.Default,
     parent: Job? = null,
     block: suspend CoroutineScope.() -> T


### PR DESCRIPTION
…ble type <T>.

Fixes #347 ( https://github.com/Kotlin/kotlinx.coroutines/issues/347 )

This is a breaking change in case if somebody used it for nullable results expecting onError() callback from Observable with NullPointerException