### PR TITLE
Cache result of ThreadContext.foldAll in the field of DispatchedCorou…

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/Builders.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/Builders.common.kt
@@ -138,7 +138,7 @@ public suspend fun <T> withContext(
     if (newContext[ContinuationInterceptor] == oldContext[ContinuationInterceptor]) {
         val coroutine = UndispatchedCoroutine(newContext, uCont) // MODE_UNDISPATCHED
         // There are changes in the context, so this thread needs to be updated
-        withCoroutineContext(newContext) {
+        withCoroutineContext(newContext, null) {
             return@sc coroutine.startUndispatchedOrReturn(coroutine, block)
         }
     }

--- a/common/kotlinx-coroutines-core-common/src/CoroutineContext.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/CoroutineContext.common.kt
@@ -17,6 +17,7 @@ internal expect fun createDefaultDispatcher(): CoroutineDispatcher
 @Suppress("PropertyName")
 internal expect val DefaultDelay: Delay
 
-internal expect inline fun <T> withCoroutineContext(context: CoroutineContext, block: () -> T): T
+// countOrElement -- pre-cached value for ThreadContext.kt
+internal expect inline fun <T> withCoroutineContext(context: CoroutineContext, countOrElement: Any?, block: () -> T): T
 internal expect fun Continuation<*>.toDebugString(): String
 internal expect val CoroutineContext.coroutineName: String?

--- a/common/kotlinx-coroutines-core-common/src/ResumeMode.kt
+++ b/common/kotlinx-coroutines-core-common/src/ResumeMode.kt
@@ -43,7 +43,7 @@ internal fun <T> Continuation<T>.resumeUninterceptedMode(value: T, mode: Int) {
         MODE_ATOMIC_DEFAULT -> intercepted().resume(value)
         MODE_CANCELLABLE -> intercepted().resumeCancellable(value)
         MODE_DIRECT -> resume(value)
-        MODE_UNDISPATCHED -> withCoroutineContext(context) { resume(value) }
+        MODE_UNDISPATCHED -> withCoroutineContext(context, null) { resume(value) }
         MODE_IGNORE -> {}
         else -> error("Invalid mode $mode")
     }
@@ -54,7 +54,7 @@ internal fun <T> Continuation<T>.resumeUninterceptedWithExceptionMode(exception:
         MODE_ATOMIC_DEFAULT -> intercepted().resumeWithException(exception)
         MODE_CANCELLABLE -> intercepted().resumeCancellableWithException(exception)
         MODE_DIRECT -> resumeWithException(exception)
-        MODE_UNDISPATCHED -> withCoroutineContext(context) { resumeWithException(exception) }
+        MODE_UNDISPATCHED -> withCoroutineContext(context, null) { resumeWithException(exception) }
         MODE_IGNORE -> {}
         else -> error("Invalid mode $mode")
     }

--- a/common/kotlinx-coroutines-core-common/src/internal/ThreadContext.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/internal/ThreadContext.common.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+internal expect fun threadContextElements(context: CoroutineContext): Any

--- a/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
+++ b/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
@@ -37,7 +37,7 @@ internal fun <R, T> (suspend (R) -> T).startCoroutineUnintercepted(receiver: R, 
  */
 internal fun <T> (suspend () -> T).startCoroutineUndispatched(completion: Continuation<T>) {
     startDirect(completion) {
-        withCoroutineContext(completion.context) {
+        withCoroutineContext(completion.context, null) {
             startCoroutineUninterceptedOrReturn(completion)
         }
     }
@@ -50,7 +50,7 @@ internal fun <T> (suspend () -> T).startCoroutineUndispatched(completion: Contin
  */
 internal fun <R, T> (suspend (R) -> T).startCoroutineUndispatched(receiver: R, completion: Continuation<T>) {
     startDirect(completion) {
-        withCoroutineContext(completion.context) {
+        withCoroutineContext(completion.context, null) {
             startCoroutineUninterceptedOrReturn(receiver, completion)
         }
     }

--- a/core/kotlinx-coroutines-core/src/CoroutineContext.kt
+++ b/core/kotlinx-coroutines-core/src/CoroutineContext.kt
@@ -63,8 +63,8 @@ public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext):
 /**
  * Executes a block using a given coroutine context.
  */
-internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, block: () -> T): T {
-    val oldValue = updateThreadContext(context)
+internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, countOrElement: Any?, block: () -> T): T {
+    val oldValue = updateThreadContext(context, countOrElement)
     try {
         return block()
     } finally {

--- a/core/kotlinx-coroutines-core/src/internal/ThreadContext.kt
+++ b/core/kotlinx-coroutines-core/src/internal/ThreadContext.kt
@@ -57,20 +57,24 @@ private val restoreState =
         return state
     }
 
-internal fun updateThreadContext(context: CoroutineContext): Any? {
-    val count = context.fold(0, countAll)
+internal actual fun threadContextElements(context: CoroutineContext): Any = context.fold(0, countAll)!!
+
+// countOrElement is pre-cached in dispatched continuation
+internal fun updateThreadContext(context: CoroutineContext, countOrElement: Any?): Any? {
+    @Suppress("NAME_SHADOWING")
+    val countOrElement = countOrElement ?: threadContextElements(context)
     @Suppress("IMPLICIT_BOXING_IN_IDENTITY_EQUALS")
     return when {
-        count === 0 -> ZERO // very fast path when there are no active ThreadContextElements
+        countOrElement === 0 -> ZERO // very fast path when there are no active ThreadContextElements
         //    ^^^ identity comparison for speed, we know zero always has the same identity
-        count is Int -> {
+        countOrElement is Int -> {
             // slow path for multiple active ThreadContextElements, allocates ThreadState for multiple old values
-            context.fold(ThreadState(context, count), updateState)
+            context.fold(ThreadState(context, countOrElement), updateState)
         }
         else -> {
             // fast path for one ThreadContextElement (no allocations, no additional context scan)
             @Suppress("UNCHECKED_CAST")
-            val element = count as ThreadContextElement<Any?>
+            val element = countOrElement as ThreadContextElement<Any?>
             element.updateThreadContext(context)
         }
     }

--- a/js/kotlinx-coroutines-core-js/src/CoroutineContext.kt
+++ b/js/kotlinx-coroutines-core-js/src/CoroutineContext.kt
@@ -34,6 +34,6 @@ public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext):
 }
 
 // No debugging facilities on JS
-internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, block: () -> T): T = block()
+internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, countOrElement: Any?, block: () -> T): T = block()
 internal actual fun Continuation<*>.toDebugString(): String = toString()
 internal actual val CoroutineContext.coroutineName: String? get() = null // not supported on JS

--- a/js/kotlinx-coroutines-core-js/src/internal/ThreadContext.kt
+++ b/js/kotlinx-coroutines-core-js/src/internal/ThreadContext.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+internal actual fun threadContextElements(context: CoroutineContext): Any = 0

--- a/native/kotlinx-coroutines-core-native/src/CoroutineContext.kt
+++ b/native/kotlinx-coroutines-core-native/src/CoroutineContext.kt
@@ -44,6 +44,6 @@ public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext):
 }
 
 // No debugging facilities on native
-internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, block: () -> T): T = block()
+internal actual inline fun <T> withCoroutineContext(context: CoroutineContext, countOrElement: Any?, block: () -> T): T = block()
 internal actual fun Continuation<*>.toDebugString(): String = toString()
 internal actual val CoroutineContext.coroutineName: String? get() = null // not supported on native

--- a/native/kotlinx-coroutines-core-native/src/internal/ThreadContext.kt
+++ b/native/kotlinx-coroutines-core-native/src/internal/ThreadContext.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+import kotlin.coroutines.*
+
+internal actual fun threadContextElements(context: CoroutineContext): Any = 0


### PR DESCRIPTION
…tine to avoid context fold in tight loops

Fixes #537