### PR TITLE
Guava: Support building with Guava 27.

### DIFF
--- a/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
+++ b/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
@@ -40,7 +40,7 @@ public fun <T> CoroutineScope.future(
     val newContext = newCoroutineContext(context)
     val future = SettableFuture.create<T>()
     val coroutine = ListenableFutureCoroutine(newContext, future)
-    future.addCallback(coroutine, MoreExecutors.directExecutor())
+    Futures.addCallback(future, coroutine, MoreExecutors.directExecutor())
     coroutine.start(start, coroutine, block)
     return future
 }

--- a/integration/kotlinx-coroutines-guava/test/ListenableFutureExceptionsTest.kt
+++ b/integration/kotlinx-coroutines-guava/test/ListenableFutureExceptionsTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines.guava
 
+import com.google.common.base.*
 import com.google.common.util.concurrent.*
 import kotlinx.coroutines.*
 import org.junit.Test
@@ -55,7 +56,11 @@ class ListenableFutureExceptionsTest : TestBase() {
         // Fast path
         runTest {
             val future = SettableFuture.create<Int>()
-            val chained = if (transformer == null) future else Futures.transform(future, transformer)
+            val chained = if (transformer == null) {
+                future
+            } else {
+                Futures.transform(future, Function(transformer), MoreExecutors.directExecutor())
+            }
             future.setException(exception)
             try {
                 chained.await()
@@ -67,7 +72,11 @@ class ListenableFutureExceptionsTest : TestBase() {
         // Slow path
         runTest {
             val future = SettableFuture.create<Int>()
-            val chained = if (transformer == null) future else Futures.transform(future, transformer)
+            val chained = if (transformer == null) {
+                future
+            } else {
+                Futures.transform(future, Function(transformer), MoreExecutors.directExecutor())
+            }
             launch {
                 future.setException(exception)
             }


### PR DESCRIPTION
Several methods were deprecated, and removed in Guava 27. This updates
existing calls to enable compiling with newer versions of Guava.