### PR TITLE
Make ReceiveChannel<E>.iterator() extension function

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -439,6 +439,10 @@ public abstract interface class kotlinx/coroutines/channels/ActorScope : kotlinx
 	public abstract fun getChannel ()Lkotlinx/coroutines/channels/Channel;
 }
 
+public final class kotlinx/coroutines/channels/ActorScope$DefaultImpls {
+	public static synthetic fun iterator (Lkotlinx/coroutines/channels/ActorScope;)Lkotlinx/coroutines/channels/ChannelIterator;
+}
+
 public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : kotlinx/coroutines/channels/SendChannel {
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract fun openSubscription ()Lkotlinx/coroutines/channels/ReceiveChannel;
@@ -464,6 +468,10 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 	public static final field Factory Lkotlinx/coroutines/channels/Channel$Factory;
 	public static final field RENDEZVOUS I
 	public static final field UNLIMITED I
+}
+
+public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
+	public static synthetic fun iterator (Lkotlinx/coroutines/channels/Channel;)Lkotlinx/coroutines/channels/ChannelIterator;
 }
 
 public final class kotlinx/coroutines/channels/Channel$Factory {
@@ -647,6 +655,7 @@ public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
 	public abstract fun getOnReceiveOrNull ()Lkotlinx/coroutines/selects/SelectClause1;
 	public abstract fun isClosedForReceive ()Z
 	public abstract fun isEmpty ()Z
+	public abstract synthetic fun iterator ()Lkotlinx/coroutines/channels/ChannelIterator;
 	public abstract fun poll ()Ljava/lang/Object;
 	public abstract fun receive (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun receiveOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -654,6 +663,7 @@ public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
 
 public final class kotlinx/coroutines/channels/ReceiveChannel$DefaultImpls {
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun iterator (Lkotlinx/coroutines/channels/ReceiveChannel;)Lkotlinx/coroutines/channels/ChannelIterator;
 }
 
 public abstract interface class kotlinx/coroutines/channels/SendChannel {

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -477,6 +477,10 @@ public abstract interface class kotlinx/coroutines/channels/ChannelIterator {
 	public abstract fun next (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class kotlinx/coroutines/channels/ChannelIteratorKt {
+	public static final fun iterator (Lkotlinx/coroutines/channels/ReceiveChannel;)Lkotlinx/coroutines/channels/ChannelIterator;
+}
+
 public final class kotlinx/coroutines/channels/ChannelKt {
 	public static final fun Channel (I)Lkotlinx/coroutines/channels/Channel;
 	public static synthetic fun Channel$default (IILjava/lang/Object;)Lkotlinx/coroutines/channels/Channel;
@@ -643,7 +647,6 @@ public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
 	public abstract fun getOnReceiveOrNull ()Lkotlinx/coroutines/selects/SelectClause1;
 	public abstract fun isClosedForReceive ()Z
 	public abstract fun isEmpty ()Z
-	public abstract fun iterator ()Lkotlinx/coroutines/channels/ChannelIterator;
 	public abstract fun poll ()Ljava/lang/Object;
 	public abstract fun receive (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun receiveOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
@@ -14,7 +14,6 @@ import kotlin.jvm.*
 
 /**
  * Abstract send channel. It is a base class for all send channel implementations.
- *
  */
 internal abstract class AbstractSendChannel<E> : SendChannel<E> {
     /** @suppress **This is unstable API and it is subject to change.** */

--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -234,9 +234,7 @@ public interface ReceiveChannel<out E> {
      * Iteration completes normally when the channel is [isClosedForReceive] without cause and
      * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
      */
-    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     @Deprecated(message = "Use extension function ReceiveChannel<E>.iterator() instead", level = DeprecationLevel.HIDDEN)
-    @kotlin.internal.LowPriorityInOverloadResolution
     public operator fun iterator(): ChannelIterator<E> = iterator()
 
     /**
@@ -271,8 +269,6 @@ public interface ReceiveChannel<out E> {
     @ExperimentalCoroutinesApi
     public fun cancel(cause: Throwable? = null): Boolean
 }
-
-
 
 /**
  * Channel is a non-blocking primitive for communication between sender using [SendChannel] and receiver using [ReceiveChannel].

--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -230,13 +230,6 @@ public interface ReceiveChannel<out E> {
     public fun poll(): E?
 
     /**
-     * Returns new iterator to receive elements from this channels using `for` loop.
-     * Iteration completes normally when the channel is [isClosedForReceive] without cause and
-     * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
-     */
-    public operator fun iterator(): ChannelIterator<E>
-
-    /**
      * Cancels reception of remaining elements from this channel. This function closes the channel
      * and removes all buffered sent elements from it.
      * This function returns `true` if the channel was not closed previously, or `false` otherwise.
@@ -269,54 +262,7 @@ public interface ReceiveChannel<out E> {
     public fun cancel(cause: Throwable? = null): Boolean
 }
 
-/**
- * Iterator for [ReceiveChannel]. Instances of this interface are *not thread-safe* and shall not be used
- * from concurrent coroutines.
- */
-public interface ChannelIterator<out E> {
-    /**
-     * Returns `true` if the channel has more elements suspending the caller while this channel
-     * [isEmpty][ReceiveChannel.isEmpty] or returns `false` if the channel
-     * [isClosedForReceive][ReceiveChannel.isClosedForReceive] without cause.
-     * It throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
-     *
-     * This function retrieves and removes the element from this channel for the subsequent invocation
-     * of [next].
-     *
-     * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
-     * function is suspended, this function immediately resumes with [CancellationException].
-     *
-     * *Cancellation of suspended receive is atomic* -- when this function
-     * throws [CancellationException] it means that the element was not retrieved from this channel.
-     * As a side-effect of atomic cancellation, a thread-bound coroutine (to some UI thread, for example) may
-     * continue to execute even after it was cancelled from the same thread in the case when this receive operation
-     * was already resumed and the continuation was posted for execution to the thread's queue.
-     *
-     * Note, that this function does not check for cancellation when it is not suspended.
-     * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
-     */
-    public suspend operator fun hasNext(): Boolean
 
-    /**
-     * Retrieves and removes the element from this channel suspending the caller while this channel
-     * [isEmpty][ReceiveChannel.isEmpty] or throws [ClosedReceiveChannelException] if the channel
-     * [isClosedForReceive][ReceiveChannel.isClosedForReceive] without cause.
-     * It throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
-     *
-     * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
-     * function is suspended, this function immediately resumes with [CancellationException].
-     *
-     * *Cancellation of suspended receive is atomic* -- when this function
-     * throws [CancellationException] it means that the element was not retrieved from this channel.
-     * As a side-effect of atomic cancellation, a thread-bound coroutine (to some UI thread, for example) may
-     * continue to execute even after it was cancelled from the same thread in the case when this receive operation
-     * was already resumed and the continuation was posted for execution to the thread's queue.
-     *
-     * Note, that this function does not check for cancellation when it is not suspended.
-     * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
-     */
-    public suspend operator fun next(): E
-}
 
 /**
  * Channel is a non-blocking primitive for communication between sender using [SendChannel] and receiver using [ReceiveChannel].

--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -230,6 +230,16 @@ public interface ReceiveChannel<out E> {
     public fun poll(): E?
 
     /**
+     * Returns new iterator to receive elements from this channels using `for` loop.
+     * Iteration completes normally when the channel is [isClosedForReceive] without cause and
+     * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
+     */
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    @Deprecated(message = "Use extension function ReceiveChannel<E>.iterator() instead", level = DeprecationLevel.HIDDEN)
+    @kotlin.internal.LowPriorityInOverloadResolution
+    public operator fun iterator(): ChannelIterator<E> = iterator()
+
+    /**
      * Cancels reception of remaining elements from this channel. This function closes the channel
      * and removes all buffered sent elements from it.
      * This function returns `true` if the channel was not closed previously, or `false` otherwise.

--- a/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
@@ -1,11 +1,8 @@
 package kotlinx.coroutines.channels
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.internal.Symbol
-import kotlinx.coroutines.yield
-import kotlin.jvm.JvmField
+import kotlinx.coroutines.*
+import kotlinx.coroutines.internal.*
+import kotlin.jvm.*
 
 /**
  * Iterator for [ReceiveChannel]. Instances of this interface are *not thread-safe* and shall not be used
@@ -33,7 +30,7 @@ public interface ChannelIterator<out E> {
      * Note, that this function does not check for cancellation when it is not suspended.
      * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
      */
-    suspend operator fun hasNext(): Boolean
+    public suspend operator fun hasNext(): Boolean
 
     /**
      * Retrieves and removes the element from this channel suspending the caller while this channel
@@ -53,69 +50,64 @@ public interface ChannelIterator<out E> {
      * Note, that this function does not check for cancellation when it is not suspended.
      * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
      */
-    suspend operator fun next(): E
+    public suspend operator fun next(): E
 }
 
 /**
  * Returns new iterator to receive elements from this channels using `for` loop.
- * Iteration completes normally when the channel is [isClosedForReceive] without cause and
+ * Iteration completes normally when the channel is [ReceiveChannel.isClosedForReceive] without cause and
  * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
  */
-public operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
-    val c = this
-    return object: ChannelIterator<E> {
-        var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") // NOT shadowed -- member is HIDDEN
+public operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> = object : ChannelIterator<E> {
+    var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
 
-        override suspend fun hasNext(): Boolean {
-            if (result != NO_RESULT) return checkNotClosed(result)
-            // Try to receive an element. Store the result even if
-            // receiving fails in order to process further [hasNext]
-            // and [next] invocations properly.
-            try {
-                // TODO use `receiveOrClosed` when it is added
-                result = c.receive()
-                return true
-            } catch (closedException: ClosedReceiveChannelException) {
-                // Channel is _closed_, cannot iterate further.
-                result = ClosedResult(null)
-                return false
-            } catch (closingCause: Throwable) {
-                // Channel is _failed_, throw the cause exception.
-                result = ClosedResult(closingCause)
-                throw closingCause
-            }
-        }
-
-        private fun checkNotClosed(result: Any?): Boolean {
-            if (result is ClosedResult) {
-                if (result.cause != null) throw result.cause
-                return false
-            }
-            return true
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        override suspend fun next(): E {
-            // Read the already received result or NO_RESULT
-            // if [hasNext] has not been invoked yet.
-            val result = this.result
-            when (result) {
-                 // Rare case -- [hasNext] has not been invoked, invoke [receive] directly.
-                NO_RESULT -> return c.receive()
-                // Channel is closed, throw the cause exception.
-                is ClosedResult -> throw result.receiveException
-                // An element has been received successfully.
-                else -> {
-                    // Reset the [result] field and return the element.
-                    this.result = NO_RESULT
-                    return result as E
-                }
-            }
+    override suspend fun hasNext(): Boolean {
+        if (result != NO_RESULT) return checkNotClosed(result)
+        // Try to receive an element. Store the result even if
+        // receiving fails in order to process further [hasNext]
+        // and [next] invocations properly.
+        return try {
+            // TODO use `receiveOrClosed` when it is added
+            result = receive()
+            true
+        } catch (closedException: ClosedReceiveChannelException) {
+            // Channel is _closed_, cannot iterate further.
+            result = ClosedResult(null)
+            false
+        } catch (closingCause: Throwable) {
+            // Channel is _failed_, throw the cause exception.
+            result = ClosedResult(closingCause)
+            throw closingCause
         }
     }
+
+    private fun checkNotClosed(result: Any?): Boolean =
+        if (result is ClosedResult) {
+            if (result.cause != null) throw result.cause
+            false
+        } else
+            true
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun next(): E =
+        // Read the already received result or NO_RESULT if [hasNext] has not been invoked yet.
+        when (val result = this.result) {
+            // Rare case -- [hasNext] has not been invoked, invoke [receive] directly.
+            NO_RESULT -> receive()
+            // Channel is closed, throw the cause exception.
+            is ClosedResult -> throw result.receiveException
+            // An element has been received successfully.
+            else -> {
+                // Reset the [result] field and return the element.
+                this.result = NO_RESULT
+                result as E
+            }
+        }
 }
 
 private val NO_RESULT = Symbol("NO_RESULT")
+
 private class ClosedResult(@JvmField val cause: Throwable?) {
     val receiveException: Throwable get() = cause ?: ClosedReceiveChannelException(DEFAULT_CLOSE_MESSAGE)
 }

--- a/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
@@ -5,12 +5,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.internal.Symbol
 import kotlinx.coroutines.yield
+import kotlin.jvm.JvmField
 
 /**
  * Iterator for [ReceiveChannel]. Instances of this interface are *not thread-safe* and shall not be used
  * from concurrent coroutines.
  */
-interface ChannelIterator<out E> {
+public interface ChannelIterator<out E> {
     /**
      * Returns `true` if the channel has more elements suspending the caller while this channel
      * [isEmpty][ReceiveChannel.isEmpty] or returns `false` if the channel
@@ -60,7 +61,7 @@ interface ChannelIterator<out E> {
  * Iteration completes normally when the channel is [isClosedForReceive] without cause and
  * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
  */
-operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
+public operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
     val c = this
     return object: ChannelIterator<E> {
         var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
@@ -71,6 +72,7 @@ operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
             // receiving fails in order to process further [hasNext]
             // and [next] invocations properly.
             try {
+                // TODO use `receiveOrClosed` when it is added
                 result = c.receive()
                 return true
             } catch (closedException: ClosedReceiveChannelException) {
@@ -114,6 +116,6 @@ operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
 }
 
 private val NO_RESULT = Symbol("NO_RESULT")
-private class ClosedResult(val cause: Throwable?) {
+private class ClosedResult(@JvmField val cause: Throwable?) {
     val receiveException: Throwable get() = cause ?: ClosedReceiveChannelException(DEFAULT_CLOSE_MESSAGE)
 }

--- a/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
@@ -60,7 +60,7 @@ public interface ChannelIterator<out E> {
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER") // NOT shadowed -- member is HIDDEN
 public operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> = object : ChannelIterator<E> {
-    var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
+    private var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
 
     override suspend fun hasNext(): Boolean {
         if (result != NO_RESULT) return checkNotClosed(result)
@@ -86,8 +86,9 @@ public operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> = objec
         if (result is ClosedResult) {
             if (result.cause != null) throw result.cause
             false
-        } else
+        } else {
             true
+        }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun next(): E =

--- a/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/ChannelIterator.kt
@@ -1,0 +1,119 @@
+package kotlinx.coroutines.channels
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.internal.Symbol
+import kotlinx.coroutines.yield
+
+/**
+ * Iterator for [ReceiveChannel]. Instances of this interface are *not thread-safe* and shall not be used
+ * from concurrent coroutines.
+ */
+interface ChannelIterator<out E> {
+    /**
+     * Returns `true` if the channel has more elements suspending the caller while this channel
+     * [isEmpty][ReceiveChannel.isEmpty] or returns `false` if the channel
+     * [isClosedForReceive][ReceiveChannel.isClosedForReceive] without cause.
+     * It throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
+     *
+     * This function retrieves and removes the element from this channel for the subsequent invocation
+     * of [next].
+     *
+     * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
+     * function is suspended, this function immediately resumes with [CancellationException].
+     *
+     * *Cancellation of suspended receive is atomic* -- when this function
+     * throws [CancellationException] it means that the element was not retrieved from this channel.
+     * As a side-effect of atomic cancellation, a thread-bound coroutine (to some UI thread, for example) may
+     * continue to execute even after it was cancelled from the same thread in the case when this receive operation
+     * was already resumed and the continuation was posted for execution to the thread's queue.
+     *
+     * Note, that this function does not check for cancellation when it is not suspended.
+     * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
+     */
+    suspend operator fun hasNext(): Boolean
+
+    /**
+     * Retrieves and removes the element from this channel suspending the caller while this channel
+     * [isEmpty][ReceiveChannel.isEmpty] or throws [ClosedReceiveChannelException] if the channel
+     * [isClosedForReceive][ReceiveChannel.isClosedForReceive] without cause.
+     * It throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
+     *
+     * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
+     * function is suspended, this function immediately resumes with [CancellationException].
+     *
+     * *Cancellation of suspended receive is atomic* -- when this function
+     * throws [CancellationException] it means that the element was not retrieved from this channel.
+     * As a side-effect of atomic cancellation, a thread-bound coroutine (to some UI thread, for example) may
+     * continue to execute even after it was cancelled from the same thread in the case when this receive operation
+     * was already resumed and the continuation was posted for execution to the thread's queue.
+     *
+     * Note, that this function does not check for cancellation when it is not suspended.
+     * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
+     */
+    suspend operator fun next(): E
+}
+
+/**
+ * Returns new iterator to receive elements from this channels using `for` loop.
+ * Iteration completes normally when the channel is [isClosedForReceive] without cause and
+ * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
+ */
+operator fun <E> ReceiveChannel<E>.iterator(): ChannelIterator<E> {
+    val c = this
+    return object: ChannelIterator<E> {
+        var result: Any? = NO_RESULT // NO_RESULT | E (next element) | ClosedResult
+
+        override suspend fun hasNext(): Boolean {
+            if (result != NO_RESULT) return checkNotClosed(result)
+            // Try to receive an element. Store the result even if
+            // receiving fails in order to process further [hasNext]
+            // and [next] invocations properly.
+            try {
+                result = c.receive()
+                return true
+            } catch (closedException: ClosedReceiveChannelException) {
+                // Channel is _closed_, cannot iterate further.
+                result = ClosedResult(null)
+                return false
+            } catch (closingCause: Throwable) {
+                // Channel is _failed_, throw the cause exception.
+                result = ClosedResult(closingCause)
+                throw closingCause
+            }
+        }
+
+        private fun checkNotClosed(result: Any?): Boolean {
+            if (result is ClosedResult) {
+                if (result.cause != null) throw result.cause
+                return false
+            }
+            return true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun next(): E {
+            // Read the already received result or NO_RESULT
+            // if [hasNext] has not been invoked yet.
+            val result = this.result
+            when (result) {
+                 // Rare case -- [hasNext] has not been invoked, invoke [receive] directly.
+                NO_RESULT -> return c.receive()
+                // Channel is closed, throw the cause exception.
+                is ClosedResult -> throw result.receiveException
+                // An element has been received successfully.
+                else -> {
+                    // Reset the [result] field and return the element.
+                    this.result = NO_RESULT
+                    return result as E
+                }
+            }
+        }
+    }
+}
+
+private val NO_RESULT = Symbol("NO_RESULT")
+private class ClosedResult(val cause: Throwable?) {
+    val receiveException: Throwable get() = cause ?: ClosedReceiveChannelException(DEFAULT_CLOSE_MESSAGE)
+}

--- a/common/kotlinx-coroutines-core-common/test/channels/TestChannelKind.kt
+++ b/common/kotlinx-coroutines-core-common/test/channels/TestChannelKind.kt
@@ -58,7 +58,6 @@ private class ChannelViaBroadcast<E>(
     override suspend fun receive(): E = sub.receive()
     override suspend fun receiveOrNull(): E? = sub.receiveOrNull()
     override fun poll(): E? = sub.poll()
-    override fun iterator(): ChannelIterator<E> = sub.iterator()
     override fun cancel(): Boolean = sub.cancel()
     override fun cancel(cause: Throwable?): Boolean = sub.cancel(cause)
     override val onReceive: SelectClause1<E>


### PR DESCRIPTION
Make `ReceiveChannel<E>.iterator()` extension function and simplify the implementation.

This new implementation is a bit less efficient, what can be fixed after a function like `receiveOrClosed` is introduced.

Note that this change breaks the binary compatibility.