### PR TITLE
Reactive streams integration conformance to TCK verified & fixed

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -144,6 +144,7 @@ public final class kotlinx/coroutines/CoroutineExceptionHandlerKt {
 	public static final fun CoroutineExceptionHandler (Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public static final fun handleCoroutineException (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;Lkotlinx/coroutines/Job;)V
 	public static synthetic fun handleCoroutineException$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;Lkotlinx/coroutines/Job;ILjava/lang/Object;)V
+	public static final fun handleExceptionViaHandler (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
 }
 
 public final class kotlinx/coroutines/CoroutineName : kotlin/coroutines/AbstractCoroutineContextElement {

--- a/common/kotlinx-coroutines-core-common/src/CoroutineExceptionHandler.kt
+++ b/common/kotlinx-coroutines-core-common/src/CoroutineExceptionHandler.kt
@@ -31,7 +31,11 @@ public fun handleCoroutineException(context: CoroutineContext, exception: Throwa
     handleExceptionViaHandler(context, exception)
 }
 
-internal fun handleExceptionViaHandler(context: CoroutineContext, exception: Throwable) {
+/**
+ * @suppress This is an internal API and it is subject to change.
+ */
+@InternalCoroutinesApi
+public fun handleExceptionViaHandler(context: CoroutineContext, exception: Throwable) {
     // Invoke exception handler from the context if present
     try {
         context[CoroutineExceptionHandler]?.let {

--- a/reactive/kotlinx-coroutines-reactive/build.gradle
+++ b/reactive/kotlinx-coroutines-reactive/build.gradle
@@ -13,6 +13,10 @@ task testNG(type: Test) {
     useTestNG()
     reports.html.destination = file("$buildDir/reports/testng")
     include '**/*ReactiveStreamTckTest.*'
+    // Skip testNG when tests are filtered with --tests, otherwise it simply fails
+    onlyIf {
+        filter.includePatterns.isEmpty()
+    }
     doFirst {
         // Classic gradle, nothing works without doFirst
         println "TestNG tests: ($includes)"

--- a/reactive/kotlinx-coroutines-reactive/build.gradle
+++ b/reactive/kotlinx-coroutines-reactive/build.gradle
@@ -2,9 +2,11 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-ext.reactive_streams_version = '1.0.0'
+ext.reactive_streams_version = '1.0.2'
+
 dependencies {
     compile "org.reactivestreams:reactive-streams:$reactive_streams_version"
+    testCompile "org.reactivestreams:reactive-streams-tck:$reactive_streams_version"
 }
 
 tasks.withType(dokka.getClass()) {

--- a/reactive/kotlinx-coroutines-reactive/build.gradle
+++ b/reactive/kotlinx-coroutines-reactive/build.gradle
@@ -9,6 +9,21 @@ dependencies {
     testCompile "org.reactivestreams:reactive-streams-tck:$reactive_streams_version"
 }
 
+task testNG(type: Test) {
+    useTestNG()
+    reports.html.destination = file("$buildDir/reports/testng")
+    include '**/*ReactiveStreamTckTest.*'
+    doFirst {
+        // Classic gradle, nothing works without doFirst
+        println "TestNG tests: ($includes)"
+    }
+}
+
+test {
+    dependsOn(testNG)
+    reports.html.destination = file("$buildDir/reports/junit")
+}
+
 tasks.withType(dokka.getClass()) {
     externalDocumentationLink {
         url = new URL("http://www.reactive-streams.org/reactive-streams-$reactive_streams_version-javadoc/")

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -160,10 +160,10 @@ private class PublisherCoroutine<in T>(
 
     private fun unlockAndCheckCompleted() {
        /*
-         There is no sense to check completion before doing `unlock`, because completion might
-         happen after this check and before `unlock` (see `signalCompleted` that does not do anything
-         if it fails to acquire the lock that we are still holding).
-         We have to recheck `isCompleted` after `unlock` anyway.
+        * There is no sense to check completion before doing `unlock`, because completion might
+        * happen after this check and before `unlock` (see `signalCompleted` that does not do anything
+        * if it fails to acquire the lock that we are still holding).
+        * We have to recheck `isCompleted` after `unlock` anyway.
         */
         mutex.unlock()
         // check isCompleted and and try to regain lock to signal completion
@@ -180,13 +180,17 @@ private class PublisherCoroutine<in T>(
                 if (cancelled) {
                     // If the parent had failed to handle our exception (handleJobException was invoked), then
                     // we must not loose this exception
-                    if (shouldHandleException && cause != null) handleExceptionViaHandler(parentContext, cause)
+                    if (shouldHandleException && cause != null) {
+                        handleExceptionViaHandler(parentContext, cause)
+                    }
                 } else {
                     try {
-                        if (cause != null && cause !is CancellationException)
+                        if (cause != null && cause !is CancellationException) {
                             subscriber.onError(cause)
-                        else
+                        }
+                        else {
                             subscriber.onComplete()
+                        }
                     } catch (e: Throwable) {
                         handleExceptionViaHandler(parentContext, e)
                     }

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -59,6 +59,9 @@ private class PublisherCoroutine<in T>(
     private val subscriber: Subscriber<T>
 ) : AbstractCoroutine<Unit>(parentContext, true), ProducerScope<T>, Subscription, SelectClause2<T, SendChannel<T>> {
     override val channel: SendChannel<T> get() = this
+
+    // cancelsParent == true ensure that error is always reported to the parent, so that parent cannot complete
+    // without receiving reported error.
     override val cancelsParent: Boolean get() = true
 
     // Mutex is locked when either nRequested == 0 or while subscriber.onXXX is being invoked
@@ -68,6 +71,8 @@ private class PublisherCoroutine<in T>(
 
     @Volatile
     private var cancelled = false // true when Subscription.cancel() is invoked
+
+    private var handleException = false // when handleJobException is invoked
 
     override val isClosedForSend: Boolean get() = isCompleted
     override val isFull: Boolean = mutex.isLocked
@@ -105,25 +110,29 @@ private class PublisherCoroutine<in T>(
         }
     }
 
+    /*
+       This code is not trivial because of the two properties:
+       1. It ensures conformance to the reactive specification that mandates that onXXX invocations should not
+          be concurrent. It uses Mutex to protect all onXXX invocation and ensure conformance even when multiple
+          coroutines are invoking `send` function.
+       2. Normally, `onComplete/onError` notification is sent only when coroutine and all its children are complete.
+          However, nothing prevents `publish` coroutine from leaking reference to it send channel to some
+          globally-scoped coroutine that is invoking `send` outside of this context. Without extra precaution this may
+          lead to `onNext` that is concurrent with `onComplete/onError`, so that is why signalling for
+          `onComplete/onError` is also done under the same mutex.
+     */
+
     // assert: mutex.isLocked()
     private fun doLockedNext(elem: T) {
-        // check if already closed for send
+        // check if already closed for send, note, that isActive become false as soon as cancel() is invoked,
+        // because the job is cancelled, so this check also ensure conformance to the reactive specification's
+        // requirement that after cancellation requested we don't call onXXX
         if (!isActive) {
-            doLockedSignalCompleted()
+            unlockAndCheckCompleted()
             throw getCancellationException()
         }
         // notify subscriber
-        try {
-            subscriber.onNext(elem)
-        } catch (e: Throwable) {
-            try {
-                if (!cancel(e))
-                    handleCoroutineException(context, e, this)
-            } finally {
-                doLockedSignalCompleted()
-            }
-            throw getCancellationException()
-        }
+        subscriber.onNext(elem)
         // now update nRequested
         while (true) { // lock-free loop on nRequested
             val cur = _nRequested.value
@@ -131,23 +140,29 @@ private class PublisherCoroutine<in T>(
             if (cur == Long.MAX_VALUE) break // no back-pressure => unlock
             val upd = cur - 1
             if (_nRequested.compareAndSet(cur, upd)) {
-                if (upd == 0L) return // return to keep locked due to back-pressure
+                if (upd == 0L) {
+                    // return to keep locked due to back-pressure
+                    return
+                }
                 break // unlock if upd > 0
             }
         }
-        /*
-           There is no sense to check for `isActive` before doing `unlock`, because cancellation/completion might
-           happen after this check and before `unlock` (see `onCancellation` that does not do anything
-           if it fails to acquire the lock that we are still holding).
-           We have to recheck `isActive` after `unlock` anyway.
-         */
-        mutex.unlock()
-        // recheck isActive
-        if (!isActive && mutex.tryLock())
-            doLockedSignalCompleted()
+        unlockAndCheckCompleted()
     }
 
-    // assert: mutex.isLocked()
+    private fun unlockAndCheckCompleted() {
+       /*
+         There is no sense to check completion before doing `unlock`, because completion might
+         happen after this check and before `unlock` (see `signalCompleted` that does not do anything
+         if it fails to acquire the lock that we are still holding).
+         We have to recheck `isCompleted` after `unlock` anyway.
+        */
+        mutex.unlock()
+        // check isCompleted and and try to regain lock to signal completion
+        if (isCompleted && mutex.tryLock()) doLockedSignalCompleted()
+    }
+
+    // assert: mutex.isLocked() & isCompleted
     private fun doLockedSignalCompleted() {
         try {
             if (_nRequested.value >= CLOSED) {
@@ -155,18 +170,19 @@ private class PublisherCoroutine<in T>(
                 val cause = getCompletionCause()
                 // Specification requires that after cancellation requested we don't call onXXX
                 if (cancelled) {
-                    // but we cannot just ignore exception so we handle it
-                    if (cause != null) handleCoroutineException(context, cause, this)
-                    return
-                }
-                try {
-                    if (cause != null && cause !is CancellationException)
-                        subscriber.onError(cause)
-                    else
-                        subscriber.onComplete()
-                } catch (e: Throwable) {
-                    handleCoroutineException(context, e, this)
-                }
+                    // If the parent had failed to handle our exception (handleJobException was invoked), then
+                    // we must not loose this exception
+                    if (handleException && cause != null) handleExceptionViaHandler(parentContext, cause)
+                } else {
+                    try {
+                        if (cause != null && cause !is CancellationException)
+                            subscriber.onError(cause)
+                        else
+                            subscriber.onComplete()
+                    } catch (e: Throwable) {
+                        handleExceptionViaHandler(parentContext, e)
+                    }
+                }                                   
             }
         } finally {
             mutex.unlock()
@@ -189,35 +205,46 @@ private class PublisherCoroutine<in T>(
             if (_nRequested.compareAndSet(cur, upd)) {
                 // unlock the mutex when we don't have back-pressure anymore
                 if (cur == 0L) {
-                    mutex.unlock()
-                    // recheck isActive
-                    if (!isActive && mutex.tryLock())
-                        doLockedSignalCompleted()
+                    unlockAndCheckCompleted()
                 }
                 return
             }
         }
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) = onCompleted(Unit)
-
-    override fun onCompleted(value: Unit) {
+    // assert: isCompleted
+    private fun signalCompleted() {
         while (true) { // lock-free loop for nRequested
             val cur = _nRequested.value
             if (cur == SIGNALLED) return // some other thread holding lock already signalled cancellation/completion
-            check(cur >= 0) // no other thread could have marked it as CLOSED, because onCancellation is invoked once
+            check(cur >= 0) // no other thread could have marked it as CLOSED, because onCompleted[Exceptionally] is invoked once
             if (!_nRequested.compareAndSet(cur, CLOSED)) continue // retry on failed CAS
             // Ok -- marked as CLOSED, now can unlock the mutex if it was locked due to backpressure
             if (cur == 0L) {
                 doLockedSignalCompleted()
             } else {
                 // otherwise mutex was either not locked or locked in concurrent onNext... try lock it to signal completion
-                if (mutex.tryLock())
-                    doLockedSignalCompleted()
+                if (mutex.tryLock()) doLockedSignalCompleted()
                 // Note: if failed `tryLock`, then `doLockedNext` will signal after performing `unlock`
             }
             return // done anyway
         }
+    }
+
+    // Note: It is invoked when parent fails to handle an exception and strictly before onCompleted[Exception]
+    // so here we just raise a flag (and it need NOT be volatile!) to handle this exception.
+    // This way we defer decision to handle this exception based on our ability to send this exception
+    // to the subscriber (see doLockedSignalCompleted)
+    override fun handleJobException(exception: Throwable) {
+        handleException = true
+    }
+    
+    override fun onCompletedExceptionally(exception: Throwable) {
+        signalCompleted()
+    }
+
+    override fun onCompleted(value: Unit) {
+        signalCompleted()
     }
 
     override fun cancel() {

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -72,7 +72,7 @@ private class PublisherCoroutine<in T>(
     @Volatile
     private var cancelled = false // true when Subscription.cancel() is invoked
 
-    private var handleException = false // when handleJobException is invoked
+    private var shouldHandleException = false // when handleJobException is invoked
 
     override val isClosedForSend: Boolean get() = isCompleted
     override val isFull: Boolean = mutex.isLocked
@@ -172,7 +172,7 @@ private class PublisherCoroutine<in T>(
                 if (cancelled) {
                     // If the parent had failed to handle our exception (handleJobException was invoked), then
                     // we must not loose this exception
-                    if (handleException && cause != null) handleExceptionViaHandler(parentContext, cause)
+                    if (shouldHandleException && cause != null) handleExceptionViaHandler(parentContext, cause)
                 } else {
                     try {
                         if (cause != null && cause !is CancellationException)
@@ -236,7 +236,7 @@ private class PublisherCoroutine<in T>(
     // This way we defer decision to handle this exception based on our ability to send this exception
     // to the subscriber (see doLockedSignalCompleted)
     override fun handleJobException(exception: Throwable) {
-        handleException = true
+        shouldHandleException = true
     }
     
     override fun onCompletedExceptionally(exception: Throwable) {

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -199,7 +199,9 @@ private class PublisherCoroutine<in T>(
         }
     }
 
-    override fun onCancellation(cause: Throwable?) {
+    override fun onCompletedExceptionally(exception: Throwable) = onCompleted(Unit)
+
+    override fun onCompleted(value: Unit) {
         while (true) { // lock-free loop for nRequested
             val cur = _nRequested.value
             if (cur == SIGNALLED) return // some other thread holding lock already signalled cancellation/completion

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -43,7 +43,7 @@ public fun <T> CoroutineScope.publish(
     @BuilderInference block: suspend ProducerScope<T>.() -> Unit
 ): Publisher<T> = Publisher { subscriber ->
     // specification requires NPE on null subscriber
-    if (subscriber == null) throw NullPointerException("subscriber")
+    if (subscriber == null) throw NullPointerException("Subscriber cannot be null")
     val newContext = newCoroutineContext(context)
     val coroutine = PublisherCoroutine(newContext, subscriber)
     subscriber.onSubscribe(coroutine) // do it first (before starting coroutine), to avoid unnecessary suspensions

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -111,15 +111,15 @@ private class PublisherCoroutine<in T>(
     }
 
     /*
-       This code is not trivial because of the two properties:
-       1. It ensures conformance to the reactive specification that mandates that onXXX invocations should not
-          be concurrent. It uses Mutex to protect all onXXX invocation and ensure conformance even when multiple
-          coroutines are invoking `send` function.
-       2. Normally, `onComplete/onError` notification is sent only when coroutine and all its children are complete.
-          However, nothing prevents `publish` coroutine from leaking reference to it send channel to some
-          globally-scoped coroutine that is invoking `send` outside of this context. Without extra precaution this may
-          lead to `onNext` that is concurrent with `onComplete/onError`, so that is why signalling for
-          `onComplete/onError` is also done under the same mutex.
+     * This code is not trivial because of the two properties:
+     * 1. It ensures conformance to the reactive specification that mandates that onXXX invocations should not
+     *    be concurrent. It uses Mutex to protect all onXXX invocation and ensure conformance even when multiple
+     *    coroutines are invoking `send` function.
+     * 2. Normally, `onComplete/onError` notification is sent only when coroutine and all its children are complete.
+     *    However, nothing prevents `publish` coroutine from leaking reference to it send channel to some
+     *    globally-scoped coroutine that is invoking `send` outside of this context. Without extra precaution this may
+     *    lead to `onNext` that is concurrent with `onComplete/onError`, so that is why signalling for
+     *    `onComplete/onError` is also done under the same mutex.
      */
 
     // assert: mutex.isLocked()

--- a/reactive/kotlinx-coroutines-reactive/test/PublishParentCancelStressTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublishParentCancelStressTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.reactive
+
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import org.reactivestreams.*
+import java.util.concurrent.*
+import kotlin.test.*
+
+public class PublishParentCancelStressTest : TestBase() {
+    private val dispatcher = newFixedThreadPoolContext(3, "PublishParentCancelStressTest")
+    private val N_TIMES = 5000 * stressTestMultiplier
+
+    @After
+    fun tearDown() {
+        dispatcher.close()
+    }
+
+    @Test
+    fun testStress() = runTest {
+        var unhandled: Throwable? = null
+        val handler = CoroutineExceptionHandler { _, ex -> unhandled = ex }
+        repeat(N_TIMES) {
+            val barrier = CyclicBarrier(4)
+            // launch parent job for publisher
+            val parent = GlobalScope.async<Unit>(dispatcher + handler) {
+                val publisher = publish<Unit> {
+                    // BARRIER #1 - child publisher crashes
+                    barrier.await()
+                    throw TestException()
+                }
+                var sub: Subscription? = null
+                publisher.subscribe(object : Subscriber<Unit> {
+                    override fun onComplete() { error("Cannot be reached") }
+                    override fun onSubscribe(s: Subscription?) { sub = s }
+                    override fun onNext(t: Unit?) { error("Cannot be reached" ) }
+                    override fun onError(t: Throwable?) {
+                        assertTrue(t is TestException)
+                    }
+                })
+                launch {
+                    // BARRIER #3 -- cancel subscription
+                    barrier.await()
+                    sub!!.cancel()
+                }
+                // BARRIER #2 -- parent completes
+                barrier.await()
+                Unit
+            }
+            // BARRIE #4 - go 1-3 together
+            barrier.await()
+            // Make sure exception is not lost, but incorporated into parent
+            val result = kotlin.runCatching { parent.await() }
+            assertTrue(result.exceptionOrNull() is TestException)
+            // Make sure unhandled exception handler was not invoked
+            assertNull(unhandled)
+        }
+    }
+
+    private class TestException : Exception()
+}

--- a/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
@@ -12,7 +12,7 @@ import org.reactivestreams.*
 
 class PublishTest : TestBase() {
     @Test
-    fun testBasicEmpty() = runBlocking {
+    fun testBasicEmpty() = runTest {
         expect(1)
         val publisher = publish<Int> {
             expect(5)
@@ -30,7 +30,7 @@ class PublishTest : TestBase() {
     }
 
     @Test
-    fun testBasicSingle() = runBlocking {
+    fun testBasicSingle() = runTest {
         expect(1)
         val publisher = publish {
             expect(5)
@@ -56,7 +56,7 @@ class PublishTest : TestBase() {
     }
 
     @Test
-    fun testBasicError() = runBlocking<Unit> {
+    fun testBasicError() = runTest {
         expect(1)
         val publisher = publish<Int>(NonCancellable) {
             expect(5)

--- a/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
@@ -168,5 +168,45 @@ class PublishTest : TestBase() {
         expectUnreached()
     }
 
+    @Test
+    fun testOnNextError() = runTest {
+        expect(1)
+        val publisher = publish<String>(NonCancellable) {
+            expect(4)
+            try {
+                send("OK")
+            } catch(e: Throwable) {
+                expect(6)
+                assert(e is TestException)
+            }
+        }
+        expect(2)
+        val latch = CompletableDeferred<Unit>()
+        publisher.subscribe(object : Subscriber<String> {
+            override fun onComplete() {
+                expectUnreached()
+            }
+
+            override fun onSubscribe(s: Subscription) {
+                expect(3)
+                s.request(1)
+            }
+
+            override fun onNext(t: String) {
+                expect(5)
+                assertEquals("OK", t)
+                throw TestException()
+            }
+
+            override fun onError(t: Throwable) {
+                expect(7)
+                assert(t is TestException)
+                latch.complete(Unit)
+            }
+        })
+        latch.await()
+        finish(8)
+    }
+
     private class TestException : Exception()
 }

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherBackpressureTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherBackpressureTest.kt
@@ -21,7 +21,7 @@ class PublisherBackpressureTest : TestBase() {
             try {
                 send("C") // will suspend (no more requested)
             } finally {
-                expect(13)
+                expect(12)
             }
             expectUnreached()
         }
@@ -43,7 +43,7 @@ class PublisherBackpressureTest : TestBase() {
             }
 
             override fun onComplete() {
-                expect(11)
+                expectUnreached()
             }
 
             override fun onError(e: Throwable) {
@@ -53,9 +53,9 @@ class PublisherBackpressureTest : TestBase() {
         expect(4)
         yield() // yield to observable coroutine
         expect(10)
-        sub!!.cancel() // now unsubscribe -- shall cancel coroutine & immediately signal onComplete
-        expect(12)
-        yield() // shall perform finally in coroutine & report onComplete
-        finish(14)
+        sub!!.cancel() // now unsubscribe -- shall cancel coroutine (& do not signal)
+        expect(11)
+        yield() // shall perform finally in coroutine
+        finish(13)
     }
 }

--- a/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
@@ -5,205 +5,59 @@
 package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.runner.*
-import org.junit.runners.*
 import org.reactivestreams.*
 import org.reactivestreams.tck.*
+import org.testng.*
+import org.testng.annotations.*
 
-@RunWith(Parameterized::class)
-class ReactiveStreamTckTest(
-    private val dispatcher: Dispatcher
-) : PublisherVerification<Long>(TestEnvironment()) {
 
-    enum class Dispatcher(val dispatcher: CoroutineDispatcher)  {
-        DEFAULT(Dispatchers.Default),
-        UNCONFINED(Dispatchers.Unconfined)
+class ReactiveStreamTckTest {
+
+    @Factory(dataProvider = "dispatchers")
+    fun createTests(dispatcher: Dispatcher): Array<Any> {
+        return arrayOf(ReactiveStreamTckTestSuite(dispatcher))
     }
 
-    private val scope = CoroutineScope(dispatcher.dispatcher)
+    @DataProvider(name = "dispatchers")
+    public fun dispatchers(): Array<Array<Any>> = Dispatcher.values().map { arrayOf<Any>(it) }.toTypedArray()
 
-    companion object {
-        @Parameterized.Parameters(name = "{0}")
-        @JvmStatic
-        fun params(): Collection<Array<Any>> = Dispatcher.values().map { arrayOf<Any>(it) }
-    }
 
-    override fun createPublisher(elements: Long): Publisher<Long> =
-        scope.publish {
-            for (i in 1..elements) send(i)
+    public class ReactiveStreamTckTestSuite(
+        private val dispatcher: Dispatcher
+    ) : PublisherVerification<Long>(TestEnvironment()) {
+
+        private val scope = CoroutineScope(dispatcher.dispatcher + NonCancellable)
+
+        override fun createPublisher(elements: Long): Publisher<Long> =
+            scope.publish {
+                for (i in 1..elements) send(i)
+            }
+
+        override fun createFailedPublisher(): Publisher<Long> =
+            scope.publish {
+                throw TestException()
+            }
+
+        @Test
+        public override fun required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() {
+            // This test fails on default dispatcher because it retains a reference to the last task
+            // in the structure of  its GlobalQueue
+            // So we skip it with the default dispatcher.
+            // todo: remove it when CoroutinesScheduler is improved
+            if (dispatcher == Dispatcher.DEFAULT) return
+            super.required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber()
         }
 
-    override fun createFailedPublisher(): Publisher<Long> =
-        scope.publish {
-            throw TestException()
+        @Test
+        public override fun optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() {
+            throw SkipException("Skipped")
         }
 
-    @Before
-    override fun setUp() {
-        super.setUp()
+        class TestException : Exception()
     }
+}
 
-    @Test
-    override fun required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() {
-        super.required_spec306_afterSubscriptionIsCancelledRequestMustBeNops()
-    }
-
-    @Test
-    override fun required_spec303_mustNotAllowUnboundedRecursion() {
-        super.required_spec303_mustNotAllowUnboundedRecursion()
-    }
-
-    @Test
-    override fun required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() {
-        super.required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled()
-    }
-
-    @Test
-    override fun required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe() {
-        super.required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe()
-    }
-
-    @Test
-    override fun required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() {
-        super.required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe()
-    }
-
-    @Test
-    override fun required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() {
-        // This test fails on default dispatcher because it retains a reference to the last task
-        // in the structure of  its GlobalQueue
-        // So we skip it with the default dispatcher.
-        // todo: remove it when CoroutinesScheduler is improved
-        if (dispatcher == Dispatcher.DEFAULT) return
-        super.required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber()
-    }
-
-    @Test
-    override fun required_validate_boundedDepthOfOnNextAndRequestRecursion() {
-        super.required_validate_boundedDepthOfOnNextAndRequestRecursion()
-    }
-
-    @Test
-    override fun required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() {
-        super.required_spec317_mustSupportAPendingElementCountUpToLongMaxValue()
-    }
-
-    @Test
-    override fun required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() {
-        super.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue()
-    }
-
-    @Test
-    override fun required_validate_maxElementsFromPublisher() {
-        super.required_validate_maxElementsFromPublisher()
-    }
-
-    @Test
-    @Ignore // This OPTIONAL requirement is not implemented, which is fine
-    override fun optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() {
-        super.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete()
-    }
-
-    @Test
-    override fun required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() {
-        super.required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates()
-    }
-
-    @Test
-    override fun optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals() {
-        super.optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals()
-    }
-
-    @Test
-    override fun required_spec102_maySignalLessThanRequestedAndTerminateSubscription() {
-        super.required_spec102_maySignalLessThanRequestedAndTerminateSubscription()
-    }
-
-    @Test
-    override fun required_createPublisher3MustProduceAStreamOfExactly3Elements() {
-        super.required_createPublisher3MustProduceAStreamOfExactly3Elements()
-    }
-
-    @Test
-    override fun optional_spec111_maySupportMultiSubscribe() {
-        super.optional_spec111_maySupportMultiSubscribe()
-    }
-
-    @Test
-    override fun stochastic_spec103_mustSignalOnMethodsSequentially() {
-        super.stochastic_spec103_mustSignalOnMethodsSequentially()
-    }
-
-    @Test
-    override fun required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops() {
-        super.required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops()
-    }
-
-    @Test
-    override fun required_createPublisher1MustProduceAStreamOfExactly1Element() {
-        super.required_createPublisher1MustProduceAStreamOfExactly1Element()
-    }
-
-    @Test
-    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() {
-        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne()
-    }
-
-    @Test
-    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() {
-        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront()
-    }
-
-    @Test
-    override fun required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() {
-        super.required_spec309_requestNegativeNumberMustSignalIllegalArgumentException()
-    }
-
-    @Test
-    override fun required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() {
-        super.required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling()
-    }
-
-    @Test
-    override fun required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue() {
-        super.required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue()
-    }
-
-    @Test
-    override fun optional_spec104_mustSignalOnErrorWhenFails() {
-        super.optional_spec104_mustSignalOnErrorWhenFails()
-    }
-
-    @Test
-    override fun required_spec309_requestZeroMustSignalIllegalArgumentException() {
-        super.required_spec309_requestZeroMustSignalIllegalArgumentException()
-    }
-
-    @Test
-    override fun optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage() {
-        super.optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage()
-    }
-
-    @Test
-    override fun required_spec109_subscribeThrowNPEOnNullSubscriber() {
-        super.required_spec109_subscribeThrowNPEOnNullSubscriber()
-    }
-
-    @Test
-    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() {
-        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected()
-    }
-
-    @Test
-    override fun required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements() {
-        super.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements()
-    }
-
-    @Test
-    override fun required_spec109_mustIssueOnSubscribeForNonNullSubscriber() {
-        super.required_spec109_mustIssueOnSubscribeForNonNullSubscriber()
-    }
-
-    class TestException : Exception()
+enum class Dispatcher(val dispatcher: CoroutineDispatcher) {
+    DEFAULT(Dispatchers.Default),
+    UNCONFINED(Dispatchers.Unconfined)
 }

--- a/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.reactive
+
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.runner.*
+import org.junit.runners.*
+import org.reactivestreams.*
+import org.reactivestreams.tck.*
+
+@RunWith(Parameterized::class)
+class ReactiveStreamTckTest(
+    private val dispatcher: Dispatcher
+) : PublisherVerification<Long>(TestEnvironment()) {
+
+    enum class Dispatcher(val dispatcher: CoroutineDispatcher)  {
+        DEFAULT(Dispatchers.Default),
+        UNCONFINED(Dispatchers.Unconfined)
+    }
+
+    private val scope = CoroutineScope(dispatcher.dispatcher)
+
+    companion object {
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun params(): Collection<Array<Any>> = Dispatcher.values().map { arrayOf<Any>(it) }
+    }
+
+    override fun createPublisher(elements: Long): Publisher<Long> =
+        scope.publish {
+            for (i in 1..elements) send(i)
+        }
+
+    override fun createFailedPublisher(): Publisher<Long> =
+        scope.publish {
+            throw TestException()
+        }
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+    }
+
+    @Test
+    override fun required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() {
+        super.required_spec306_afterSubscriptionIsCancelledRequestMustBeNops()
+    }
+
+    @Test
+    override fun required_spec303_mustNotAllowUnboundedRecursion() {
+        super.required_spec303_mustNotAllowUnboundedRecursion()
+    }
+
+    @Test
+    override fun required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() {
+        super.required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled()
+    }
+
+    @Test
+    override fun required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe() {
+        super.required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe()
+    }
+
+    @Test
+    override fun required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() {
+        super.required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe()
+    }
+
+    @Test
+    override fun required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() {
+        // This test fails on default dispatcher because it retains a reference to the last task
+        // in the structure of  its GlobalQueue
+        // So we skip it with the default dispatcher.
+        // todo: remove it when CoroutinesScheduler is improved
+        if (dispatcher == Dispatcher.DEFAULT) return
+        super.required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber()
+    }
+
+    @Test
+    override fun required_validate_boundedDepthOfOnNextAndRequestRecursion() {
+        super.required_validate_boundedDepthOfOnNextAndRequestRecursion()
+    }
+
+    @Test
+    override fun required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() {
+        super.required_spec317_mustSupportAPendingElementCountUpToLongMaxValue()
+    }
+
+    @Test
+    override fun required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() {
+        super.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue()
+    }
+
+    @Test
+    override fun required_validate_maxElementsFromPublisher() {
+        super.required_validate_maxElementsFromPublisher()
+    }
+
+    @Test
+    @Ignore // This OPTIONAL requirement is not implemented, which is fine
+    override fun optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() {
+        super.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete()
+    }
+
+    @Test
+    override fun required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() {
+        super.required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates()
+    }
+
+    @Test
+    override fun optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals() {
+        super.optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals()
+    }
+
+    @Test
+    override fun required_spec102_maySignalLessThanRequestedAndTerminateSubscription() {
+        super.required_spec102_maySignalLessThanRequestedAndTerminateSubscription()
+    }
+
+    @Test
+    override fun required_createPublisher3MustProduceAStreamOfExactly3Elements() {
+        super.required_createPublisher3MustProduceAStreamOfExactly3Elements()
+    }
+
+    @Test
+    override fun optional_spec111_maySupportMultiSubscribe() {
+        super.optional_spec111_maySupportMultiSubscribe()
+    }
+
+    @Test
+    override fun stochastic_spec103_mustSignalOnMethodsSequentially() {
+        super.stochastic_spec103_mustSignalOnMethodsSequentially()
+    }
+
+    @Test
+    override fun required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops() {
+        super.required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops()
+    }
+
+    @Test
+    override fun required_createPublisher1MustProduceAStreamOfExactly1Element() {
+        super.required_createPublisher1MustProduceAStreamOfExactly1Element()
+    }
+
+    @Test
+    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne()
+    }
+
+    @Test
+    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront()
+    }
+
+    @Test
+    override fun required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() {
+        super.required_spec309_requestNegativeNumberMustSignalIllegalArgumentException()
+    }
+
+    @Test
+    override fun required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() {
+        super.required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling()
+    }
+
+    @Test
+    override fun required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue() {
+        super.required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue()
+    }
+
+    @Test
+    override fun optional_spec104_mustSignalOnErrorWhenFails() {
+        super.optional_spec104_mustSignalOnErrorWhenFails()
+    }
+
+    @Test
+    override fun required_spec309_requestZeroMustSignalIllegalArgumentException() {
+        super.required_spec309_requestZeroMustSignalIllegalArgumentException()
+    }
+
+    @Test
+    override fun optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage() {
+        super.optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage()
+    }
+
+    @Test
+    override fun required_spec109_subscribeThrowNPEOnNullSubscriber() {
+        super.required_spec109_subscribeThrowNPEOnNullSubscriber()
+    }
+
+    @Test
+    override fun optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected()
+    }
+
+    @Test
+    override fun required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements() {
+        super.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements()
+    }
+
+    @Test
+    override fun required_spec109_mustIssueOnSubscribeForNonNullSubscriber() {
+        super.required_spec109_mustIssueOnSubscribeForNonNullSubscriber()
+    }
+
+    class TestException : Exception()
+}


### PR DESCRIPTION
* Throw NPE on null subscriber
* Throw IAE when requested n <= 0 elements
* Do not sent any notification after cancel()