### PR TITLE
Never unwrap 3rd party CancellationException

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
+++ b/common/kotlinx-coroutines-core-common/src/AbstractContinuation.kt
@@ -105,7 +105,7 @@ internal abstract class AbstractContinuation<in T>(
     /**
      * It is used when parent is cancelled to get the cancellation cause for this continuation.
      */
-    open fun getParentCancellationCause(parent: Job): Throwable =
+    open fun getContinuationCancellationCause(parent: Job): Throwable =
         parent.getCancellationException()
 
     private fun trySuspend(): Boolean {

--- a/common/kotlinx-coroutines-core-common/src/Job.kt
+++ b/common/kotlinx-coroutines-core-common/src/Job.kt
@@ -425,13 +425,30 @@ public inline fun DisposableHandle(crossinline block: () -> Unit) =
 internal interface ChildJob : Job {
     /**
      * Parent is cancelling its child by invoking this method.
-     * Child finds the cancellation cause using [getCancellationException] of the [parentJob].
+     * Child finds the cancellation cause using [ParentJob.getChildJobCancellationCause].
      * This method does nothing is the child is already being cancelled.
      *
      * @suppress **This is unstable API and it is subject to change.**
      */
     @InternalCoroutinesApi
-    public fun parentCancelled(parentJob: Job)
+    public fun parentCancelled(parentJob: ParentJob)
+}
+
+/**
+ * A reference that child receives from its parent when it is being cancelled by the parent.
+ *
+ * @suppress **This is unstable API and it is subject to change.**
+ */
+@InternalCoroutinesApi
+internal interface ParentJob : Job {
+    /**
+     * Child job is using this method to learn its cancellation cause when the parent cancels it with [ChildJob.parentCancelled].
+     * This method is invoked only if the child was not already being cancelled.
+     *
+     * @suppress **This is unstable API and it is subject to change.**
+     */
+    @InternalCoroutinesApi
+    public fun getChildJobCancellationCause(): Throwable
 }
 
 /**


### PR DESCRIPTION
* Exceptions are never unwrapped when building cancellation cause
* This leads to more consistent behavior with respect to 3rd-party
  exception that may be flowing through coroutines -- no 3rd-party
  stack-trace will even get accidentally lost.
* This also leads to consistent behavior with respect to CancellationException:
  they are never handled (even if they have some real exception as cause).
* The logic of how to cancel a child on failure (depending on the
  "handlesException" flag in the parent job) is now encapsulated into
  the parent itself, which leads to cleaner implementation in JobSupport.
* Job.getCancellationException is not used for child cancellation anymore
  (it is used only and exclusively to cancel continuations)
* ParentJob interface with ParentJob.getChildJobCancellationCause is
  introduced for parent job -> child job cancellation path.