### PR TITLE
More idiomatic and readable example for coroutines debug module readme

### DIFF
--- a/core/kotlinx-coroutines-debug/test/Example.kt
+++ b/core/kotlinx-coroutines-debug/test/Example.kt
@@ -1,0 +1,32 @@
+import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.*
+
+suspend fun computeValue(): String = coroutineScope {
+    val one = async { computeOne() }
+    val two = async { computeTwo() }
+    combineResults(one, two)
+}
+
+suspend fun combineResults(one: Deferred<String>, two: Deferred<String>): String =
+    one.await() + two.await()
+
+suspend fun computeOne(): String {
+    delay(5000)
+    return "4"
+}
+
+suspend fun computeTwo(): String {
+    delay(5000)
+    return "2"
+}
+
+fun main() = runBlocking {
+    DebugProbes.install()
+    val deferred = async { computeValue() }
+    // Delay for some time
+    delay(1000)
+    // Dump running coroutines
+    DebugProbes.dumpCoroutines()
+    println("\nDumping only deferred")
+    DebugProbes.printJob(deferred)
+}


### PR DESCRIPTION
* Idiomatically use suspend functions
* Idiomatic parallal decomposition with coroutineContext/async
* No GlobalScope
* Use less vertical space & more concise code to aid readability
* Link to full code file (in tests)