### PR TITLE
New integration: AndroidX Lifecycle

### DIFF
--- a/binary-compatibility-validator/build.gradle
+++ b/binary-compatibility-validator/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testArtifacts project(':kotlinx-coroutines-jdk8')
     testArtifacts project(':kotlinx-coroutines-slf4j')
     testArtifacts project(path: ':kotlinx-coroutines-play-services', configuration: 'default')
+    testArtifacts project(path: ':kotlinx-coroutines-androidx-lifecycle', configuration: 'default')
 
     testArtifacts project(':kotlinx-coroutines-android')
     testArtifacts project(':kotlinx-coroutines-javafx')

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-androidx-lifecycle.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-androidx-lifecycle.txt
@@ -1,9 +1,12 @@
+public final class kotlinx/coroutines/androidx/lifecycle/LifecycleDefaultScopesKt {
+	public static final fun getCoroutineScope (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getCoroutineScope (Landroidx/lifecycle/LifecycleOwner;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getJob (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/Job;
+}
+
 public final class kotlinx/coroutines/androidx/lifecycle/LifecycleKt {
 	public static final fun createJob (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;)Lkotlinx/coroutines/Job;
 	public static synthetic fun createJob$default (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun createScope (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun getCoroutineScope (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun getCoroutineScope (Landroidx/lifecycle/LifecycleOwner;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun getJob (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/Job;
 }
 

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-androidx-lifecycle.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-androidx-lifecycle.txt
@@ -1,0 +1,9 @@
+public final class kotlinx/coroutines/androidx/lifecycle/LifecycleKt {
+	public static final fun createJob (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;)Lkotlinx/coroutines/Job;
+	public static synthetic fun createJob$default (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
+	public static final fun createScope (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getCoroutineScope (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getCoroutineScope (Landroidx/lifecycle/LifecycleOwner;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getJob (Landroidx/lifecycle/Lifecycle;)Lkotlinx/coroutines/Job;
+}
+

--- a/integration/README.md
+++ b/integration/README.md
@@ -8,7 +8,8 @@ Module name below corresponds to the artifact name in Maven/Gradle.
 * [kotlinx-coroutines-jdk8](kotlinx-coroutines-jdk8/README.md) -- integration with JDK8 `CompletableFuture` (Android API level 24).
 * [kotlinx-coroutines-guava](kotlinx-coroutines-guava/README.md) -- integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained).
 * [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j/README.md) -- integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html).
-* [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) -- integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks). |
+* [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) -- integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks).
+* [kotlinx-coroutines-androidx-lifecycle](kotlinx-coroutines-androidx-lifecycle) -- integration with AndroidX [Lifecycle](https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle) and [LifecycleOwner](https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleOwner).
 
 ## Contributing
 

--- a/integration/kotlinx-coroutines-androidx-lifecycle/README.md
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/README.md
@@ -1,0 +1,59 @@
+# Module kotlinx-coroutines-androidx-lifecycle
+
+Integration with AndroidX [Lifecycle](
+https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle
+) and [LifecycleOwner](
+https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleOwner
+).
+
+Extension properties:
+
+| **Name** | **Description**
+| -------- | ---------------
+| [Lifecycle.coroutineScope][lifecycleScope] | A scope that dispatches on Android Main thread and is active until the Lifecycle is destroyed.
+| [LifecycleOwner.coroutineScope][lifecycleOwnerScope] | A scope that dispatches on Android Main thread and is active until the LifecycleOwner is destroyed.
+| [Lifecycle.job][lifecycleJob] | A job that is cancelled when the Lifecycle is destroyed.
+
+Extension functions:
+
+| **Name** | **Description**
+| -------- | ---------------
+| [Lifecycle.createJob][lifecycleCreateJob] | A job that is active while the state is at least the passed one.
+| [Lifecycle.createScope][lifecycleCreateScope] | A scope that dispatches on Android Main thread and is active while the state is at least the passed one.
+
+## Example
+
+```kotlin
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycle.coroutineScope.launch {
+            someSuspendFunction()
+            someOtherSuspendFunction()
+            someCancellableSuspendFunction()
+        }
+    }
+    
+    override fun onStart() {
+        super.onStart()
+        val startedScope = lifecycle.createScope(activeWhile = Lifecycle.State.STARTED)
+        startedScope.launch {
+            aCancellableSuspendFunction()
+            yetAnotherCancellableSuspendFunction()
+        }
+        startedScope.aMethodThatWillLaunchSomeCoroutines()
+    }
+}
+```
+
+# Package kotlinx.coroutines.androidx.lifecycle
+
+Integration with AndroidX [Lifecycle](https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle)
+and [LifecycleOwner](https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleOwner).
+
+<!--- MODULE kotlinx-coroutines-core -->
+<!--- INDEX kotlinx.coroutines -->
+<!--- MODULE kotlinx-coroutines-androidx-lifecycle -->
+<!--- INDEX kotlinx.coroutines.androidx.lifecycle -->
+<!--- END -->

--- a/integration/kotlinx-coroutines-androidx-lifecycle/build.gradle
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/build.gradle
@@ -1,0 +1,92 @@
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+ext.androidx_lifecycle_version = '2.0.0'
+
+repositories {
+    google()
+}
+
+def attr = Attribute.of("artifactType", String.class)
+configurations {
+    aar {
+        attributes { attribute(attr, ArtifactTypeDefinition.JAR_TYPE) }
+        sourceSets.main.compileClasspath += it
+        sourceSets.test.compileClasspath += it
+        sourceSets.test.runtimeClasspath += it
+    }
+    aarTest {
+        attributes { attribute(attr, ArtifactTypeDefinition.JAR_TYPE) }
+        sourceSets.test.compileClasspath += it
+        sourceSets.test.runtimeClasspath += it
+    }
+}
+
+sourceSets {
+    test {
+        resources.srcDirs = ["test/resources"]
+    }
+}
+
+dependencies {
+    registerTransform {
+        from.attribute(attr, "aar")
+        to.attribute(attr, "jar")
+        artifactTransform(ExtractJars.class)
+    }
+    aar("androidx.lifecycle:lifecycle-common:$androidx_lifecycle_version")
+    aarTest("androidx.lifecycle:lifecycle-runtime:$androidx_lifecycle_version")
+    api project(":kotlinx-coroutines-android")
+}
+
+tasks.withType(dokka.getClass()) {
+    externalDocumentationLink {
+        url = new URL("https://developer.android.com/reference/androidx/")
+    }
+}
+
+class ExtractJars extends ArtifactTransform {
+    @Override
+    List<File> transform(File input) {
+        unzip(input)
+
+        List<File> jars = new ArrayList<>()
+        outputDirectory.traverse(nameFilter: ~/.*\.jar/) { jars += it }
+
+        return jars
+    }
+
+    private void unzip(File zipFile) {
+        ZipFile zip
+        try {
+            zip = new ZipFile(zipFile)
+            for (entry in zip.entries()) {
+                unzipEntryTo(zip, entry)
+            }
+        } finally {
+            if (zip != null) zip.close()
+        }
+    }
+
+    private void unzipEntryTo(ZipFile zip, ZipEntry entry) {
+        File output = new File(outputDirectory, entry.name)
+        if (entry.isDirectory()) {
+            output.mkdirs()
+        } else {
+            InputStream stream
+            try {
+                stream = zip.getInputStream(entry)
+                Files.copy(stream, output.toPath())
+            } catch (NoSuchFileException ignored) {
+            } finally {
+                if (stream != null) stream.close()
+            }
+        }
+    }
+}

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
@@ -8,31 +8,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import java.util.concurrent.ConcurrentHashMap
-
-/**
- * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that is cancelled when
- * the [Lifecycle] reaches [Lifecycle.State.DESTROYED] state.
- *
- * Note that this value is cached until the Lifecycle reaches the destroyed state.
- */
-val Lifecycle.coroutineScope: CoroutineScope
-    get() = lifecycleCoroutineScopes[this] ?: job.let { job ->
-        val newScope = CoroutineScope(job + Dispatchers.Main)
-        if (job.isActive) {
-            lifecycleCoroutineScopes[this] = newScope
-            job.invokeOnCompletion { _ -> lifecycleCoroutineScopes -= this }
-        }
-        newScope
-    }
-
-/**
- * Calls [Lifecycle.coroutineScope] for the [Lifecycle] of this [LifecycleOwner].
- *
- * This is an inline property, just there for convenient usage from any [LifecycleOwner],
- * like FragmentActivity, AppCompatActivity, Fragment and LifecycleService.
- */
-inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
 
 /**
  * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that will be cancelled as
@@ -45,22 +20,6 @@ inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
 fun Lifecycle.createScope(activeWhile: Lifecycle.State): CoroutineScope {
     return CoroutineScope(createJob(activeWhile) + Dispatchers.Main)
 }
-
-/**
- * Returns a [SupervisorJob] that will be cancelled as soon as the [Lifecycle] reaches
- * [Lifecycle.State.DESTROYED] state.
- *
- * Note that this value is cached until the Lifecycle reaches the destroyed state.
- *
- * You can use this job for custom [CoroutineScope]s, or as a parent [Job].
- */
-val Lifecycle.job: Job
-    get() = lifecycleJobs[this] ?: createJob().also {
-        if (it.isActive) {
-            lifecycleJobs[this] = it
-            it.invokeOnCompletion { _ -> lifecycleJobs -= this }
-        }
-    }
 
 /**
  * Creates a [SupervisorJob] that will be cancelled as soon as this [Lifecycle]
@@ -86,6 +45,3 @@ fun Lifecycle.createJob(activeWhile: Lifecycle.State = INITIALIZED): Job {
         })
     }
 }
-
-private val lifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
-private val lifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
@@ -2,7 +2,6 @@ package kotlinx.coroutines.androidx.lifecycle
 
 import androidx.lifecycle.GenericLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.Lifecycle.State.DESTROYED
 import androidx.lifecycle.Lifecycle.State.INITIALIZED
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +43,6 @@ inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
  * already cancelled scope.
  */
 fun Lifecycle.createScope(activeWhile: Lifecycle.State): CoroutineScope {
-    if (activeWhile == DESTROYED) return coroutineScope
     return CoroutineScope(createJob(activeWhile) + Dispatchers.Main)
 }
 

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
@@ -1,0 +1,92 @@
+package kotlinx.coroutines.androidx.lifecycle
+
+import androidx.lifecycle.GenericLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.Lifecycle.State.INITIALIZED
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that is cancelled when
+ * the [Lifecycle] reaches [Lifecycle.State.DESTROYED] state.
+ *
+ * Note that this value is cached until the Lifecycle reaches the destroyed state.
+ */
+val Lifecycle.coroutineScope: CoroutineScope
+    get() = lifecycleCoroutineScopes[this] ?: job.let { job ->
+        val newScope = CoroutineScope(job + Dispatchers.Main)
+        if (job.isActive) {
+            lifecycleCoroutineScopes[this] = newScope
+            job.invokeOnCompletion { _ -> lifecycleCoroutineScopes -= this }
+        }
+        newScope
+    }
+
+/**
+ * Calls [Lifecycle.coroutineScope] for the [Lifecycle] of this [LifecycleOwner].
+ *
+ * This is an inline property, just there for convenient usage from any [LifecycleOwner],
+ * like FragmentActivity, AppCompatActivity, Fragment and LifecycleService.
+ */
+inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
+
+/**
+ * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that will be cancelled as
+ * soon as this [Lifecycle] [currentState][Lifecycle.getCurrentState] is no longer
+ * [at least][Lifecycle.State.isAtLeast] the passed [activeWhile] state.
+ *
+ * **Beware**: if the current state is lower than the passed [activeWhile] state, you'll get an
+ * already cancelled scope.
+ */
+fun Lifecycle.createScope(activeWhile: Lifecycle.State): CoroutineScope {
+    if (activeWhile == DESTROYED) return coroutineScope
+    return CoroutineScope(createJob(activeWhile) + Dispatchers.Main)
+}
+
+/**
+ * Returns a [Job] that will be cancelled as soon as the [Lifecycle] reaches
+ * [Lifecycle.State.DESTROYED] state.
+ *
+ * Note that this value is cached until the Lifecycle reaches the destroyed state.
+ *
+ * You can use this job for custom [CoroutineScope]s, or as a parent [Job].
+ */
+val Lifecycle.job: Job
+    get() = lifecycleJobs[this] ?: createJob().also {
+        if (it.isActive) {
+            lifecycleJobs[this] = it
+            it.invokeOnCompletion { _ -> lifecycleJobs -= this }
+        }
+    }
+
+/**
+ * Creates a [Job] that will be cancelled as soon as this [Lifecycle]
+ * [currentState][Lifecycle.getCurrentState] is no longer [at least][Lifecycle.State.isAtLeast] the
+ * passed [activeWhile] state.
+ *
+ * **Beware**: if the current state is lower than the passed [activeWhile] state, you'll get an
+ * already cancelled job.
+ */
+fun Lifecycle.createJob(activeWhile: Lifecycle.State = INITIALIZED): Job {
+    require(activeWhile != Lifecycle.State.DESTROYED) {
+        "DESTROYED is a terminal state that is forbidden for createJob(…), to avoid leaks."
+    }
+    return Job().also { job ->
+        if (!currentState.isAtLeast(activeWhile)) job.cancel()
+        else addObserver(object : GenericLifecycleObserver {
+            override fun onStateChanged(source: LifecycleOwner?, event: Lifecycle.Event) {
+                if (!currentState.isAtLeast(activeWhile)) {
+                    removeObserver(this)
+                    job.cancel()
+                }
+            }
+        })
+    }
+}
+
+private val lifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
+private val lifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/Lifecycle.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -48,7 +49,7 @@ fun Lifecycle.createScope(activeWhile: Lifecycle.State): CoroutineScope {
 }
 
 /**
- * Returns a [Job] that will be cancelled as soon as the [Lifecycle] reaches
+ * Returns a [SupervisorJob] that will be cancelled as soon as the [Lifecycle] reaches
  * [Lifecycle.State.DESTROYED] state.
  *
  * Note that this value is cached until the Lifecycle reaches the destroyed state.
@@ -64,7 +65,7 @@ val Lifecycle.job: Job
     }
 
 /**
- * Creates a [Job] that will be cancelled as soon as this [Lifecycle]
+ * Creates a [SupervisorJob] that will be cancelled as soon as this [Lifecycle]
  * [currentState][Lifecycle.getCurrentState] is no longer [at least][Lifecycle.State.isAtLeast] the
  * passed [activeWhile] state.
  *
@@ -75,7 +76,7 @@ fun Lifecycle.createJob(activeWhile: Lifecycle.State = INITIALIZED): Job {
     require(activeWhile != Lifecycle.State.DESTROYED) {
         "DESTROYED is a terminal state that is forbidden for createJob(…), to avoid leaks."
     }
-    return Job().also { job ->
+    return SupervisorJob().also { job ->
         if (!currentState.isAtLeast(activeWhile)) job.cancel()
         else addObserver(object : GenericLifecycleObserver {
             override fun onStateChanged(source: LifecycleOwner?, event: Lifecycle.Event) {

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
@@ -16,11 +16,11 @@ import java.util.concurrent.ConcurrentHashMap
  * Note that this value is cached until the Lifecycle reaches the destroyed state.
  */
 val Lifecycle.coroutineScope: CoroutineScope
-    get() = lifecycleCoroutineScopes[this] ?: job.let { job ->
+    get() = cachedLifecycleCoroutineScopes[this] ?: job.let { job ->
         val newScope = CoroutineScope(job + Dispatchers.Main)
         if (job.isActive) {
-            lifecycleCoroutineScopes[this] = newScope
-            job.invokeOnCompletion { _ -> lifecycleCoroutineScopes -= this }
+            cachedLifecycleCoroutineScopes[this] = newScope
+            job.invokeOnCompletion { _ -> cachedLifecycleCoroutineScopes -= this }
         }
         newScope
     }
@@ -42,12 +42,12 @@ inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
  * You can use this job for custom [CoroutineScope]s, or as a parent [Job].
  */
 val Lifecycle.job: Job
-    get() = lifecycleJobs[this] ?: createJob().also {
+    get() = cachedLifecycleJobs[this] ?: createJob().also {
         if (it.isActive) {
-            lifecycleJobs[this] = it
-            it.invokeOnCompletion { _ -> lifecycleJobs -= this }
+            cachedLifecycleJobs[this] = it
+            it.invokeOnCompletion { _ -> cachedLifecycleJobs -= this }
         }
     }
 
-private val lifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
-private val lifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()
+private val cachedLifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
+private val cachedLifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import java.util.concurrent.ConcurrentHashMap
-
 
 /**
  * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that is cancelled when
@@ -49,5 +47,5 @@ val Lifecycle.job: Job
         }
     }
 
-private val cachedLifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
-private val cachedLifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()
+private val cachedLifecycleJobs = mutableMapOf<Lifecycle, Job>()
+private val cachedLifecycleCoroutineScopes = mutableMapOf<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that is cancelled when
@@ -47,5 +48,5 @@ val Lifecycle.job: Job
         }
     }
 
-private val cachedLifecycleJobs = mutableMapOf<Lifecycle, Job>()
-private val cachedLifecycleCoroutineScopes = mutableMapOf<Lifecycle, CoroutineScope>()
+private val cachedLifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
+private val cachedLifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/src/LifecycleDefaultScopes.kt
@@ -1,0 +1,53 @@
+package kotlinx.coroutines.androidx.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import java.util.concurrent.ConcurrentHashMap
+
+
+/**
+ * Returns a [CoroutineScope] that uses [Dispatchers.Main] by default, and that is cancelled when
+ * the [Lifecycle] reaches [Lifecycle.State.DESTROYED] state.
+ *
+ * Note that this value is cached until the Lifecycle reaches the destroyed state.
+ */
+val Lifecycle.coroutineScope: CoroutineScope
+    get() = lifecycleCoroutineScopes[this] ?: job.let { job ->
+        val newScope = CoroutineScope(job + Dispatchers.Main)
+        if (job.isActive) {
+            lifecycleCoroutineScopes[this] = newScope
+            job.invokeOnCompletion { _ -> lifecycleCoroutineScopes -= this }
+        }
+        newScope
+    }
+
+/**
+ * Calls [Lifecycle.coroutineScope] for the [Lifecycle] of this [LifecycleOwner].
+ *
+ * This is an inline property, just there for convenient usage from any [LifecycleOwner],
+ * like FragmentActivity, AppCompatActivity, Fragment and LifecycleService.
+ */
+inline val LifecycleOwner.coroutineScope get() = lifecycle.coroutineScope
+
+/**
+ * Returns a [SupervisorJob] that will be cancelled as soon as the [Lifecycle] reaches
+ * [Lifecycle.State.DESTROYED] state.
+ *
+ * Note that this value is cached until the Lifecycle reaches the destroyed state.
+ *
+ * You can use this job for custom [CoroutineScope]s, or as a parent [Job].
+ */
+val Lifecycle.job: Job
+    get() = lifecycleJobs[this] ?: createJob().also {
+        if (it.isActive) {
+            lifecycleJobs[this] = it
+            it.invokeOnCompletion { _ -> lifecycleJobs -= this }
+        }
+    }
+
+private val lifecycleJobs = ConcurrentHashMap<Lifecycle, Job>()
+private val lifecycleCoroutineScopes = ConcurrentHashMap<Lifecycle, CoroutineScope>()

--- a/integration/kotlinx-coroutines-androidx-lifecycle/test/LifecycleTest.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/test/LifecycleTest.kt
@@ -1,0 +1,127 @@
+package kotlinx.coroutines.androidx.lifecycle
+
+import androidx.lifecycle.GenericLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import kotlinx.coroutines.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlin.test.*
+
+class LifecycleTest : TestBase() {
+
+    @Test
+    fun `Test lifecycle default scope uses default job`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        val lifecycleJob = lifecycle.job
+        val lifecycleScopeJob = lifecycle.coroutineScope.coroutineContext[Job]
+        assertSame(lifecycleJob, lifecycleScopeJob)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `Test lifecycle job is cached`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        assertSame(lifecycle.job, lifecycle.job)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `Test lifecycle on destroy cancels job`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        val job = lifecycle.job
+        assertTrue(job.isActive)
+        assertFalse(job.isCancelled)
+        lifecycle.markState(Lifecycle.State.STARTED)
+        lifecycle.markState(Lifecycle.State.RESUMED)
+        assertTrue(job.isActive)
+        assertFalse(job.isCancelled)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+        suspendCoroutine<Unit> { c ->
+            job.invokeOnCompletion { c.resume(Unit) }
+        }
+        assertTrue(job.isCancelled)
+        assertFalse(job.isActive)
+    }
+
+    @Test
+    fun `Test already destroyed lifecycle makes cancelled job`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+        val job = lifecycle.job
+        assertFalse(job.isActive)
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun `Test lifecycle owner scope is lifecycle scope`() = runTest {
+        val lifecycleOwner = TestLifecycleOwner()
+        val lifecycle = lifecycleOwner.lifecycle
+        assertSame(lifecycle.coroutineScope, lifecycleOwner.coroutineScope)
+    }
+
+    @Test
+    fun `Test scope is not active after destroy`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        lifecycle.markState(Lifecycle.State.STARTED)
+        val scope = lifecycle.createScope(Lifecycle.State.STARTED)
+        expect(1)
+        val testJob = scope.launch {
+            try {
+                expect(2)
+                delay(Long.MAX_VALUE)
+                expectUnreached()
+            } catch (e: CancellationException) {
+                expect(3)
+                throw e
+            } finally {
+                expect(4)
+            }
+        }
+        lifecycle.markState(Lifecycle.State.CREATED)
+        testJob.join()
+        finish(5)
+        assertFalse(scope.isActive)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `Test observer is called after destroy`() = runTest {
+        val lifecycle = TestLifecycleOwner().lifecycle
+        lifecycle.markState(Lifecycle.State.CREATED)
+        val activeWhile = Lifecycle.State.INITIALIZED
+        val job = with(lifecycle) {
+            Job().also { job ->
+                addObserver(object : GenericLifecycleObserver {
+                    override fun onStateChanged(source: LifecycleOwner?, event: Lifecycle.Event) {
+                        if (!currentState.isAtLeast(activeWhile)) {
+                            removeObserver(this)
+                            job.cancel()
+                        }
+                    }
+                })
+            }
+        }
+        assertTrue(job.isActive)
+        assertFalse(job.isCancelled)
+        lifecycle.markState(Lifecycle.State.DESTROYED)
+        job.join()
+        assertFalse(job.isActive)
+        assertTrue(job.isCancelled)
+    }
+
+    @AfterTest
+    fun closeTestMainDispatcher() {
+        TestMainDispatcher.default.close()
+    }
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        override fun getLifecycle() = LifecycleRegistry(this)
+    }
+}

--- a/integration/kotlinx-coroutines-androidx-lifecycle/test/TestMainDispatcher.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/test/TestMainDispatcher.kt
@@ -1,0 +1,31 @@
+package kotlinx.coroutines.androidx.lifecycle
+
+import androidx.annotation.Keep
+import kotlinx.coroutines.MainCoroutineDispatcher
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.internal.MainDispatcherFactory
+import kotlinx.coroutines.newSingleThreadContext
+import kotlin.coroutines.CoroutineContext
+
+public class TestMainDispatcher : MainCoroutineDispatcher() {
+    private val singleThreadDispatcher = newSingleThreadContext("test-main-dispatcher")
+    override val immediate: MainCoroutineDispatcher
+        get() = TODO("Should not be needed for current tests as of 2018/10/15")
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        return singleThreadDispatcher.dispatch(context, block)
+    }
+
+    fun close() = default.singleThreadDispatcher.close()
+
+    companion object {
+        val default by lazy { TestMainDispatcher() }
+    }
+}
+
+
+@Keep
+internal class TestAndroidDispatcherFactory : MainDispatcherFactory {
+    override fun createDispatcher(): MainCoroutineDispatcher = TestMainDispatcher.default
+    override val loadPriority: Int get() = Int.MAX_VALUE
+}

--- a/integration/kotlinx-coroutines-androidx-lifecycle/test/android/util/Log.kt
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/test/android/util/Log.kt
@@ -1,0 +1,14 @@
+package android.util
+
+import androidx.lifecycle.LifecycleRegistry
+
+@Suppress("unused")
+class Log {
+    companion object {
+        /**
+         * Mocks Android Log method called in [LifecycleRegistry.sync].
+         */
+        @JvmStatic
+        fun w(tag: String, message: String): Int = 0
+    }
+}

--- a/integration/kotlinx-coroutines-androidx-lifecycle/test/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
+++ b/integration/kotlinx-coroutines-androidx-lifecycle/test/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
@@ -1,0 +1,1 @@
+kotlinx.coroutines.androidx.lifecycle.TestAndroidDispatcherFactory

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ module('integration/kotlinx-coroutines-guava')
 module('integration/kotlinx-coroutines-jdk8')
 module('integration/kotlinx-coroutines-slf4j')
 module('integration/kotlinx-coroutines-play-services')
+module('integration/kotlinx-coroutines-androidx-lifecycle')
 
 module('reactive/kotlinx-coroutines-reactive')
 module('reactive/kotlinx-coroutines-reactor')

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -23,6 +23,7 @@ Library support for Kotlin coroutines. This reference is a companion to
 | [kotlinx-coroutines-guava](kotlinx-coroutines-guava)                 | Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) |
 | [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j)                 | Integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html) |
 | [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) | Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks) |
+| [kotlinx-coroutines-androidx-lifecycle](kotlinx-coroutines-androidx-lifecycle) | Integration with AndroidX [Lifecycle](https://developer.android.com/reference/kotlin/androidx/lifecycle/Lifecycle) and [LifecycleOwner](https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleOwner) |
 
 ## Examples
 


### PR DESCRIPTION
This PR replaces #726 which replaced #655.

Includes:

Job and CoroutineScope extensions for Lifecycle and LifecycleOwner
Transitive dependency to kotlinx-android artifact
Tests and test supporting code
Documentation
Entry in binary-compatibility-validator build.gradle file

Note that while binary compatibility text file was generated and is included in this PR, the related gradle task was still failing.

Also, the knit warns for this new module regarding dokka documentation and unresolved references. I don't know how to solve these, but the maintainers can edit this PR, and you're free to help.