### PR TITLE
Do not probabilistically steal blocking tasks as part of anti-starvat…

### DIFF
--- a/core/kotlinx-coroutines-core/src/scheduling/Tasks.kt
+++ b/core/kotlinx-coroutines-core/src/scheduling/Tasks.kt
@@ -110,9 +110,8 @@ internal class TaskImpl(
 
 // Open for tests
 internal open class GlobalQueue : LockFreeTaskQueue<Task>(singleConsumer = false) {
-    // Open for tests
-    public open fun removeFirstBlockingModeOrNull(): Task? =
-        removeFirstOrNullIf { it.mode == TaskMode.PROBABLY_BLOCKING }
+    public fun removeFirstWithModeOrNull(mode: TaskMode): Task? =
+        removeFirstOrNullIf { it.mode == mode }
 }
 
 internal abstract class TimeSource {

--- a/core/kotlinx-coroutines-core/test/scheduling/WorkQueueStressTest.kt
+++ b/core/kotlinx-coroutines-core/test/scheduling/WorkQueueStressTest.kt
@@ -117,8 +117,6 @@ class WorkQueueStressTest : TestBase() {
 }
 
 internal class Queue : GlobalQueue() {
-    override fun removeFirstBlockingModeOrNull(): Task? = error("Should not be called")
-
     fun addAll(tasks: Collection<Task>) {
         tasks.forEach { addLast(it) }
     }


### PR DESCRIPTION
…ion mechanism: stealing thread might be woken up in `blockingQuiescence` and already have a blocking task in its local queue