### PR TITLE
Remove unnecessary function declaration from example

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -219,14 +219,11 @@ fun main() = runBlocking {
 //sampleEnd
 }
 
-fun CoroutineScope.produceSquares(): ReceiveChannel<Int> = produce {
-    for (x in 1..5) send(x * x)
-}
-
 fun CoroutineScope.produceNumbers() = produce<Int> {
     var x = 1
     while (true) send(x++) // infinite stream of integers starting from 1
 }
+
 fun CoroutineScope.square(numbers: ReceiveChannel<Int>): ReceiveChannel<Int> = produce {
     for (x in numbers) send(x * x)
 }


### PR DESCRIPTION
The produceSquares() function is probably a leftover, because only produceNumbers() 
and square() are actually used in the code sample.