### PR TITLE
Deprecate Job.cancel(cause) and ReceiveChannel.cancel(cause), return …

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -76,6 +76,7 @@ public abstract interface class kotlinx/coroutines/ChildJob : kotlinx/coroutines
 }
 
 public final class kotlinx/coroutines/ChildJob$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/ChildJob;)Z
 	public static fun fold (Lkotlinx/coroutines/ChildJob;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/ChildJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/ChildJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -89,6 +90,7 @@ public abstract interface class kotlinx/coroutines/CompletableDeferred : kotlinx
 }
 
 public final class kotlinx/coroutines/CompletableDeferred$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/CompletableDeferred;)Z
 	public static fun fold (Lkotlinx/coroutines/CompletableDeferred;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/CompletableDeferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/CompletableDeferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -197,6 +199,7 @@ public abstract interface class kotlinx/coroutines/Deferred : kotlinx/coroutines
 }
 
 public final class kotlinx/coroutines/Deferred$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/Deferred;)Z
 	public static fun fold (Lkotlinx/coroutines/Deferred;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/Deferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/Deferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -260,7 +263,8 @@ public abstract interface annotation class kotlinx/coroutines/InternalCoroutines
 public abstract interface class kotlinx/coroutines/Job : kotlin/coroutines/CoroutineContext$Element {
 	public static final field Key Lkotlinx/coroutines/Job$Key;
 	public abstract fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public abstract fun cancel ()Z
+	public abstract fun cancel ()V
+	public abstract synthetic fun cancel ()Z
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract fun getCancellationException ()Ljava/util/concurrent/CancellationException;
 	public abstract fun getChildren ()Lkotlin/sequences/Sequence;
@@ -276,6 +280,7 @@ public abstract interface class kotlinx/coroutines/Job : kotlin/coroutines/Corou
 }
 
 public final class kotlinx/coroutines/Job$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/Job;)Z
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 	public static fun fold (Lkotlinx/coroutines/Job;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/Job;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
@@ -292,12 +297,14 @@ public final class kotlinx/coroutines/JobKt {
 	public static final fun DisposableHandle (Lkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/DisposableHandle;
 	public static final fun Job (Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/Job;
 	public static synthetic fun Job$default (Lkotlinx/coroutines/Job;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;)Z
+	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;)V
+	public static final synthetic fun cancel (Lkotlin/coroutines/CoroutineContext;)Z
 	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)Z
 	public static synthetic fun cancel$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 	public static final fun cancelAndJoin (Lkotlinx/coroutines/Job;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun cancelChildren (Lkotlin/coroutines/CoroutineContext;)V
 	public static final fun cancelChildren (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
+	public static final fun cancelChildren (Lkotlinx/coroutines/Job;)V
 	public static final fun cancelChildren (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;)V
 	public static synthetic fun cancelChildren$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;ILjava/lang/Object;)V
 	public static synthetic fun cancelChildren$default (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;ILjava/lang/Object;)V
@@ -309,7 +316,8 @@ public final class kotlinx/coroutines/JobKt {
 public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlinx/coroutines/Job, kotlinx/coroutines/ParentJob, kotlinx/coroutines/selects/SelectClause0 {
 	public fun <init> (Z)V
 	public final fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public fun cancel ()Z
+	public fun cancel ()V
+	public synthetic fun cancel ()Z
 	public fun cancel (Ljava/lang/Throwable;)Z
 	public fun childCancelled (Ljava/lang/Throwable;)Z
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
@@ -349,7 +357,8 @@ public abstract class kotlinx/coroutines/MainCoroutineDispatcher : kotlinx/corou
 public final class kotlinx/coroutines/NonCancellable : kotlin/coroutines/AbstractCoroutineContextElement, kotlinx/coroutines/Job {
 	public static final field INSTANCE Lkotlinx/coroutines/NonCancellable;
 	public fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public fun cancel ()Z
+	public fun cancel ()V
+	public synthetic fun cancel ()Z
 	public fun cancel (Ljava/lang/Throwable;)Z
 	public fun getCancellationException ()Ljava/util/concurrent/CancellationException;
 	public fun getChildren ()Lkotlin/sequences/Sequence;
@@ -379,6 +388,7 @@ public abstract interface class kotlinx/coroutines/ParentJob : kotlinx/coroutine
 }
 
 public final class kotlinx/coroutines/ParentJob$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/ParentJob;)Z
 	public static fun fold (Lkotlinx/coroutines/ParentJob;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/ParentJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/ParentJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -439,6 +449,10 @@ public abstract interface class kotlinx/coroutines/channels/ActorScope : kotlinx
 	public abstract fun getChannel ()Lkotlinx/coroutines/channels/Channel;
 }
 
+public final class kotlinx/coroutines/channels/ActorScope$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ActorScope;)Z
+}
+
 public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : kotlinx/coroutines/channels/SendChannel {
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract fun openSubscription ()Lkotlinx/coroutines/channels/ReceiveChannel;
@@ -464,6 +478,10 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 	public static final field Factory Lkotlinx/coroutines/channels/Channel$Factory;
 	public static final field RENDEZVOUS I
 	public static final field UNLIMITED I
+}
+
+public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)Z
 }
 
 public final class kotlinx/coroutines/channels/Channel$Factory {
@@ -637,7 +655,8 @@ public abstract interface class kotlinx/coroutines/channels/ProducerScope : kotl
 }
 
 public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
