### PR TITLE
Coroutine scheduler is used by default instead of deprecated CommonPool

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/Dispatchers.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/Dispatchers.common.kt
@@ -16,10 +16,8 @@ public object Dispatchers {
      * [launch][CoroutineScope.launch], [async][CoroutineScope.async], etc
      * if no dispatcher nor any other [ContinuationInterceptor] is specified in their context.
      *
-     * It is backed by a shared pool of threads on JVM.
-     * You can set system property "`kotlinx.coroutines.scheduler`" (either no value or to the value of "`on`")
-     * to use an experimental coroutine dispatcher that shares threads with [Dispatchers.IO] and thus can switch to
-     * context without performing an actual thread context switch.
+     * It is backed by a shared pool of threads on JVM. By default, the maximal number of threads used
+     * by this dispatcher is equal to the number CPU cores, but is at least two.
      */
     @JvmField
     public val Default: CoroutineDispatcher =

--- a/core/kotlinx-coroutines-core/build.gradle
+++ b/core/kotlinx-coroutines-core/build.gradle
@@ -32,6 +32,7 @@ tasks.withType(Test) {
 
 test {
     exclude '**/*LFTest.*'
+    systemProperty 'kotlinx.coroutines.scheduler.keep.alive.sec', '100000' // any unpark problem hangs test
 }
 
 task lockFreedomTest(type: Test, dependsOn: testClasses) {
@@ -48,18 +49,14 @@ task jdk16Test(type: Test, dependsOn: [testClasses, checkJdk16]) {
     exclude '**/exceptions/.*'
 }
 
-task schedulerTest(type: Test, dependsOn: testClasses) {
-    systemProperty 'kotlinx.coroutines.scheduler', ''
-    systemProperty 'kotlinx.coroutines.scheduler.keep.alive.sec', '100000' // any unpark problem hangs test
-}
-
 // Always run those tests
 task moreTest(dependsOn: [lockFreedomTest])
 
-build.dependsOn moreTest
-
 // Run these tests only during nightly stress test
-task extraTest(dependsOn: [jdk16Test, schedulerTest])
+task extraTest(dependsOn: [jdk16Test])
+
+
+build.dependsOn moreTest
 
 extraTest.onlyIf { project.properties['stressTest'] != null }
 

--- a/core/kotlinx-coroutines-core/src/CommonPool.kt
+++ b/core/kotlinx-coroutines-core/src/CommonPool.kt
@@ -106,7 +106,7 @@ object CommonPool : ExecutorCoroutineDispatcher() {
         pool ?: createPool().also { pool = it }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) =
-        try { (pool ?: getOrCreatePoolSync()).execute(timeSource.trackTask(block)) }
+        try { (pool ?: getOrCreatePoolSync()).execute(timeSource.wrapTask(block)) }
         catch (e: RejectedExecutionException) {
             timeSource.unTrackTask()
             DefaultExecutor.execute(block)

--- a/core/kotlinx-coroutines-core/src/CoroutineContext.kt
+++ b/core/kotlinx-coroutines-core/src/CoroutineContext.kt
@@ -20,8 +20,8 @@ internal const val COROUTINES_SCHEDULER_PROPERTY_NAME = "kotlinx.coroutines.sche
 
 internal val useCoroutinesScheduler = systemProp(COROUTINES_SCHEDULER_PROPERTY_NAME).let { value ->
     when (value) {
-        null -> false
-        "", "on" -> true
+        null, "", "on" -> true
+        "off" -> false
         else -> error("System property '$COROUTINES_SCHEDULER_PROPERTY_NAME' has unrecognized value '$value'")
     }
 }
@@ -39,7 +39,7 @@ public actual val DefaultDispatcher: CoroutineDispatcher
     get() = Dispatchers.Default
 
 internal actual fun createDefaultDispatcher(): CoroutineDispatcher =
-    if (useCoroutinesScheduler) BackgroundDispatcher else CommonPool
+    if (useCoroutinesScheduler) DefaultScheduler else CommonPool
 
 /**
  * The [CoroutineDispatcher] that is designed for offloading blocking IO tasks to a shared pool of threads.

--- a/core/kotlinx-coroutines-core/src/Dispatchers.kt
+++ b/core/kotlinx-coroutines-core/src/Dispatchers.kt
@@ -20,6 +20,10 @@ public const val IO_PARALLELISM_PROPERTY_NAME = "kotlinx.coroutines.io.paralleli
  * The number of threads used by this dispatcher is limited by the value of
  * "`kotlinx.coroutines.io.parallelism`" ([IO_PARALLELISM_PROPERTY_NAME]) system property.
  * It defaults to the limit of 64 threads or the number of cores (whichever is larger).
+ *
+ * This dispatcher shares threads with a [Default][Dispatchers.Default] dispatcher, so using
+ * `withContext(Dispatchers.IO) { ... }` does not lead to an actual switching to another thread &mdash;
+ * typically execution continues in the same thread.
  */
 public val Dispatchers.IO: CoroutineDispatcher
-    get() = BackgroundDispatcher.IO
+    get() = DefaultScheduler.IO

--- a/core/kotlinx-coroutines-core/src/Executors.kt
+++ b/core/kotlinx-coroutines-core/src/Executors.kt
@@ -95,7 +95,7 @@ public abstract class ExecutorCoroutineDispatcherBase : ExecutorCoroutineDispatc
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) =
-        try { executor.execute(timeSource.trackTask(block)) }
+        try { executor.execute(timeSource.wrapTask(block)) }
         catch (e: RejectedExecutionException) {
             timeSource.unTrackTask()
             DefaultExecutor.execute(block)

--- a/core/kotlinx-coroutines-core/src/TimeSource.kt
+++ b/core/kotlinx-coroutines-core/src/TimeSource.kt
@@ -9,7 +9,8 @@ import java.util.concurrent.locks.LockSupport
 internal interface TimeSource {
     fun currentTimeMillis(): Long
     fun nanoTime(): Long
-    fun trackTask(block: Runnable): Runnable
+    fun wrapTask(block: Runnable): Runnable
+    fun trackTask()
     fun unTrackTask()
     fun registerTimeLoopThread()
     fun unregisterTimeLoopThread()
@@ -20,7 +21,8 @@ internal interface TimeSource {
 internal object DefaultTimeSource : TimeSource {
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
     override fun nanoTime(): Long = System.nanoTime()
-    override fun trackTask(block: Runnable): Runnable = block
+    override fun wrapTask(block: Runnable): Runnable = block
+    override fun trackTask() {}
     override fun unTrackTask() {}
     override fun registerTimeLoopThread() {}
     override fun unregisterTimeLoopThread() {}

--- a/core/kotlinx-coroutines-core/src/scheduling/Tasks.kt
+++ b/core/kotlinx-coroutines-core/src/scheduling/Tasks.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.*
 
 // TODO most of these fields will be moved to 'object ExperimentalDispatcher'
 
-internal const val DEFAULT_SCHEDULER_NAME = "CoroutineScheduler"
+internal const val DEFAULT_SCHEDULER_NAME = "DefaultDispatcher"
 
 // 100us as default
 @JvmField

--- a/core/kotlinx-coroutines-core/src/scheduling/WorkQueue.kt
+++ b/core/kotlinx-coroutines-core/src/scheduling/WorkQueue.kt
@@ -144,6 +144,13 @@ internal class WorkQueue {
         }
     }
 
+    internal fun offloadAllWork(globalQueue: GlobalQueue) {
+        while (true) {
+            val task = pollExternal() ?: return
+            globalQueue.addLast(task)
+        }
+    }
+
     /**
      * [poll] for external (not owning this queue) workers
      */

--- a/core/kotlinx-coroutines-core/test/TestBase.kt
+++ b/core/kotlinx-coroutines-core/test/TestBase.kt
@@ -5,8 +5,8 @@
 package kotlinx.coroutines.experimental
 
 import kotlinx.coroutines.experimental.internal.*
-import org.junit.*
 import kotlinx.coroutines.experimental.scheduling.*
+import org.junit.*
 import java.util.concurrent.atomic.*
 
 private val VERBOSE = systemProp("test.verbose", false)
@@ -124,13 +124,15 @@ public actual open class TestBase actual constructor() {
 
     fun initPoolsBeforeTest() {
         CommonPool.usePrivatePool()
-        BackgroundDispatcher.usePrivateScheduler()
+        DefaultScheduler.usePrivateScheduler()
     }
 
     fun shutdownPoolsAfterTest() {
         CommonPool.shutdown(SHUTDOWN_TIMEOUT)
-        BackgroundDispatcher.shutdown(SHUTDOWN_TIMEOUT)
+        DefaultScheduler.shutdown(SHUTDOWN_TIMEOUT)
         DefaultExecutor.shutdown(SHUTDOWN_TIMEOUT)
+        CommonPool.restore()
+        DefaultScheduler.restore()
     }
 
     @Suppress("ACTUAL_WITHOUT_EXPECT", "ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")

--- a/core/kotlinx-coroutines-core/test/VirtualTimeSource.kt
+++ b/core/kotlinx-coroutines-core/test/VirtualTimeSource.kt
@@ -58,13 +58,17 @@ internal class VirtualTimeSource(
     override fun currentTimeMillis(): Long = TimeUnit.NANOSECONDS.toMillis(time)
     override fun nanoTime(): Long = time
 
-    @Synchronized
-    override fun trackTask(block: Runnable): Runnable {
-        trackedTasks++
+    override fun wrapTask(block: Runnable): Runnable {
+        trackTask()
         return Runnable {
             try { block.run() }
             finally { unTrackTask() }
         }
+    }
+
+    @Synchronized
+    override fun trackTask() {
+        trackedTasks++
     }
 
     @Synchronized

--- a/core/kotlinx-coroutines-core/test/channels/ChannelsConsumeTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/ChannelsConsumeTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.*
 /**
  * Tests that various operators on channels properly consume (close) their source channels.
  */
-class ChannelsConsumeTest {
+class ChannelsConsumeTest : TestBase() {
     private val sourceList = (1..10).toList()
 
     // test source with numbers 1..10

--- a/core/kotlinx-coroutines-core/test/channels/SimpleSendReceiveJvmTest.kt
+++ b/core/kotlinx-coroutines-core/test/channels/SimpleSendReceiveJvmTest.kt
@@ -16,7 +16,7 @@ class SimpleSendReceiveJvmTest(
     private val kind: TestChannelKind,
     val n: Int,
     val concurrent: Boolean
-) {
+) : TestBase() {
     companion object {
         @Parameterized.Parameters(name = "{0}, n={1}, concurrent={2}")
         @JvmStatic

--- a/core/kotlinx-coroutines-core/test/guide/example-context-01.kt
+++ b/core/kotlinx-coroutines-core/test/guide/example-context-01.kt
@@ -15,7 +15,7 @@ fun main(args: Array<String>) = runBlocking<Unit> {
     launch(Dispatchers.Unconfined) { // not confined -- will work with main thread
         println("Unconfined            : I'm working in thread ${Thread.currentThread().name}")
     }
-    launch(Dispatchers.Default) { // will get dispatched to ForkJoinPool.commonPool (or equivalent)
+    launch(Dispatchers.Default) { // will get dispatched to DefaultDispatcher 
         println("Default               : I'm working in thread ${Thread.currentThread().name}")
     }
     launch(newSingleThreadContext("MyOwnThread")) { // will get its own new thread

--- a/core/kotlinx-coroutines-core/test/guide/test/DispatcherGuideTest.kt
+++ b/core/kotlinx-coroutines-core/test/guide/test/DispatcherGuideTest.kt
@@ -9,7 +9,7 @@ class DispatchersGuideTest {
     fun testKotlinxCoroutinesExperimentalGuideContext01() {
         test("KotlinxCoroutinesExperimentalGuideContext01") { kotlinx.coroutines.experimental.guide.context01.main(emptyArray()) }.verifyLinesStartUnordered(
             "Unconfined            : I'm working in thread main",
-            "Default               : I'm working in thread CommonPool-worker-1",
+            "Default               : I'm working in thread DefaultDispatcher-worker-1",
             "newSingleThreadContext: I'm working in thread MyOwnThread",
             "main runBlocking      : I'm working in thread main"
         )
@@ -84,7 +84,7 @@ class DispatchersGuideTest {
     @Test
     fun testKotlinxCoroutinesExperimentalGuideContext09() {
         test("KotlinxCoroutinesExperimentalGuideContext09") { kotlinx.coroutines.experimental.guide.context09.main(emptyArray()) }.verifyLinesFlexibleThread(
-            "I'm working in thread CommonPool-worker-1 @test#2"
+            "I'm working in thread DefaultDispatcher-worker-1 @test#2"
         )
     }
 
@@ -102,8 +102,8 @@ class DispatchersGuideTest {
     fun testKotlinxCoroutinesExperimentalGuideContext11() {
         test("KotlinxCoroutinesExperimentalGuideContext11") { kotlinx.coroutines.experimental.guide.context11.main(emptyArray()) }.verifyLinesFlexibleThread(
             "Pre-main, current thread: Thread[main @coroutine#1,5,main], thread local value: 'main'",
-            "Launch start, current thread: Thread[CommonPool-worker-1 @coroutine#2,5,main], thread local value: 'launch'",
-            "After yield, current thread: Thread[CommonPool-worker-2 @coroutine#2,5,main], thread local value: 'launch'",
+            "Launch start, current thread: Thread[DefaultDispatcher-worker-1 @coroutine#2,5,main], thread local value: 'launch'",
+            "After yield, current thread: Thread[DefaultDispatcher-worker-2 @coroutine#2,5,main], thread local value: 'launch'",
             "Post-main, current thread: Thread[main @coroutine#1,5,main], thread local value: 'main'"
         )
     }

--- a/core/kotlinx-coroutines-core/test/guide/test/ExceptionsGuideTest.kt
+++ b/core/kotlinx-coroutines-core/test/guide/test/ExceptionsGuideTest.kt
@@ -9,7 +9,7 @@ class ExceptionsGuideTest {
     fun testKotlinxCoroutinesExperimentalGuideExceptions01() {
         test("KotlinxCoroutinesExperimentalGuideExceptions01") { kotlinx.coroutines.experimental.guide.exceptions01.main(emptyArray()) }.verifyExceptions(
             "Throwing exception from launch",
-            "Exception in thread \"ForkJoinPool.commonPool-worker-2 @coroutine#2\" java.lang.IndexOutOfBoundsException",
+            "Exception in thread \"DefaultDispatcher-worker-2 @coroutine#2\" java.lang.IndexOutOfBoundsException",
             "Joined failed job",
             "Throwing exception from async",
             "Caught ArithmeticException"

--- a/docs/coroutine-context-and-dispatchers.md
+++ b/docs/coroutine-context-and-dispatchers.md
@@ -72,7 +72,7 @@ fun main(args: Array<String>) = runBlocking<Unit> {
     launch(Dispatchers.Unconfined) { // not confined -- will work with main thread
         println("Unconfined            : I'm working in thread ${Thread.currentThread().name}")
     }
-    launch(Dispatchers.Default) { // will get dispatched to ForkJoinPool.commonPool (or equivalent)
+    launch(Dispatchers.Default) { // will get dispatched to DefaultDispatcher 
         println("Default               : I'm working in thread ${Thread.currentThread().name}")
     }
     launch(newSingleThreadContext("MyOwnThread")) { // will get its own new thread
@@ -89,7 +89,7 @@ It produces the following output (maybe in different order):
 
 ```text
 Unconfined            : I'm working in thread main
-Default               : I'm working in thread CommonPool-worker-1
+Default               : I'm working in thread DefaultDispatcher-worker-1
 newSingleThreadContext: I'm working in thread MyOwnThread
 main runBlocking      : I'm working in thread main
 ```
@@ -475,7 +475,7 @@ fun main(args: Array<String>) = runBlocking<Unit> {
 The output of this code  with `-Dkotlinx.coroutines.debug` JVM option is: 
 
 ```text
-I'm working in thread CommonPool-worker-1 @test#2
+I'm working in thread DefaultDispatcher-worker-1 @test#2
 ```
 
 <!--- TEST FLEXIBLE_THREAD -->
@@ -632,8 +632,8 @@ Thus, output (with [debug](#debugging-coroutines-and-threads)) is:
 
 ```text
 Pre-main, current thread: Thread[main @coroutine#1,5,main], thread local value: 'main'
-Launch start, current thread: Thread[CommonPool-worker-1 @coroutine#2,5,main], thread local value: 'launch'
-After yield, current thread: Thread[CommonPool-worker-2 @coroutine#2,5,main], thread local value: 'launch'
+Launch start, current thread: Thread[DefaultDispatcher-worker-1 @coroutine#2,5,main], thread local value: 'launch'
+After yield, current thread: Thread[DefaultDispatcher-worker-2 @coroutine#2,5,main], thread local value: 'launch'
 Post-main, current thread: Thread[main @coroutine#1,5,main], thread local value: 'main'
 ```
 

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -81,7 +81,7 @@ The output of this code is (with [debug](https://github.com/Kotlin/kotlinx.corou
 
 ```text
 Throwing exception from launch
-Exception in thread "ForkJoinPool.commonPool-worker-2 @coroutine#2" java.lang.IndexOutOfBoundsException
+Exception in thread "DefaultDispatcher-worker-2 @coroutine#2" java.lang.IndexOutOfBoundsException
 Joined failed job
 Throwing exception from async
 Caught ArithmeticException

--- a/reactive/kotlinx-coroutines-rx2/test/guide/test/ReactiveTestBase.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/test/ReactiveTestBase.kt
@@ -43,5 +43,5 @@ private class WrapperWorker(private val worker: Scheduler.Worker) : Scheduler.Wo
     override fun isDisposed(): Boolean = worker.isDisposed
     override fun dispose() = worker.dispose()
     override fun schedule(run: Runnable, delay: Long, unit: TimeUnit): Disposable =
-        worker.schedule(trackTask(run), delay, unit)
+        worker.schedule(wrapTask(run), delay, unit)
 }


### PR DESCRIPTION
* Documentation and guide are updated correspondingly
* "DefaultDispatcher" is used as a public name of the default impl
* Implementation is integrated with virtual time-source
* Shutdown sequence is reimplemented in a safe way for tests,
  makes "close" safe to use on custom instances.
* "close" on DefaultDispatcher throws exception just in case
* -Dkotlinx.coroutines.scheduler=off can be used to switch back to
  CommonPool

Fixes #198