### PR TITLE
Promote Unconfined, immediate, MainScope and CoroutineScope.cancel to stable API

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -33,11 +33,14 @@ public abstract class CoroutineDispatcher :
      * Returns `true` if execution shall be dispatched onto another thread.
      * The default behaviour for most dispatchers is to return `true`.
      *
+     * This method should never be used from general code, it is used only by `kotlinx.coroutines`
+     * internals and its contract with the rest of API is an implementation detail.
+     *
      * UI dispatchers _should not_ override `isDispatchNeeded`, but leave a default implementation that
      * returns `true`. To understand the rationale beyond this recommendation, consider the following code:
      *
      * ```kotlin
-     * fun asyncUpdateUI() = async(MainThread) {
+     * fun asyncUpdateUI() = async(Dispatchers.Main) {
      *     // do something here that updates something in UI
      * }
      * ```
@@ -60,6 +63,9 @@ public abstract class CoroutineDispatcher :
      * parameter that allows one to optionally choose C#-style [CoroutineStart.UNDISPATCHED] behaviour
      * whenever it is needed for efficiency.
      *
+     * This method should be generally exception-safe, an exception thrown from this method
+     * may leave the coroutines that use this dispatcher in the inconsistent and hard to debug state.
+     *
      * **Note: This is an experimental api.** Execution semantics of coroutines may change in the future when this function returns `false`.
      */
     @ExperimentalCoroutinesApi
@@ -67,6 +73,9 @@ public abstract class CoroutineDispatcher :
 
     /**
      * Dispatches execution of a runnable [block] onto another thread in the given [context].
+     *
+     * This method should be generally exception-safe, an exception thrown from this method
+     * may leave the coroutines that use this dispatcher in the inconsistent and hard to debug state.
      */
     public abstract fun dispatch(context: CoroutineContext, block: Runnable)
 
@@ -85,6 +94,9 @@ public abstract class CoroutineDispatcher :
 
     /**
      * Returns continuation that wraps the original [continuation], thus intercepting all resumptions.
+     *
+     * This method should be generally exception-safe, an exception thrown from this method
+     * may leave the coroutines that use this dispatcher in the inconsistent and hard to debug state.
      */
     public final override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
         DispatchedContinuation(this, continuation)

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -94,7 +94,6 @@ public operator fun CoroutineScope.plus(context: CoroutineContext): CoroutineSco
  * `val scope = MainScope() + CoroutineName("MyActivity")`.
  */
 @Suppress("FunctionName")
-@ExperimentalCoroutinesApi // Experimental since 1.1.0, tentatively until 1.2.0
 public fun MainScope(): CoroutineScope = ContextScope(SupervisorJob() + Dispatchers.Main)
 
 /**
@@ -200,12 +199,8 @@ public fun CoroutineScope(context: CoroutineContext): CoroutineScope =
 /**
  * Cancels this scope, including its job and all its children.
  * Throws [IllegalStateException] if the scope does not have a job in it.
- *
- * This API is experimental in order to investigate possible clashes with other cancellation mechanisms.
- */
-@Suppress("NOTHING_TO_INLINE")
-@ExperimentalCoroutinesApi // Experimental and inline since 1.1.0, tentatively until 1.2.0
-public inline fun CoroutineScope.cancel() {
+ **/
+public fun CoroutineScope.cancel() {
     val job = coroutineContext[Job] ?: error("Scope cannot be cancelled because it does not have a job: $this")
     job.cancel()
 }

--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -47,15 +47,30 @@ public expect object Dispatchers {
      * mandating any specific threading policy. Nested coroutines launched in this dispatcher form an event-loop to avoid
      * stack overflows.
      *
+     * ### Event loop
+     * Event loop semantics is a purely internal concept and have no guarantees on the order of execution
+     * except that all queued coroutines will be executed on the current thread in the lexical scope of the outermost
+     * unconfined coroutine.
+     *
+     * For example, the following code:
+     * ```
+     * withContext(Dispatcher.Unconfined) {
+     *    println(1)
+     *    withContext(Dispatcher.Unconfined) { // Nested unconfined
+     *        println(2)
+     *    }
+     *    println(3)
+     * }
+     * println("Done")
+     * ```
+     * Can print both "1 2 3" and "1 3 2", this is an implementation detail that can be changed.
+     * But it is guaranteed that "Done" will be printed only when both `withContext` are completed.
+     *
      * Note, that if you need your coroutine to be confined to a particular thread or a thread-pool after resumption,
      * but still want to execute it in the current call-frame until its first suspension, then you can use
      * an optional [CoroutineStart] parameter in coroutine builders like
      * [launch][CoroutineScope.launch] and [async][CoroutineScope.async] setting it to the
      * the value of [CoroutineStart.UNDISPATCHED].
-     *
-     * **Note: This is an experimental api.**
-     * Semantics, order of execution, and particular implementation details of this dispatcher may change in the future.
      */
-    @ExperimentalCoroutinesApi
     public val Unconfined: CoroutineDispatcher
 }

--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -31,7 +31,6 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
      *   }
      *   // Do context-independent logic such as logging
      * }
