### PR TITLE
Wrap all Incomplete final state into box (and unbox it where necessar…

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/Builders.common.kt
+++ b/common/kotlinx-coroutines-core-common/src/Builders.common.kt
@@ -228,7 +228,7 @@ private class DispatchedCoroutine<in T>(
     fun getResult(): Any? {
         if (trySuspend()) return COROUTINE_SUSPENDED
         // otherwise, onCompletionInternal was already invoked & invoked tryResume, and the result is in the state
-        val state = this.state
+        val state = this.state.unboxState()
         if (state is CompletedExceptionally) throw state.cause
         @Suppress("UNCHECKED_CAST")
         return state as T

--- a/common/kotlinx-coroutines-core-common/src/JobSupport.kt
+++ b/common/kotlinx-coroutines-core-common/src/JobSupport.kt
@@ -1034,7 +1034,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
         private val job: JobSupport
     ) : CancellableContinuationImpl<T>(delegate, MODE_CANCELLABLE) {
         override fun getContinuationCancellationCause(parent: Job): Throwable {
-            val state = job.state.unboxState()
+            val state = job.state
             /*
              * When the job we are waiting for had already completely completed exceptionally or
              * is failing, we shall use its root/completion cause for await's result.
@@ -1059,7 +1059,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     public val isCompletedExceptionally: Boolean get() = state is CompletedExceptionally
 
     public fun getCompletionExceptionOrNull(): Throwable? {
-        val state = this.state.unboxState()
+        val state = this.state
         check(state !is Incomplete) { "This job has not completed yet" }
         return state.exceptionOrNull
     }
@@ -1068,10 +1068,10 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      * @suppress **This is unstable API and it is subject to change.**
      */
     internal fun getCompletedInternal(): Any? {
-        val state = this.state.unboxState()
+        val state = this.state
         check(state !is Incomplete) { "This job has not completed yet" }
         if (state is CompletedExceptionally) throw state.cause
-        return state
+        return state.unboxState()
     }
 
     /**
@@ -1080,11 +1080,11 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     internal suspend fun awaitInternal(): Any? {
         // fast-path -- check state (avoid extra object creation)
         while (true) { // lock-free loop on state
-            val state = this.state.unboxState()
+            val state = this.state
             if (state !is Incomplete) {
                 // already complete -- just return result
                 if (state is CompletedExceptionally) throw state.cause
-                return state
+                return state.unboxState()
 
             }
             if (startInternal(state) >= 0) break // break unless needs to retry
@@ -1116,10 +1116,12 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
             if (state !is Incomplete) {
                 // already complete -- select result
                 if (select.trySelect(null)) {
-                    if (state is CompletedExceptionally)
+                    if (state is CompletedExceptionally) {
                         select.resumeSelectCancellableWithException(state.cause)
-                    else
-                        block.startCoroutineUnintercepted(state as T, select.completion)
+                    }
+                    else {
+                        block.startCoroutineUnintercepted(state.unboxState() as T, select.completion)
+                    }
                 }
                 return
             }
@@ -1136,12 +1138,12 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      */
     @Suppress("UNCHECKED_CAST")
     internal fun <T, R> selectAwaitCompletion(select: SelectInstance<R>, block: suspend (T) -> R) {
-        val state = this.state.unboxState()
+        val state = this.state
         // Note: await is non-atomic (can be cancelled while dispatched)
         if (state is CompletedExceptionally)
             select.resumeSelectCancellableWithException(state.cause)
         else
-            block.startCoroutineCancellable(state as T, select.completion)
+            block.startCoroutineCancellable(state.unboxState() as T, select.completion)
     }
 }
 
@@ -1242,14 +1244,15 @@ private class ResumeAwaitOnCompletion<T>(
     private val continuation: AbstractContinuation<T>
 ) : JobNode<JobSupport>(job) {
     override fun invoke(cause: Throwable?) {
-        val state = job.state.unboxState()
+        val state = job.state
+        check(state !is Incomplete)
         if (state is CompletedExceptionally) {
             // Resume with exception in atomic way to preserve exception
             continuation.resumeWithExceptionMode(state.cause, MODE_ATOMIC_DEFAULT)
         } else {
             // Resuming with value in a cancellable way (AwaitContinuation is configured for this mode).
             @Suppress("UNCHECKED_CAST")
-            continuation.resume(state as T)
+            continuation.resume(state.unboxState() as T)
         }
     }
     override fun toString() = "ResumeAwaitOnCompletion[$continuation]"

--- a/common/kotlinx-coroutines-core-common/src/JobSupport.kt
+++ b/common/kotlinx-coroutines-core-common/src/JobSupport.kt
@@ -154,10 +154,10 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     }
 
     // ------------ state query ------------
-
     /**
      * Returns current state of this job.
-     * @suppress **This is unstable API and it is subject to change.**
+     * If final state of the job is [Incomplete], then it is boxed into [IncompleteStateBox]
+     * and should be [unboxed][unboxState] before returning to user code.
      */
     internal val state: Any? get() {
         _state.loop { state -> // helper loop on state (complete in-progress atomic operations)
@@ -192,7 +192,12 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     // Finalizes Finishing -> Completed (terminal state) transition.
     // ## IMPORTANT INVARIANT: Only one thread can be concurrently invoking this method.
     private fun tryFinalizeFinishingState(state: Finishing, proposedUpdate: Any?, mode: Int): Boolean {
-        require(proposedUpdate !is Incomplete) // only incomplete -> completed transition is allowed
+        /*
+         * Note: proposed state can be Incompleted, e.g.
+         * async {
+         *   smth.invokeOnCompletion {} // <- returns handle which implements Incomplete under the hood
+         * }
+         */
         require(this.state === state) // consistency check -- it cannot change
         require(!state.isSealed) // consistency check -- cannot be sealed yet
         require(state.isCompleting) // consistency check -- must be marked as completing
@@ -220,7 +225,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
             handleJobException(finalException)
         }
         // Then CAS to completed state -> it must succeed
-        require(_state.compareAndSet(state, finalState)) { "Unexpected state: ${_state.value}, expected: $state, update: $finalState" }
+        require(_state.compareAndSet(state, finalState.boxIncomplete())) { "Unexpected state: ${_state.value}, expected: $state, update: $finalState" }
         // And process all post-completion actions
         completeStateFinalization(state, finalState, mode, suppressed)
         return true
@@ -254,7 +259,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     private fun tryFinalizeSimpleState(state: Incomplete, update: Any?, mode: Int): Boolean {
         check(state is Empty || state is JobNode<*>) // only simple state without lists where children can concurrently add
         check(update !is CompletedExceptionally) // only for normal completion
-        if (!_state.compareAndSet(state, update)) return false
+        if (!_state.compareAndSet(state, update.boxIncomplete())) return false
         completeStateFinalization(state, update, mode, false)
         return true
     }
@@ -1029,7 +1034,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
         private val job: JobSupport
     ) : CancellableContinuationImpl<T>(delegate, MODE_CANCELLABLE) {
         override fun getContinuationCancellationCause(parent: Job): Throwable {
-            val state = job.state
+            val state = job.state.unboxState()
             /*
              * When the job we are waiting for had already completely completed exceptionally or
              * is failing, we shall use its root/completion cause for await's result.
@@ -1054,7 +1059,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     public val isCompletedExceptionally: Boolean get() = state is CompletedExceptionally
 
     public fun getCompletionExceptionOrNull(): Throwable? {
-        val state = this.state
+        val state = this.state.unboxState()
         check(state !is Incomplete) { "This job has not completed yet" }
         return state.exceptionOrNull
     }
@@ -1063,7 +1068,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      * @suppress **This is unstable API and it is subject to change.**
      */
     internal fun getCompletedInternal(): Any? {
-        val state = this.state
+        val state = this.state.unboxState()
         check(state !is Incomplete) { "This job has not completed yet" }
         if (state is CompletedExceptionally) throw state.cause
         return state
@@ -1075,7 +1080,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     internal suspend fun awaitInternal(): Any? {
         // fast-path -- check state (avoid extra object creation)
         while (true) { // lock-free loop on state
-            val state = this.state
+            val state = this.state.unboxState()
             if (state !is Incomplete) {
                 // already complete -- just return result
                 if (state is CompletedExceptionally) throw state.cause
@@ -1131,7 +1136,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      */
     @Suppress("UNCHECKED_CAST")
     internal fun <T, R> selectAwaitCompletion(select: SelectInstance<R>, block: suspend (T) -> R) {
-        val state = this.state
+        val state = this.state.unboxState()
         // Note: await is non-atomic (can be cancelled while dispatched)
         if (state is CompletedExceptionally)
             select.resumeSelectCancellableWithException(state.cause)
@@ -1139,6 +1144,13 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
             block.startCoroutineCancellable(state as T, select.completion)
     }
 }
+
+/*
+ * Class to represent object as the final state of the Job
+ */
+private class IncompleteStateBox(@JvmField val state: Incomplete)
+private fun Any?.boxIncomplete(): Any? = if (this is Incomplete) IncompleteStateBox(this) else this
+internal fun Any?.unboxState(): Any? = (this as? IncompleteStateBox)?.state ?: this
 
 // --------------- helper classes & constants for job implementation
 
@@ -1230,8 +1242,7 @@ private class ResumeAwaitOnCompletion<T>(
     private val continuation: AbstractContinuation<T>
 ) : JobNode<JobSupport>(job) {
     override fun invoke(cause: Throwable?) {
-        val state = job.state
-        check(state !is Incomplete)
+        val state = job.state.unboxState()
         if (state is CompletedExceptionally) {
             // Resume with exception in atomic way to preserve exception
             continuation.resumeWithExceptionMode(state.cause, MODE_ATOMIC_DEFAULT)

--- a/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
+++ b/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
@@ -123,7 +123,7 @@ private inline fun <T> AbstractCoroutine<T>.undispatchedResult(
     return when {
         result === COROUTINE_SUSPENDED -> COROUTINE_SUSPENDED
         makeCompletingOnce(result, MODE_IGNORE) -> {
-            val state = state.unboxState()
+            val state = state
             if (state is CompletedExceptionally) {
                 when {
                     shouldThrow(state.cause) -> throw state.cause
@@ -131,7 +131,7 @@ private inline fun <T> AbstractCoroutine<T>.undispatchedResult(
                     else -> result
                 }
             } else {
-                state
+                state.unboxState()
             }
         }
         else -> COROUTINE_SUSPENDED

--- a/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
+++ b/common/kotlinx-coroutines-core-common/src/intrinsics/Undispatched.kt
@@ -123,7 +123,7 @@ private inline fun <T> AbstractCoroutine<T>.undispatchedResult(
     return when {
         result === COROUTINE_SUSPENDED -> COROUTINE_SUSPENDED
         makeCompletingOnce(result, MODE_IGNORE) -> {
-            val state = state
+            val state = state.unboxState()
             if (state is CompletedExceptionally) {
                 when {
                     shouldThrow(state.cause) -> throw state.cause

--- a/common/kotlinx-coroutines-core-common/test/AsyncTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/AsyncTest.kt
@@ -2,7 +2,7 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED", "UNREACHABLE_CODE") // KT-21913
+@file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED", "UNREACHABLE_CODE", "USELESS_IS_CHECK") // KT-21913
 
 package kotlinx.coroutines
 
@@ -241,13 +241,30 @@ class AsyncTest : TestBase() {
 
     @Test
     fun testIncompleteAsyncState() = runTest {
-        val job = async {
+        val deferred = async {
             coroutineContext[Job]!!.invokeOnCompletion {  }
         }
 
-        job.await().dispose()
-        assertTrue(job.isCompleted)
-        assertFalse(job.isActive)
-        assertFalse(job.isCancelled)
+        deferred.await().dispose()
+        assertTrue(deferred.getCompleted() is DisposableHandle)
+        assertNull(deferred.getCompletionExceptionOrNull())
+        assertTrue(deferred.isCompleted)
+        assertFalse(deferred.isActive)
+        assertFalse(deferred.isCancelled)
     }
+
+    @Test
+    fun testIncompleteAsyncFastPath() = runTest {
+        val deferred = async(Dispatchers.Unconfined) {
+            coroutineContext[Job]!!.invokeOnCompletion {  }
+        }
+
+        deferred.await().dispose()
+        assertTrue(deferred.getCompleted() is DisposableHandle)
+        assertNull(deferred.getCompletionExceptionOrNull())
+        assertTrue(deferred.isCompleted)
+        assertFalse(deferred.isActive)
+        assertFalse(deferred.isCancelled)
+    }
+
 }

--- a/common/kotlinx-coroutines-core-common/test/AsyncTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/AsyncTest.kt
@@ -238,4 +238,16 @@ class AsyncTest : TestBase() {
             finish(3)
         }
     }
+
+    @Test
+    fun testIncompleteAsyncState() = runTest {
+        val job = async {
+            coroutineContext[Job]!!.invokeOnCompletion {  }
+        }
+
+        job.await().dispose()
+        assertTrue(job.isCompleted)
+        assertFalse(job.isActive)
+        assertFalse(job.isCancelled)
+    }
 }

--- a/common/kotlinx-coroutines-core-common/test/CompletableDeferredTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CompletableDeferredTest.kt
@@ -15,7 +15,28 @@ class CompletableDeferredTest : TestBase() {
         checkFresh(c)
     }
 
-    private fun checkFresh(c: CompletableDeferred<String>) {
+    @Test
+    fun testComplete() {
+        val c = CompletableDeferred<String>()
+        assertEquals(true, c.complete("OK"))
+        checkCompleteOk(c)
+        assertEquals("OK", c.getCompleted())
+        assertEquals(false, c.complete("OK"))
+        checkCompleteOk(c)
+        assertEquals("OK", c.getCompleted())
+    }
+
+    @Test
+    fun testCompleteWithIncompleteResult() {
+        val c = CompletableDeferred<DisposableHandle>()
+        assertEquals(true, c.complete(c.invokeOnCompletion {  }))
+        checkCompleteOk(c)
+        assertEquals(false,  c.complete(c.invokeOnCompletion {  }))
+        checkCompleteOk(c)
+        assertTrue(c.getCompleted() is Incomplete)
+    }
+
+    private fun checkFresh(c: CompletableDeferred<*>) {
         assertEquals(true, c.isActive)
         assertEquals(false, c.isCancelled)
         assertEquals(false, c.isCompleted)
@@ -24,21 +45,11 @@ class CompletableDeferredTest : TestBase() {
         assertThrows<IllegalStateException> { c.getCompletionExceptionOrNull() }
     }
 
-    @Test
-    fun testComplete() {
-        val c = CompletableDeferred<String>()
-        assertEquals(true, c.complete("OK"))
-        checkCompleteOk(c)
-        assertEquals(false, c.complete("OK"))
-        checkCompleteOk(c)
-    }
-
-    private fun checkCompleteOk(c: CompletableDeferred<String>) {
+    private fun checkCompleteOk(c: CompletableDeferred<*>) {
         assertEquals(false, c.isActive)
         assertEquals(false, c.isCancelled)
         assertEquals(true, c.isCompleted)
         assertTrue(c.getCancellationException() is JobCancellationException)
-        assertEquals("OK", c.getCompleted())
         assertEquals(null, c.getCompletionExceptionOrNull())
     }
 

--- a/common/kotlinx-coroutines-core-common/test/CoroutineScopeTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CoroutineScopeTest.kt
@@ -256,6 +256,20 @@ class CoroutineScopeTest : TestBase() {
         assertSame(Dispatchers.Unconfined, scopePlusContext(Dispatchers.Unconfined, Dispatchers.Unconfined))
     }
 
+    @Test
+    fun testIncompleteScopeState() = runTest {
+        lateinit var scopeJob: Job
+        coroutineScope {
+            scopeJob = coroutineContext[Job]!!
+            scopeJob.invokeOnCompletion { }
+        }
+
+        scopeJob.join()
+        assertTrue(scopeJob.isCompleted)
+        assertFalse(scopeJob.isActive)
+        assertFalse(scopeJob.isCancelled)
+    }
+
     private fun scopePlusContext(c1: CoroutineContext, c2: CoroutineContext) =
         (ContextScope(c1) + c2).coroutineContext
 }

--- a/common/kotlinx-coroutines-core-common/test/JobTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/JobTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("DEPRECATION")
+
 package kotlinx.coroutines
 
 import kotlin.test.*
@@ -204,5 +206,31 @@ class JobTest : TestBase() {
         job.cancel(TestException())
         assertTrue(job.isCancelled)
         assertTrue(parent.isCancelled)
+    }
+
+    @Test
+    fun testIncompleteJobState() = runTest {
+        val job = launch {
+            coroutineContext[Job]!!.invokeOnCompletion {  }
+        }
+
+        job.join()
+        assertTrue(job.isCompleted)
+        assertFalse(job.isActive)
+        assertFalse(job.isCancelled)
+    }
+
+    @Test
+    fun testChildrenWithIncompleteState() = runTest {
+        val job = async { Wrapper() }
+        job.join()
+        assertTrue(job.children.toList().isEmpty())
+    }
+
+    private class Wrapper : Incomplete {
+        override val isActive: Boolean
+            get() =  error("")
+        override val list: NodeList?
+            get() = error("")
     }
 }

--- a/common/kotlinx-coroutines-core-common/test/WithTimeoutTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/WithTimeoutTest.kt
@@ -195,5 +195,19 @@ class WithTimeoutTest : TestBase() {
             finish(4)
         }
     }
-}
 
+    @Test
+    fun testIncompleteWithTimeoutState() = runTest {
+        lateinit var timeoutJob: Job
+        val handle = withTimeout(Long.MAX_VALUE) {
+            timeoutJob = coroutineContext[Job]!!
+            timeoutJob.invokeOnCompletion { }
+        }
+
+        handle.dispose()
+        timeoutJob.join()
+        assertTrue(timeoutJob.isCompleted)
+        assertFalse(timeoutJob.isActive)
+        assertFalse(timeoutJob.isCancelled)
+    }
+}

--- a/core/kotlinx-coroutines-core/src/Builders.kt
+++ b/core/kotlinx-coroutines-core/src/Builders.kt
@@ -80,7 +80,7 @@ private class BlockingCoroutine<T>(
         }
         timeSource.unregisterTimeLoopThread()
         // now return result
-        val state = this.state
+        val state = this.state.unboxState()
         (state as? CompletedExceptionally)?.let { throw it.cause }
         return state as T
     }

--- a/core/kotlinx-coroutines-core/test/RunBlockingTest.kt
+++ b/core/kotlinx-coroutines-core/test/RunBlockingTest.kt
@@ -152,4 +152,14 @@ class RunBlockingTest : TestBase() {
 
         assertEquals(1, value)
     }
+
+    @Test
+    fun testIncompleteState() {
+        val handle = runBlocking {
+            // See #835
+            coroutineContext[Job]!!.invokeOnCompletion {  }
+        }
+
+        handle.dispose()
+    }
 }


### PR DESCRIPTION
…y) because otherwise job machinery treats such state as intermediate

Fixes #835