### PR TITLE
Undeprecate Channel.receiveOrNull

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
+++ b/common/kotlinx-coroutines-core-common/src/channels/Channel.kt
@@ -206,14 +206,7 @@ public interface ReceiveChannel<out E> {
      *
      * This function can be used in [select] invocation with [onReceiveOrNull] clause.
      * Use [poll] to try receiving from this channel without waiting.
-     *
-     * **Note: This is an obsolete api.**
-     * This function will be replaced with `receiveOrClosed: ReceiveResult<E>` and
-     * extension `suspend fun <E: Any> ReceiveChannel<E>.receiveOrNull(): E?`
      */
-    @ExperimentalCoroutinesApi
-    @ObsoleteCoroutinesApi
-    @Deprecated(level = DeprecationLevel.WARNING, message = "This method does not distinguish closed channel and null elements")
     public suspend fun receiveOrNull(): E?
 
     /**


### PR DESCRIPTION
* It is a valid method for channels of non-null elements that is
  also consistent with Kotlin stdlib tradition.
* However, leave Channel.onReceiveOrNull since this is a tricker one,
  because on failure it aborts the whole select without letting figure
  out which clause failed.