-	public abstract fun cancel ()Z
+	public abstract fun cancel ()V
+	public abstract synthetic fun cancel ()Z
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract fun getOnReceive ()Lkotlinx/coroutines/selects/SelectClause1;
 	public abstract fun getOnReceiveOrNull ()Lkotlinx/coroutines/selects/SelectClause1;
@@ -650,6 +669,7 @@ public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
 }
 
 public final class kotlinx/coroutines/channels/ReceiveChannel$DefaultImpls {
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ReceiveChannel;)Z
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 }
 

--- a/common/kotlinx-coroutines-core-common/src/JobSupport.kt
+++ b/common/kotlinx-coroutines-core-common/src/JobSupport.kt
@@ -559,8 +559,9 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     internal open val onCancelComplete: Boolean get() = false
 
     // external cancel without cause, never invoked implicitly from internal machinery
-    public override fun cancel(): Boolean =
+    public override fun cancel(): Unit {
         cancel(null) // must delegate here, because some classes override cancel(x)
+    }
 
     // external cancel with (optional) cause, never invoked implicitly from internal machinery
     public override fun cancel(cause: Throwable?): Boolean =

--- a/common/kotlinx-coroutines-core-common/src/NonCancellable.kt
+++ b/common/kotlinx-coroutines-core-common/src/NonCancellable.kt
@@ -88,11 +88,13 @@ public object NonCancellable : AbstractCoroutineContextElement(Job), Job {
         NonDisposableHandle
 
     /**
-     * Always returns `false`.
+     * Does nothing.
      * @suppress **This an internal API and should not be used from general code.**
      */
     @InternalCoroutinesApi
-    override fun cancel(): Boolean = false
+    @Suppress("RETURN_TYPE_MISMATCH_ON_OVERRIDE")
+    override fun cancel(): Unit {
+    }
 
     /**
      * Always returns `false`.

--- a/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/AbstractChannel.kt
@@ -657,7 +657,9 @@ internal abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E
         return if (result === POLL_FAILED) null else receiveOrNullResult(result)
     }
 
-    override fun cancel(): Boolean = cancel(null)
+    override fun cancel(): Unit {
+        cancel(null)
+    }
 
     override fun cancel(cause: Throwable?): Boolean =
         close(cause).also {

--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -7,10 +7,11 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.selects.*
+import kotlin.jvm.*
 
 /**
  * Sender's interface to [Channel].
@@ -239,7 +240,6 @@ public interface ReceiveChannel<out E> {
     /**
      * Cancels reception of remaining elements from this channel. This function closes the channel
      * and removes all buffered sent elements from it.
-     * This function returns `true` if the channel was not closed previously, or `false` otherwise.
      *
      * Immediately after invocation of this function [isClosedForReceive] and
      * [isClosedForSend][SendChannel.isClosedForSend]
@@ -247,25 +247,21 @@ public interface ReceiveChannel<out E> {
      * afterwards will throw [ClosedSendChannelException], while attempts to receive will throw
      * [ClosedReceiveChannelException].
      */
-    public fun cancel(): Boolean
+    public fun cancel(): Unit
 
     /**
-     * Cancels reception of remaining elements from this channel. This function closes the channel with
-     * the specified cause (unless it was already closed) and removes all buffered sent elements from it.
-     * This function returns `true` if the channel was not closed previously, or `false` otherwise.
-     *
-     * Immediately after invocation of this function [isClosedForReceive] and
-     * [isClosedForSend][SendChannel.isClosedForSend]
-     * on the side of [SendChannel] start returning `true`, so all attempts to send to this channel
-     * afterwards will throw [ClosedSendChannelException], while attempts to receive will throw
-     * [ClosedReceiveChannelException] if it was cancelled without a cause.
-     * A channel that was cancelled with non-null [cause] is called a _failed_ channel. Attempts to send or
-     * receive on a failed channel throw the specified [cause] exception.
-     *
-     * **Note: This is an experimental api.** Semantics of _cancelling_ a channel with exception may
-     *         change in the future or this feature may be completely removed.
+     * @suppress
      */
-    @ExperimentalCoroutinesApi
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Left here for binary compatibility")
+    @JvmName("cancel")
+    public fun cancel0(): Boolean = cancel(null)
+
+    /**
+     * @suppress
+     */
+    @ObsoleteCoroutinesApi
+    @Deprecated(level = DeprecationLevel.WARNING, message = "Use cancel without cause", replaceWith = ReplaceWith("cancel()"))
     public fun cancel(cause: Throwable? = null): Boolean
 }
 

