### PR TITLE
Added @Keep annotations for CoroutineExceptionHandler and MainDispatсherFactory which are loaded via ServiceLoader.load() on Android.

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/CoroutineExceptionHandler.kt
+++ b/common/kotlinx-coroutines-core-common/src/CoroutineExceptionHandler.kt
@@ -82,6 +82,7 @@ public inline fun CoroutineExceptionHandler(crossinline handler: (CoroutineConte
  *     * Otherwise, all instances of [CoroutineExceptionHandler] found via [ServiceLoader]
  *     * and current thread's [Thread.uncaughtExceptionHandler] are invoked.
  **/
+@Keep
 public interface CoroutineExceptionHandler : CoroutineContext.Element {
     /**
      * Key for [CoroutineExceptionHandler] instance in the coroutine context.

--- a/common/kotlinx-coroutines-core-common/src/internal/MainDispatcherFactory.kt
+++ b/common/kotlinx-coroutines-core-common/src/internal/MainDispatcherFactory.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.experimental.internal
 
 import kotlinx.coroutines.experimental.*
 
+@Keep
 @InternalCoroutinesApi // Emulating DI for Kotlin object's
 public interface MainDispatcherFactory {
     val loadPriority: Int // higher priority wins


### PR DESCRIPTION
Android app crashes in runtime when obfuscated with default Proguard settings. This PR adds `@Keep` annotation for two classes which are located via `ServiceLoader.load()`.