### PR TITLE
Fixed cancellation of runBlocking event loon in the presence of delay

### DIFF
--- a/core/kotlinx-coroutines-core/test/RunBlockingTest.kt
+++ b/core/kotlinx-coroutines-core/test/RunBlockingTest.kt
@@ -82,4 +82,18 @@ class RunBlockingTest : TestBase() {
             job.cancelAndJoin()
         }
     }
+
+    @Test
+    fun testCancelWithDelay() {
+        // see https://github.com/Kotlin/kotlinx.coroutines/issues/586
+        try {
+            runBlocking {
+                coroutineContext.cancel()
+                delay(1)
+            }
+            error("should not be reached")
+        } catch (e: JobCancellationException) {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
Fixes #586