### PR TITLE
Try to reflectively use public JavaFX API before PlatormImpl fallback…

### DIFF
--- a/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
+++ b/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
@@ -127,14 +127,10 @@ internal fun initPlatform() {
      * Additionally, ignore ISE("Toolkit already initialized") because since Java 9
      * consecutive calls to 'startup' throw it
      */
-    val platformJava9 = runCatching {
-        Class.forName("javafx.application.Platform")
-    }
-
-    val platformClass = if (platformJava9.isSuccess) {
-        platformJava9.getOrNull()!!
-    } else {
-        Class.forName("com.sun.javafx.application.PlatformImpl")
+    val platformClass = runCatching {
+        Class.forName("javafx.application.Platform") // Java 9+
+    }.getOrElse {
+        Class.forName("com.sun.javafx.application.PlatformImpl") // Fallback
     }
 
     try {

--- a/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
+++ b/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
@@ -10,6 +10,8 @@ import javafx.event.*
 import javafx.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
+import java.lang.IllegalStateException
+import java.lang.reflect.*
 import java.util.concurrent.*
 import kotlin.coroutines.*
 
@@ -114,9 +116,34 @@ private class PulseTimer : AnimationTimer() {
 }
 
 internal fun initPlatform() {
-    // Ad-hoc workaround for #443. Will be fixed with multi-release jar.
-    // If this code throws an exception (Java 9 + prohibited reflective access), initialize JavaFX directly
-    Class.forName("com.sun.javafx.application.PlatformImpl")
-        .getMethod("startup", java.lang.Runnable::class.java)
-        .invoke(null, java.lang.Runnable { })
+    /*
+     * Try to instantiate JavaFx platform in a way which works
+     * both on Java 8 and Java 11 and does not produce "illegal reflective access":
+     *
+     * 1) Try to invoke javafx.application.Platform.startup if this class is
+     *    present in a classpath (since Java 9 it is a separate dependency)
+     * 2) If it is not present, invoke plain old PlatformImpl.startup
+     *
+     * Additionally, ignore ISE("Toolkit already initialized") because since Java 9
+     * consecutive calls to 'startup' throw it
+     */
+    val platformJava9 = runCatching {
+        Class.forName("javafx.application.Platform")
+    }
+
+    val platformClass = if (platformJava9.isSuccess) {
+        platformJava9.getOrNull()!!
+    } else {
+        Class.forName("com.sun.javafx.application.PlatformImpl")
+    }
+
+    try {
+        platformClass.getMethod("startup", java.lang.Runnable::class.java)
+            .invoke(null, java.lang.Runnable { })
+    } catch (e: InvocationTargetException) {
+        val cause = e.cause
+        if (cause !is IllegalStateException || "Toolkit already initialized" != cause.message) {
+            throw e
+        }
+    }
 }

--- a/ui/kotlinx-coroutines-javafx/test/JavaFxTest.kt
+++ b/ui/kotlinx-coroutines-javafx/test/JavaFxTest.kt
@@ -11,7 +11,7 @@ import org.junit.*
 class JavaFxTest : TestBase() {
     @Before
     fun setup() {
-        ignoreLostThreads("JavaFX Application Thread", "Thread-", "QuantumRenderer-")
+        ignoreLostThreads("JavaFX Application Thread", "Thread-", "QuantumRenderer-", "InvokeLaterDispatcher")
     }
 
     @Test


### PR DESCRIPTION
…, ignore "Toolkit already initialized"

  * Fixes "illegal reflective access" warning on Java 9
  * Works on Java 8 and 11
  * Avoid conflicts with multiple calls to Platform.startup

Fixes #463