--- a/common/kotlinx-coroutines-core-common/src/channels/ChannelCoroutine.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/ChannelCoroutine.kt
@@ -16,7 +16,11 @@ internal open class ChannelCoroutine<E>(
 
     val channel: Channel<E> get() = this
 
-    override fun cancel() = cancel(null)
+    override fun cancel(): Unit {
+        cancel(null)
+    }
+
+    override fun cancel0(): Boolean = cancel(null)
 
     override fun cancel(cause: Throwable?): Boolean {
         val wasCancelled = _channel.cancel(cause)

--- a/common/kotlinx-coroutines-core-common/test/AsyncLazyTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/AsyncLazyTest.kt
@@ -150,9 +150,8 @@ class AsyncLazyTest : TestBase() {
         }
         expect(2)
         assertTrue(!d.isActive && !d.isCompleted)
-        assertTrue(d.cancel())
+        d.cancel()
         assertTrue(!d.isActive && d.isCompleted && d.isCancelled)
-        assertTrue(!d.cancel())
         assertTrue(!d.start())
         finish(3)
         assertEquals(d.await(), 42) // await shall throw CancellationException
@@ -178,9 +177,8 @@ class AsyncLazyTest : TestBase() {
         yield() // yield to d
         expect(5)
         assertTrue(d.isActive && !d.isCompleted && !d.isCancelled)
-        assertTrue(d.cancel())
+        d.cancel()
         assertTrue(!d.isActive && d.isCancelled) // cancelling !
-        assertTrue(d.cancel())
         assertTrue(!d.isActive && d.isCancelled) // still cancelling
         finish(6)
         assertEquals(d.await(), 42) // await shall throw CancellationException

--- a/common/kotlinx-coroutines-core-common/test/CompletableDeferredTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CompletableDeferredTest.kt
@@ -42,15 +42,6 @@ class CompletableDeferredTest : TestBase() {
         assertEquals(null, c.getCompletionExceptionOrNull())
     }
 
-    @Test
-    fun testCancel() {
-        val c = CompletableDeferred<String>()
-        assertEquals(true, c.cancel())
-        checkCancel(c)
-        assertEquals(false, c.cancel())
-        checkCancel(c)
-    }
-
     private fun checkCancel(c: CompletableDeferred<String>) {
         assertEquals(false, c.isActive)
         assertEquals(true, c.isCancelled)
@@ -121,7 +112,7 @@ class CompletableDeferredTest : TestBase() {
         val c = CompletableDeferred<String>(parent)
         checkFresh(c)
         assertEquals(true, parent.isActive)
-        assertEquals(true, c.cancel())
+        c.cancel()
         checkCancel(c)
         assertEquals(true, parent.isActive)
     }

--- a/common/kotlinx-coroutines-core-common/test/CoroutinesTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CoroutinesTest.kt
@@ -199,10 +199,9 @@ class CoroutinesTest : TestBase() {
         yield() // to job
         expect(4)
         assertTrue(job.isActive && !job.isCompleted)
-        assertTrue(job.cancel())  // cancels job
+        job.cancel()  // cancels job
         expect(5) // still here
         assertTrue(!job.isActive && !job.isCompleted)
-        assertTrue(job.cancel()) // second attempt returns true as well, job is still completing
         expect(6) // we're still here
         job.join() // join the job, let job complete its "finally" section
         expect(8)

--- a/common/kotlinx-coroutines-core-common/test/WithContextTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/WithContextTest.kt
@@ -203,7 +203,7 @@ class WithContextTest : TestBase() {
                 withContext(wrapperDispatcher(coroutineContext)) {
                     require(isActive)
                     expect(5)
-                    require(job!!.cancel()) // cancel itself
+                    job!!.cancel()
                     require(job!!.cancel(AssertionError())) // cancel again, no success here
                     require(!isActive)
                     throw TestException() // but throw a different exception
@@ -233,7 +233,7 @@ class WithContextTest : TestBase() {
                 withContext(wrapperDispatcher(coroutineContext)) {
                     require(isActive)
                     expect(5)
-                    require(job!!.cancel()) // cancel itself
+                    job!!.cancel() // cancel itself
                     require(job!!.cancel(AssertionError()))
                     require(!isActive)
                 }

--- a/common/kotlinx-coroutines-core-common/test/channels/TestChannelKind.kt
+++ b/common/kotlinx-coroutines-core-common/test/channels/TestChannelKind.kt
@@ -59,7 +59,7 @@ private class ChannelViaBroadcast<E>(
     override suspend fun receiveOrNull(): E? = sub.receiveOrNull()
     override fun poll(): E? = sub.poll()
     override fun iterator(): ChannelIterator<E> = sub.iterator()
-    override fun cancel(): Boolean = sub.cancel()
+    override fun cancel(): Unit = sub.cancel()
     override fun cancel(cause: Throwable?): Boolean = sub.cancel(cause)
     override val onReceive: SelectClause1<E>
         get() = sub.onReceive

--- a/core/kotlinx-coroutines-core/test/AsyncJvmTest.kt
+++ b/core/kotlinx-coroutines-core/test/AsyncJvmTest.kt
@@ -28,9 +28,8 @@ class AsyncJvmTest : TestBase() {
         yield() // to async
         expect(4)
         check(d.isActive && !d.isCompleted && !d.isCancelled)
-        check(d.cancel())
+        d.cancel()
         check(!d.isActive && !d.isCompleted && d.isCancelled)
-        check(d.cancel()) // second attempt still returns true (still cancelling)
         check(!d.isActive && !d.isCompleted && d.isCancelled)
         expect(5)
         try {
@@ -40,8 +39,6 @@ class AsyncJvmTest : TestBase() {
             expect(7)
             check(e is CancellationException)
         }
-        check(!d.isActive && d.isCompleted && d.isCancelled)
-        check(!d.cancel()) // now cancel return false -- already cancelled
         check(!d.isActive && d.isCompleted && d.isCancelled)
         finish(8)
     }

--- a/core/kotlinx-coroutines-core/test/JobDisposeStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/JobDisposeStressTest.kt
@@ -49,9 +49,8 @@ class JobDisposeStressTest: TestBase() {
         threads += testThread("canceller") {
             while (!done) {
                 val job = this.job ?: continue
-                val result = job.cancel()
+                job.cancel()
                 // Always returns true, TestJob never completes
-                check(result)
             }
         }
 

--- a/core/kotlinx-coroutines-core/test/JoinStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/JoinStressTest.kt
@@ -50,7 +50,6 @@ class JoinStressTest : TestBase() {
             barrier.await()
             exceptionalJob.cancel()
             ++results[awaiterJob.await()]
-            require(!exceptionalJob.cancel())
         }
 
         // Check that concurrent cancellation of job which throws TestException without suspends doesn't suppress TestException
@@ -93,7 +92,6 @@ class JoinStressTest : TestBase() {
                 assertTrue(cancellerResult)
             }
             ++results[awaiterResult]
-            require(!exceptionalJob.cancel())
 
             if (cancellerResult) {
                 ++successfulCancellations

--- a/core/kotlinx-coroutines-core/test/exceptions/JobBasicCancellationTest.kt
+++ b/core/kotlinx-coroutines-core/test/exceptions/JobBasicCancellationTest.kt
@@ -26,7 +26,7 @@ class JobBasicCancellationTest : TestBase() {
 
             yield()
             expect(3)
-            assertFalse(child.cancel())
+            child.cancel()
             child.join()
             expect(4)
         }
@@ -44,7 +44,7 @@ class JobBasicCancellationTest : TestBase() {
             }
 
             expect(2)
-            assertTrue(child.cancel())
+            child.cancel()
             child.join()
             yield()
             expect(4)
@@ -66,7 +66,7 @@ class JobBasicCancellationTest : TestBase() {
 
             yield()
             expect(3)
-            assertFalse(child.cancel())
+            child.cancel()
             child.await()
             expect(4)
         }
@@ -84,7 +84,7 @@ class JobBasicCancellationTest : TestBase() {
             }
 
             expect(2)
-            assertTrue(child.cancel())
+            child.cancel()
             child.join()
             expect(4)
         }
@@ -121,7 +121,7 @@ class JobBasicCancellationTest : TestBase() {
             expect(1)
             val child = Job(coroutineContext[Job])
             expect(2)
-            assertFalse(child.cancel()) // cancel without cause -- should not cancel us (parent)
+            child.cancel() // cancel without cause -- should not cancel us (parent)
             child.join()
             expect(3)
         }
@@ -135,7 +135,7 @@ class JobBasicCancellationTest : TestBase() {
             expect(1)
             val child = CompletableDeferred<Unit>(coroutineContext[Job])
             expect(2)
-            assertTrue(child.cancel()) // cancel without cause -- should not cancel us (parent)
+            child.cancel() // cancel without cause -- should not cancel us (parent)
             child.join()
             expect(3)
         }

--- a/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
+++ b/core/kotlinx-coroutines-core/test/test/TestCoroutineContextTest.kt
@@ -369,8 +369,7 @@ class TestCoroutineContextTest {
         }
 
         advanceTimeBy(500)
-        assertTrue(job.cancel())
-
+        job.cancel()
         assertAllUnhandledExceptions { it is CancellationException }
     }
 
@@ -381,7 +380,7 @@ class TestCoroutineContextTest {
         }
 
         advanceTimeBy(500)
-        assertTrue(job.cancel())
+        job.cancel()
     }
 }
 

--- a/reactive/kotlinx-coroutines-reactor/src/Mono.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Mono.kt
@@ -58,7 +58,7 @@ private class MonoCoroutine<in T>(
     
     override fun dispose() {
         disposed = true
-        cancel(cause = null)
+        cancel()
     }
 
     override fun isDisposed(): Boolean = disposed


### PR DESCRIPTION
…Unit from cancel without cause

Fixes #713
Fixes #481

