### PR TITLE
Stricter checking for CompletableContinuation state machine

### DIFF
--- a/common/kotlinx-coroutines-core-common/src/CompletedExceptionally.kt
+++ b/common/kotlinx-coroutines-core-common/src/CompletedExceptionally.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines
 
+import kotlinx.atomicfu.*
 import kotlin.coroutines.*
 import kotlin.jvm.*
 
@@ -31,5 +32,12 @@ internal open class CompletedExceptionally(
  */
 internal class CancelledContinuation(
     continuation: Continuation<*>,
-    cause: Throwable?
-) : CompletedExceptionally(cause ?: CancellationException("Continuation $continuation was cancelled normally"))
+    cause: Throwable?,
+    handled: Boolean
+) : CompletedExceptionally(cause ?: CancellationException("Continuation $continuation was cancelled normally")) {
+    private val resumed = atomic(false)
+    private val handled = atomic(handled)
+
+    fun makeResumed(): Boolean = resumed.compareAndSet(false, true)
+    fun makeHandled(): Boolean = handled.compareAndSet(false, true)
+}

--- a/common/kotlinx-coroutines-core-common/test/CancellableContinuationHandlersTest.kt
+++ b/common/kotlinx-coroutines-core-common/test/CancellableContinuationHandlersTest.kt
@@ -23,6 +23,7 @@ class CancellableContinuationHandlersTest : TestBase() {
             c.resume(Unit)
             // Nothing happened
             c.invokeOnCancellation { expectUnreached() }
+            // Cannot validate after completion
             c.invokeOnCancellation { expectUnreached() }
         }
     }
@@ -36,13 +37,10 @@ class CancellableContinuationHandlersTest : TestBase() {
                     assertTrue(it is CancellationException)
                     expect(1)
                 }
-                c.invokeOnCancellation {
-                    assertTrue(it is CancellationException)
-                    expect(2)
-                }
+                assertFailsWith<IllegalStateException> { c.invokeOnCancellation { expectUnreached() } }
             }
         } catch (e: CancellationException) {
-            finish(3)
+            finish(2)
         }
     }
 
@@ -55,13 +53,10 @@ class CancellableContinuationHandlersTest : TestBase() {
                     require(it is AssertionError)
                     expect(1)
                 }
-                c.invokeOnCancellation {
-                    require(it is AssertionError)
-                    expect(2)
-                }
+                assertFailsWith<IllegalStateException> { c.invokeOnCancellation { expectUnreached() } }
             }
         } catch (e: AssertionError) {
-            finish(3)
+            finish(2)
         }
     }
 
@@ -73,15 +68,11 @@ class CancellableContinuationHandlersTest : TestBase() {
                     require(it is IndexOutOfBoundsException)
                     expect(1)
                 }
-
                 c.cancel(IndexOutOfBoundsException())
-                c.invokeOnCancellation {
-                    require(it is IndexOutOfBoundsException)
-                    expect(2)
-                }
+                assertFailsWith<IllegalStateException> { c.invokeOnCancellation { expectUnreached() } }
             }
         } catch (e: IndexOutOfBoundsException) {
-            finish(3)
+            finish(2)
         }
     }
 


### PR DESCRIPTION
* Always throw ISE on the second resume attempt
* Always throw ISE on the second invokeOnCancellation attempt when cancelled
* Moved error-throwing code into separate funs (slight optimization)

Fixes #901