### PR TITLE
Ignore exception on cancel/fail race in CancellableContinuation

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -34,7 +34,7 @@ public final class kotlinx/coroutines/BuildersKt {
 public abstract interface class kotlinx/coroutines/CancellableContinuation : kotlin/coroutines/Continuation {
 	public abstract fun cancel (Ljava/lang/Throwable;)Z
 	public abstract fun completeResume (Ljava/lang/Object;)V
-	public abstract fun initCancellability ()V
+	public abstract synthetic fun initCancellability ()V
 	public abstract fun invokeOnCancellation (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun isActive ()Z
 	public abstract fun isCancelled ()Z
@@ -50,17 +50,28 @@ public final class kotlinx/coroutines/CancellableContinuation$DefaultImpls {
 	public static synthetic fun tryResume$default (Lkotlinx/coroutines/CancellableContinuation;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public class kotlinx/coroutines/CancellableContinuationImpl : java/lang/Runnable, kotlin/coroutines/jvm/internal/CoroutineStackFrame, kotlinx/coroutines/CancellableContinuation {
+public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/jvm/internal/CoroutineStackFrame, kotlinx/coroutines/CancellableContinuation {
 	public fun <init> (Lkotlin/coroutines/Continuation;I)V
+	public fun cancel (Ljava/lang/Throwable;)Z
 	public fun completeResume (Ljava/lang/Object;)V
 	public fun getCallerFrame ()Lkotlin/coroutines/jvm/internal/CoroutineStackFrame;
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun getContinuationCancellationCause (Lkotlinx/coroutines/Job;)Ljava/lang/Throwable;
+	public final fun getDelegate ()Lkotlin/coroutines/Continuation;
+	public final fun getResult ()Ljava/lang/Object;
 	public fun getStackTraceElement ()Ljava/lang/StackTraceElement;
 	public fun getSuccessfulResult (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun initCancellability ()V
+	public synthetic fun initCancellability ()V
+	public fun invokeOnCancellation (Lkotlin/jvm/functions/Function1;)V
+	public fun isActive ()Z
+	public fun isCancelled ()Z
+	public fun isCompleted ()Z
 	protected fun nameString ()Ljava/lang/String;
 	public fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
+	public fun resumeWith (Ljava/lang/Object;)V
+	public fun takeState ()Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
 	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;
 }

--- a/common/kotlinx-coroutines-core-common/src/JobSupport.kt
+++ b/common/kotlinx-coroutines-core-common/src/JobSupport.kt
@@ -1049,7 +1049,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
         }
 
         protected override fun nameString(): String =
-            "AwaitContinuation(${delegate.toDebugString()})"
+            "AwaitContinuation"
     }
 
     /*
@@ -1105,7 +1105,6 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
          * thrown and not a JobCancellationException.
          */
         val cont = AwaitContinuation(uCont.intercepted(), this)
-        cont.initCancellability()
         cont.disposeOnCancellation(invokeOnCompletion(ResumeAwaitOnCompletion(this, cont).asHandler))
         cont.getResult()
     }
@@ -1249,7 +1248,7 @@ private class ResumeOnCompletion(
 
 private class ResumeAwaitOnCompletion<T>(
     job: JobSupport,
-    private val continuation: AbstractContinuation<T>
+    private val continuation: CancellableContinuationImpl<T>
 ) : JobNode<JobSupport>(job) {
     override fun invoke(cause: Throwable?) {
         val state = job.state
@@ -1330,10 +1329,10 @@ internal class ChildHandleNode(
 // Same as ChildHandleNode, but for cancellable continuation
 internal class ChildContinuation(
     parent: Job,
-    @JvmField val child: AbstractContinuation<*>
+    @JvmField val child: CancellableContinuationImpl<*>
 ) : JobCancellingNode<Job>(parent) {
     override fun invoke(cause: Throwable?) {
-        child.cancelImpl(child.getContinuationCancellationCause(job))
+        child.cancel(child.getContinuationCancellationCause(job))
     }
     override fun toString(): String =
         "ChildContinuation[$child]"

--- a/common/kotlinx-coroutines-core-common/src/sync/Mutex.kt
+++ b/common/kotlinx-coroutines-core-common/src/sync/Mutex.kt
@@ -186,7 +186,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
         return lockSuspend(owner)
     }
 
-    private suspend fun lockSuspend(owner: Any?) = suspendAtomicCancellableCoroutine<Unit>(holdCancellability = true) sc@ { cont ->
+    private suspend fun lockSuspend(owner: Any?) = suspendAtomicCancellableCoroutine<Unit> sc@ { cont ->
         val waiter = LockCont(owner, cont)
         _state.loop { state ->
             when (state) {
@@ -207,7 +207,6 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
                     check(curOwner !== owner) { "Already locked by $owner" }
                     if (state.addLastIf(waiter, { _state.value === state })) {
                         // added to waiter list!
-                        cont.initCancellability() // make it properly cancellable
                         cont.removeOnCancellation(waiter)
                         return@sc
                     }

--- a/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CancellableContinuationTest.kt
@@ -72,7 +72,7 @@ class CancellableContinuationTest : TestBase() {
      * should be ignored. Here suspended coroutine is cancelled but then resumed with exception.
      */
     @Test
-    fun testCancelAndResumeWithException() = runTest(unhandled = listOf({e -> e is TestException})) {
+    fun testCancelAndResumeWithException() = runTest {
         var continuation: Continuation<Unit>? = null
         val job = launch {
             try {


### PR DESCRIPTION
There seems to be no other way to satisfactory fix the problem of a race between cancellation on CancellationContinuation and concurrent failure of the corresponding background process in a way the distinguishes "failure from cancellation attempt" from a "true failure" without placing undue burden on anyone who is implementing `await()` extension function for various future types.

- Added testTimeoutCancellationFailRace that works as a perfect litmus test; being allowed to run for a while it realiable detects various  problems in alternative approaches.
- Optimized CancellableContinuationImpl; merged its code with AbstractContinuation class that is not needed as a separate class and it removed.
- Deprecated and hidden CancellableContinuation.initCancellability(); it is now always invoked after the end of the block that was passed to suspendCancellableCoroutine.
- Deprecated `holdCancellability` parameter to an internal suspendAtomicCancellableCoroutine function.

Fixes #892
Fixes #830