### PR TITLE
Fix: default dispatcher doesn't work with jsdom

### DIFF
--- a/gradle/test-mocha-js.gradle
+++ b/gradle/test-mocha-js.gradle
@@ -74,3 +74,25 @@ task testMochaChrome(type: NodeTask, dependsOn: prepareMochaChrome) {
 // todo: Commented out because mocha-headless-chrome does not work on TeamCity
 //test.dependsOn testMochaChrome
 
+// -- Testing with Mocha under jsdom
+
+task installDependenciesMochaJsdom(type: NpmTask, dependsOn: [npmInstall]) {
+    args = ['install',
+            "mocha@$mocha_version",
+            'jsdom',
+            'jsdom-global',
+            "source-map-support@$source_map_support_version",
+            '--no-save']
+    if (project.hasProperty("teamcity")) args += [
+            "mocha-teamcity-reporter@$mocha_teamcity_reporter_version"]
+}
+
+task testMochaJsdom(type: NodeTask, dependsOn: [compileTestKotlin2Js, installDependenciesMochaJsdom]) {
+    script = file("$node.nodeModulesDir/node_modules/mocha/bin/mocha")
+    args = [compileTestKotlin2Js.outputFile, '--require', 'source-map-support/register', '--require', 'jsdom-global/register']
+    if (project.hasProperty("teamcity")) args += ['--reporter', 'mocha-teamcity-reporter']
+    if (project.hasProperty("mochaTests")) args += ['--grep', "$mochaTests"]
+}
+
+test.dependsOn testMochaJsdom
+

--- a/js/kotlinx-coroutines-core-js/src/CoroutineContext.kt
+++ b/js/kotlinx-coroutines-core-js/src/CoroutineContext.kt
@@ -17,12 +17,23 @@ internal actual fun createDefaultDispatcher(): CoroutineDispatcher = when {
     // The check for ReactNative is based on https://github.com/facebook/react-native/commit/3c65e62183ce05893be0822da217cb803b121c61
     jsTypeOf(navigator) != UNDEFINED && navigator != null && navigator.product == "ReactNative" ->
         NodeDispatcher()
+    // Check if we are running under jsdom. WindowDispatcher doesn't work under jsdom because it accesses MessageEvent#source.
+    // It is not implemented in jsdom, see https://github.com/jsdom/jsdom/blob/master/Changelog.md
+    // "It's missing a few semantics, especially around origins, as well as MessageEvent source."
+    isJsdom() -> NodeDispatcher()
     // Check if we are in the browser and must use window.postMessage to avoid setTimeout throttling
     jsTypeOf(window) != UNDEFINED && window.asDynamic() != null && jsTypeOf(window.asDynamic().addEventListener) != UNDEFINED ->
         window.asCoroutineDispatcher()
     // Fallback to NodeDispatcher when browser environment is not detected
     else -> NodeDispatcher()
 }
+
+private fun isJsdom() = jsTypeOf(navigator) != UNDEFINED &&
+    navigator != null &&
+    navigator.userAgent != null &&
+    jsTypeOf(navigator.userAgent) != UNDEFINED &&
+    jsTypeOf(navigator.userAgent.match) != UNDEFINED &&
+    navigator.userAgent.match("\\bjsdom\\b")
 
 internal actual val DefaultDelay: Delay
     get() = Dispatchers.Default as Delay


### PR DESCRIPTION
I've noticed that coroutines don't work under [jsdom](https://github.com/jsdom/jsdom). The reason is described in the code. I think it's necessary to treat jsdom separately like ReactNative.