### PR TITLE
Fix typo in deprecation message of JavaFx dispatcher

### DIFF
--- a/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
+++ b/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
@@ -32,7 +32,7 @@ public sealed class JavaFxDispatcher : CoroutineDispatcher(), Delay {
  * @suppress **Deprecated**: Use [Dispatchers.JavaFx].
  */
 @Deprecated(
-    message = "Use Dispatchers.Main",
+    message = "Use Dispatchers.JavaFx",
     replaceWith = ReplaceWith("Dispatchers.JavaFx",
         imports = ["kotlinx.coroutines.experimental.Dispatchers", "kotlinx.coroutines.experimental.javafx.JavaFx"])
 )


### PR DESCRIPTION
Deprecation message of `JavaFx` says: "Use Dispatchers.Main". This is a bit confusing, since there is no `Dispatchers.Main` available in `kotlinx-coroutines-javafx`.

Deprecation message should be "Use Dispatchers.JavaFx".