### PR TITLE
Fixed CoroutineScope of withContext block for structured concurrency

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/CoroutineScope.kt
+++ b/common/kotlinx-coroutines-core-common/src/CoroutineScope.kt
@@ -16,7 +16,8 @@ import kotlin.coroutines.experimental.intrinsics.*
  *
  * Every coroutine builder (like [launch][CoroutineScope.launch], [async][CoroutineScope.async], etc)
  * and every scoping function (like [coroutineScope], [withContext], etc) provides _its own_ scope
- * into the inner block of code it runs. By convention, they all wait for all the coroutines inside
+ * with its own [Job] instance into the inner block of code it runs.
+ * By convention, they all wait for all the coroutines inside
  * their block to complete before completing themselves, thus enforcing the
  * discipline of **structured concurrency**.
  *

--- a/core/kotlinx-coroutines-core/test/WithContextCancellationStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/WithContextCancellationStressTest.kt
@@ -32,7 +32,7 @@ class WithContextCancellationStressTest : TestBase() {
             val barrier = CyclicBarrier(4)
             val ctx = pool + NonCancellable
             val jobWithContext = async(ctx) {
-                withContext(wrapperDispatcher(coroutineContext), start = CoroutineStart.ATOMIC) {
+                withContext(wrapperDispatcher(coroutineContext)) {
                     barrier.await()
                     throw IOException()
                 }


### PR DESCRIPTION
* Both are optimized and are rewritten via AbstractCoroutine
* Support for cancelling state is dropped from AbstractContinuation
  and it is now faster, too

Fixes #553
Fixes #617