### PR TITLE
Expose silent internal clock overflows in TestCoroutineContext.

### DIFF
--- a/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
+++ b/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
@@ -5,8 +5,10 @@
 package kotlinx.coroutines.experimental.test
 
 import kotlinx.coroutines.experimental.*
+import kotlinx.coroutines.experimental.CancellationException
 import org.junit.*
 import org.junit.Assert.*
+import java.util.concurrent.*
 import kotlin.coroutines.experimental.*
 
 class TestCoroutineContextTest {
@@ -382,6 +384,21 @@ class TestCoroutineContextTest {
 
         advanceTimeBy(500)
         assertTrue(job.cancel())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testAdvanceTimeByOverflow() = withTestContext {
+        advanceTimeBy(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
+        assertEquals(Long.MAX_VALUE, now(TimeUnit.NANOSECONDS))
+        advanceTimeBy(1, TimeUnit.NANOSECONDS)
+    }
+
+    @Test(expected = ArithmeticException::class)
+    fun testRunBlockingWithMaxValueClock() = withTestContext {
+        advanceTimeTo(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
+        runBlocking(this) {
+            launch { delay(1) }.join()
+        }
     }
 }
 


### PR DESCRIPTION
When writing tests I find that its better to be strict and explicit. This particular change would have exposed that I called `advanceTimeBy` instead of `advanceTimeTo` when using `Long.MAX_VALUE` as a "much later" value.