-     *
      * ```
      *
      * Method may throw [UnsupportedOperationException] if immediate dispatching is not supported by current dispatcher,

--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -14,13 +14,30 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
 
     /**
      * Returns dispatcher that executes coroutines immediately when it is already in the right context
-     * (e.g. current looper is the same as this handler's looper). See [isDispatchNeeded] documentation on
-     * why this should not be done by default.
+     * (e.g. current looper is the same as this handler's looper) without an additional [re-dispatch][CoroutineDispatcher.dispatch].
+     *
+     * Immediate dispatcher is safe from stack overflows and in case of nested invocations forms event-loop similar to [Dispatchers.Unconfined].
+     * The event loop is an advanced topic and its implications can be found in [Dispatchers.Unconfined] documentation.
+     *
+     * Example of usage:
+     * ```
+     * suspend fun updateUiElement(val text: String) {
+     *   /*
+     *    * If it is known that updateUiElement can be invoked both from the Main thread and from other threads,
+     *    * `immediate` dispatcher is used as a performance optimization to avoid unnecessary dispatch.
+     *    */
+     *   withContext(Dispatchers.Main.immediate) {
+     *     uiElement.text = text
+     *   }
+     *   // Do context-independent logic such as logging
+     * }
+     *
+     * ```
+     *
      * Method may throw [UnsupportedOperationException] if immediate dispatching is not supported by current dispatcher,
      * please refer to specific dispatcher documentation.
      *
-     * **Note: This is an experimental api.** Semantics of this dispatcher may change in the future.
+     * [Dispatchers.Main] supports immediate execution for Android, JavaFx and Swing platforms.
      */
-    @ExperimentalCoroutinesApi
     public abstract val immediate: MainCoroutineDispatcher
 }

--- a/kotlinx-coroutines-test/src/internal/MainTestDispatcher.kt
+++ b/kotlinx-coroutines-test/src/internal/MainTestDispatcher.kt
@@ -28,7 +28,6 @@ internal class TestMainDispatcher(private val mainFactory: MainDispatcherFactory
     @Suppress("INVISIBLE_MEMBER")
     private val delay: Delay get() = delegate as? Delay ?: DefaultDelay
 
-    @ExperimentalCoroutinesApi
     override val immediate: MainCoroutineDispatcher
         get() = (delegate as? MainCoroutineDispatcher)?.immediate ?: this
 

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -21,13 +21,28 @@ import kotlin.coroutines.*
  */
 public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
     /**
-     * Returns dispatcher that executes coroutines immediately when it is already in the right handler context
-     * (current looper is the same as this handler's looper). See [isDispatchNeeded] documentation on
-     * why this should not be done by default.
+     * Returns dispatcher that executes coroutines immediately when it is already in the right context
+     * (current looper is the same as this handler's looper) without an additional [re-dispatch][CoroutineDispatcher.dispatch].
+     * This dispatcher does not use [Handler.post] when current looper is the same as looper of the handler.
      *
-     * **Note: This is an experimental api.** Semantics of this dispatcher may change in the future.
+     * Immediate dispatcher is safe from stack overflows and in case of nested invocations forms event-loop similar to [Dispatchers.Unconfined].
+     * The event loop is an advanced topic and its implications can be found in [Dispatchers.Unconfined] documentation.
+     *
+     * Example of usage:
+     * ```
+     * suspend fun updateUiElement(val text: String) {
+     *   /*
+     *    * If it is known that updateUiElement can be invoked both from the Main thread and from other threads,
+     *    * `immediate` dispatcher is used as a performance optimization to avoid unnecessary dispatch.
+     *    */
+     *   withContext(Dispatchers.Main.immediate) {
+     *     uiElement.text = text
+     *   }
+     *   // Do context-independent logic such as logging
+     * }
+     *
+     * ```
      */
-    @ExperimentalCoroutinesApi
     public abstract override val immediate: HandlerDispatcher
 }
 

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -40,7 +40,6 @@ public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
      *   }
      *   // Do context-independent logic such as logging
      * }
-     *
      * ```
      */
     public abstract override val immediate: HandlerDispatcher


### PR DESCRIPTION
Fixes #972 