### PR TITLE
Do not yield in CoroutineScheduler during transition to the idle stat…

### DIFF
--- a/benchmarks/src/jmh/kotlin/benchmarks/YieldRelativeCostBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/YieldRelativeCostBenchmark.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package benchmarks
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+open class YieldRelativeCostBenchmark {
+
+    @Param("1", "10", "100", "1000")
+    var iterations: Int = 10
+
+    @Benchmark
+    fun yields() {
+        repeat(iterations) {
+            Thread.yield()
+        }
+    }
+
+    @Benchmark
+    fun spins(bh: Blackhole) {
+        repeat(iterations) {
+            bh.consume(it)
+        }
+    }
+}

--- a/core/kotlinx-coroutines-core/src/Dispatchers.kt
+++ b/core/kotlinx-coroutines-core/src/Dispatchers.kt
@@ -25,8 +25,9 @@ public actual object Dispatchers {
      * [launch][CoroutineScope.launch], [async][CoroutineScope.async], etc
      * if no dispatcher nor any other [ContinuationInterceptor] is specified in their context.
      *
-     * It is backed by a shared pool of threads on JVM. By default, the maximal number of threads used
-     * by this dispatcher is equal to the number CPU cores, but is at least two.
+     * It is backed by a shared pool of threads on JVM. By default, the maximal level of parallelism used
+     * by this dispatcher is equal to the number of CPU cores, but is at least two.
+     * Level of parallelism X guarantees that no more than X tasks can be executed in this dispatcher in parallel.
      */
     @JvmStatic
     public actual val Default: CoroutineDispatcher = createDefaultDispatcher()

--- a/core/kotlinx-coroutines-core/src/scheduling/CoroutineScheduler.kt
+++ b/core/kotlinx-coroutines-core/src/scheduling/CoroutineScheduler.kt
@@ -251,8 +251,8 @@ internal class CoroutineScheduler(
     private val isTerminated: Boolean get() = _isTerminated.value != 0
 
     companion object {
-        private const val MAX_SPINS = 1000
-        private const val MAX_YIELDS = MAX_SPINS + 500
+        private val MAX_SPINS = systemProp("kotlinx.coroutines.scheduler.spins", 1000, minValue = 1)
+        private val MAX_YIELDS = MAX_SPINS + systemProp("kotlinx.coroutines.scheduler.yields", 0, minValue = 0)
 
         @JvmStatic // Note, that is fits into Int (it is equal to 10^9)
         private val MAX_PARK_TIME_NS = TimeUnit.SECONDS.toNanos(1).toInt()


### PR DESCRIPTION
…e, introduce system properties to tune this behaviour.

Rationale:

Thread.yield has a significant CPU cost (especially relatively to spins) and provides no significant benefits compared with exponential parking.
Thus yields burn a lot of CPU due to JVM upcall + syscall, providing benefits neither for liveness property (as CPU is mostly busy with doing these calls) nor for latencies. Initial benchmarking shows significant CPU usage reduction (200-300%) in low-to-average load benchmarks with no degradation on target affinity benchmarks.

Partially addresses #840