### PR TITLE
Re-add common sources to platform sources jar

### DIFF
--- a/gradle/publish-bintray.gradle
+++ b/gradle/publish-bintray.gradle
@@ -29,7 +29,7 @@ task sourcesJar(type: Jar) {
 
     if (project.name == coroutines_core && platform != "common") {
         // add common source, too
-        from rootProject.file("common/$project.name-common/src/main/kotlin")
+        from rootProject.file("common/$project.name-common/src")
     }
 }
 


### PR DESCRIPTION
This change fixes a regression introduced by commit e1fa197ddef67768c1586328cbdb2e88c89a26f0, which changed the directory layout of the project.

The directory layout change reintroduced the bug in [KT-20971](https://youtrack.jetbrains.com/issue/KT-20971), which was initially fixed in commit 2bc0a1ba13bb2015c013a3429948e73218cce909.