### PR TITLE
list all documentation files to include to kotlinlang.org website.

### DIFF
--- a/docs/_nav.yml
+++ b/docs/_nav.yml
@@ -1,0 +1,27 @@
+- md: basics.md
+  url: basics.html
+  title: Basics
+- md: coroutines-guide.md
+  url: coroutines-guide.html
+  title: Coroutines Guide
+- md: cancellation-and-timeouts.md
+  url: cancellation-and-timeouts.html
+  title: Cancellation and Timeouts
+- md: channels.md
+  url: channels.html
+  title: Channels
+- md: composing-suspending-functions.md
+  url: composing-suspending-functions.html
+  title: Composing Suspending Functions
+- md: coroutine-context-and-dispatchers.md
+  url: coroutine-context-and-dispatchers.html
+  title: Coroutine Context and Dispatchers
+- md: exception-handling.md
+  url: exception-handling.html
+  title: Exception Handling
+- md: select-expression.md
+  url: select-expression.html
+  title: Select Expression
+- md: shared-mutable-state-and-concurrency.md
+  url: shared-mutable-state-and-concurrency.html
+  title: Shared Mutable State and Concurrency


### PR DESCRIPTION
Added a missing `_nav.yml` for documentation, needed for the kotlin web site import