### PR TITLE
Start lazy actor when calling close

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -156,6 +156,11 @@ private class LazyActorCoroutine<E>(
         return super.offer(element)
     }
 
+    override fun close(cause: Throwable?): Boolean {
+        start()
+        return super.close(cause)
+    }
+
     override val onSend: SelectClause2<E, SendChannel<E>>
         get() = this
 

--- a/kotlinx-coroutines-core/jvm/test/channels/ActorLazyTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ActorLazyTest.kt
@@ -61,4 +61,22 @@ class ActorLazyTest : TestBase() {
         assertThat(actor.isClosedForSend, IsEqual(true))
         finish(6)
     }
+
+    @Test
+    fun testCloseFreshActor() = runTest {
+        val job = launch {
+            expect(2)
+            val actor = actor<Int>(start = CoroutineStart.LAZY) {
+                expect(3)
+                for (i in channel) { }
+                expect(4)
+            }
+
+            actor.close()
+        }
+
+        expect(1)
+        job.join()
+        finish(5)
+    }
 }

--- a/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
@@ -169,4 +169,16 @@ class ActorTest(private val capacity: Int) : TestBase() {
         parent.join()
         finish(2)
     }
+
+    @Test
+    fun testCloseFreshActor() = runTest {
+        for (start in CoroutineStart.values()) {
+            val job = launch {
+                val actor = actor<Int>(start = start) { for (i in channel) {} }
+                actor.close()
+            }
+
+            job.join()
+        }
+    }
 }


### PR DESCRIPTION
Rationale:
While it is possible to atomically transition state machine to "completed", it has multiple caveats:
  * It breaks intuition that "close" allows actors to process remaining messages and call its body
  * It introduces one more internal API dependency
  * It makes behaviour of non-lazy and lazy actors inconsistent

Fixes #939