### PR TITLE
Fixed rescheduling, synchronization & task disposal in EventLoop

### DIFF
--- a/core/kotlinx-coroutines-core/src/internal/ThreadSafeHeap.kt
+++ b/core/kotlinx-coroutines-core/src/internal/ThreadSafeHeap.kt
@@ -48,7 +48,7 @@ public class ThreadSafeHeap<T> : SynchronizedObject() where T: ThreadSafeHeapNod
     // @Synchronized // NOTE! NOTE! NOTE! inline fun cannot be @Synchronized
     public inline fun removeFirstIf(predicate: (T) -> Boolean): T? = synchronized(this) {
         val first = firstImpl() ?: return null
-        return if (predicate(first)) {
+        if (predicate(first)) {
             removeAtImpl(0)
         } else {
             null
@@ -58,14 +58,15 @@ public class ThreadSafeHeap<T> : SynchronizedObject() where T: ThreadSafeHeapNod
     @Synchronized
     public fun addLast(node: T) = addImpl(node)
 
-    @Synchronized
-    public fun addLastIf(node: T, cond: () -> Boolean): Boolean =
+    // @Synchronized // NOTE! NOTE! NOTE! inline fun cannot be @Synchronized
+    public inline fun addLastIf(node: T, cond: () -> Boolean): Boolean = synchronized(this) {
         if (cond()) {
             addImpl(node)
             true
         } else {
             false
         }
+    }
 
     @Synchronized
     public fun remove(node: T): Boolean {

--- a/core/kotlinx-coroutines-core/src/test_/TestCoroutineContext.kt
+++ b/core/kotlinx-coroutines-core/src/test_/TestCoroutineContext.kt
@@ -239,6 +239,7 @@ private class TimedRunnable(
     private val count: Long = 0,
     @JvmField internal val time: Long = 0
 ) : Comparable<TimedRunnable>, Runnable by run, ThreadSafeHeapNode {
+    override var heap: ThreadSafeHeap<*>? = null
     override var index: Int = 0
 
     override fun run() = run.run()

--- a/core/kotlinx-coroutines-core/test/internal/ThreadSafeHeapTest.kt
+++ b/core/kotlinx-coroutines-core/test/internal/ThreadSafeHeapTest.kt
@@ -10,6 +10,7 @@ import java.util.*
 
 class ThreadSafeHeapTest : TestBase() {
     class Node(val value: Int) : ThreadSafeHeapNode, Comparable<Node> {
+        override var heap: ThreadSafeHeap<*>? = null
         override var index = -1
         override fun compareTo(other: Node): Int = value.compareTo(other.value)
         override fun equals(other: Any?): Boolean = other is Node && other.value == value

--- a/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerCloseStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/CoroutineSchedulerCloseStressTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.experimental.scheduling
+
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.experimental.*
+import org.junit.Test
+import java.util.*
+import kotlin.test.*
+
+class CoroutineSchedulerCloseStressTest : TestBase() {
+    private val N_REPEAT = 2 * stressTestMultiplier
+    private val MAX_LEVEL = 5
+    private val N_COROS = (1 shl (MAX_LEVEL + 1)) - 1
+    private val N_THREADS = 4
+    private val rnd = Random()
+
+    private lateinit var dispatcher: ExecutorCoroutineDispatcher
+    private var closeIndex = -1
+
+    private val started = atomic(0)
+    private val finished = atomic(0)
+
+    @Test
+    fun testNormalClose() {
+        try {
+            launchCoroutines()
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    @Test
+    fun testRacingClose() {
+        repeat(N_REPEAT) {
+            closeIndex = rnd.nextInt(N_COROS)
+            launchCoroutines()
+        }
+    }
+
+    private fun launchCoroutines() = runBlocking {
+        dispatcher = ExperimentalCoroutineDispatcher(N_THREADS)
+        started.value = 0
+        finished.value = 0
+        withContext(dispatcher) {
+            launchChild(0, 0)
+        }
+        assertEquals(N_COROS, started.value)
+        assertEquals(N_COROS, finished.value)
+    }
+
+    private fun CoroutineScope.launchChild(index: Int, level: Int): Job = launch(start = CoroutineStart.ATOMIC) {
+        started.incrementAndGet()
+        try {
+            if (index == closeIndex) dispatcher.close()
+            if (level < MAX_LEVEL) {
+                launchChild(2 * index + 1, level + 1)
+                launchChild(2 * index + 2, level + 1)
+            } else {
+                delay(1000)
+            }
+        } finally {
+            finished.incrementAndGet()
+        }
+    }
+}


### PR DESCRIPTION
* **CRITICAL**: Fixed synchronization of `ThreadSafeHeap.removeFirstIf`
* Reworked code to make sure that memory for disposed task never leaks
  without violating ThreadSafeHeap encapsulation