### PR TITLE
Structured concurrency & Job cancellation improvements

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -173,9 +173,7 @@ public final class kotlinx/coroutines/CoroutineExceptionHandler$Key : kotlin/cor
 
 public final class kotlinx/coroutines/CoroutineExceptionHandlerKt {
 	public static final fun CoroutineExceptionHandler (Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/CoroutineExceptionHandler;
-	public static final fun handleCoroutineException (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;Lkotlinx/coroutines/Job;)V
-	public static synthetic fun handleCoroutineException$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;Lkotlinx/coroutines/Job;ILjava/lang/Object;)V
-	public static final fun handleExceptionViaHandler (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
+	public static final fun handleCoroutineException (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
 }
 
 public final class kotlinx/coroutines/CoroutineName : kotlin/coroutines/AbstractCoroutineContextElement {
@@ -371,7 +369,7 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	protected fun getHandlesException ()Z
 	public final fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
 	public final fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
-	protected fun handleJobException (Ljava/lang/Throwable;)V
+	protected fun handleJobException (Ljava/lang/Throwable;Z)V
 	public final fun invokeOnCompletion (Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
 	public final fun invokeOnCompletion (ZZLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
 	public fun isActive ()Z

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -89,7 +89,7 @@ public abstract interface class kotlinx/coroutines/ChildJob : kotlinx/coroutines
 }
 
 public final class kotlinx/coroutines/ChildJob$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/ChildJob;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/ChildJob;)V
 	public static fun fold (Lkotlinx/coroutines/ChildJob;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/ChildJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/ChildJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -103,7 +103,7 @@ public abstract interface class kotlinx/coroutines/CompletableDeferred : kotlinx
 }
 
 public final class kotlinx/coroutines/CompletableDeferred$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/CompletableDeferred;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/CompletableDeferred;)V
 	public static fun fold (Lkotlinx/coroutines/CompletableDeferred;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/CompletableDeferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/CompletableDeferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -123,7 +123,7 @@ public abstract interface class kotlinx/coroutines/CompletableJob : kotlinx/coro
 }
 
 public final class kotlinx/coroutines/CompletableJob$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/CompletableJob;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/CompletableJob;)V
 	public static fun fold (Lkotlinx/coroutines/CompletableJob;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/CompletableJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/CompletableJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -198,7 +198,8 @@ public abstract interface class kotlinx/coroutines/CoroutineScope {
 public final class kotlinx/coroutines/CoroutineScopeKt {
 	public static final fun CoroutineScope (Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/CoroutineScope;
 	public static final fun MainScope ()Lkotlinx/coroutines/CoroutineScope;
-	public static final fun cancel (Lkotlinx/coroutines/CoroutineScope;)V
+	public static final fun cancel (Lkotlinx/coroutines/CoroutineScope;Ljava/util/concurrent/CancellationException;)V
+	public static synthetic fun cancel$default (Lkotlinx/coroutines/CoroutineScope;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public static final fun coroutineScope (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun isActive (Lkotlinx/coroutines/CoroutineScope;)Z
 	public static final fun plus (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/CoroutineScope;
@@ -231,7 +232,7 @@ public abstract interface class kotlinx/coroutines/Deferred : kotlinx/coroutines
 }
 
 public final class kotlinx/coroutines/Deferred$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/Deferred;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/Deferred;)V
 	public static fun fold (Lkotlinx/coroutines/Deferred;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/Deferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/Deferred;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -274,6 +275,10 @@ public final class kotlinx/coroutines/EventLoopKt {
 	public static final fun processNextEventInCurrentThread ()J
 }
 
+public final class kotlinx/coroutines/ExceptionsKt {
+	public static final fun CancellationException (Ljava/lang/String;Ljava/lang/Throwable;)Ljava/util/concurrent/CancellationException;
+}
+
 public abstract class kotlinx/coroutines/ExecutorCoroutineDispatcher : kotlinx/coroutines/CoroutineDispatcher, java/io/Closeable {
 	public fun <init> ()V
 	public abstract fun close ()V
@@ -299,9 +304,9 @@ public abstract interface annotation class kotlinx/coroutines/InternalCoroutines
 public abstract interface class kotlinx/coroutines/Job : kotlin/coroutines/CoroutineContext$Element {
 	public static final field Key Lkotlinx/coroutines/Job$Key;
 	public abstract fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public abstract fun cancel ()V
-	public abstract synthetic fun cancel ()Z
-	public abstract fun cancel (Ljava/lang/Throwable;)Z
+	public abstract synthetic fun cancel ()V
+	public abstract synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public abstract fun cancel (Ljava/util/concurrent/CancellationException;)V
 	public abstract fun getCancellationException ()Ljava/util/concurrent/CancellationException;
 	public abstract fun getChildren ()Lkotlin/sequences/Sequence;
 	public abstract fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
@@ -316,8 +321,9 @@ public abstract interface class kotlinx/coroutines/Job : kotlin/coroutines/Corou
 }
 
 public final class kotlinx/coroutines/Job$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/Job;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/Job;)V
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun cancel$default (Lkotlinx/coroutines/Job;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public static fun fold (Lkotlinx/coroutines/Job;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/Job;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static synthetic fun invokeOnCompletion$default (Lkotlinx/coroutines/Job;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/DisposableHandle;
@@ -335,17 +341,22 @@ public final class kotlinx/coroutines/JobKt {
 	public static final synthetic fun Job (Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/Job;
 	public static synthetic fun Job$default (Lkotlinx/coroutines/Job;ILjava/lang/Object;)Lkotlinx/coroutines/CompletableJob;
 	public static synthetic fun Job$default (Lkotlinx/coroutines/Job;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;)V
-	public static final synthetic fun cancel (Lkotlin/coroutines/CoroutineContext;)Z
-	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)Z
+	public static final synthetic fun cancel (Lkotlin/coroutines/CoroutineContext;)V
+	public static final synthetic fun cancel (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)Z
+	public static final fun cancel (Lkotlin/coroutines/CoroutineContext;Ljava/util/concurrent/CancellationException;)V
 	public static synthetic fun cancel$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun cancel$default (Lkotlin/coroutines/CoroutineContext;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public static final fun cancelAndJoin (Lkotlinx/coroutines/Job;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun cancelChildren (Lkotlin/coroutines/CoroutineContext;)V
-	public static final fun cancelChildren (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
-	public static final fun cancelChildren (Lkotlinx/coroutines/Job;)V
-	public static final fun cancelChildren (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;)V
+	public static final synthetic fun cancelChildren (Lkotlin/coroutines/CoroutineContext;)V
+	public static final synthetic fun cancelChildren (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
+	public static final fun cancelChildren (Lkotlin/coroutines/CoroutineContext;Ljava/util/concurrent/CancellationException;)V
+	public static final synthetic fun cancelChildren (Lkotlinx/coroutines/Job;)V
+	public static final synthetic fun cancelChildren (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;)V
+	public static final fun cancelChildren (Lkotlinx/coroutines/Job;Ljava/util/concurrent/CancellationException;)V
 	public static synthetic fun cancelChildren$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun cancelChildren$default (Lkotlin/coroutines/CoroutineContext;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public static synthetic fun cancelChildren$default (Lkotlinx/coroutines/Job;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun cancelChildren$default (Lkotlinx/coroutines/Job;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public static final fun cancelFutureOnCancellation (Lkotlinx/coroutines/CancellableContinuation;Ljava/util/concurrent/Future;)V
 	public static final fun cancelFutureOnCompletion (Lkotlinx/coroutines/Job;Ljava/util/concurrent/Future;)Lkotlinx/coroutines/DisposableHandle;
 	public static final fun isActive (Lkotlin/coroutines/CoroutineContext;)Z
@@ -354,9 +365,11 @@ public final class kotlinx/coroutines/JobKt {
 public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlinx/coroutines/Job, kotlinx/coroutines/ParentJob, kotlinx/coroutines/selects/SelectClause0 {
 	public fun <init> (Z)V
 	public final fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public fun cancel ()V
-	public synthetic fun cancel ()Z
-	public fun cancel (Ljava/lang/Throwable;)Z
+	public synthetic fun cancel ()V
+	public synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public fun cancel (Ljava/util/concurrent/CancellationException;)V
+	public final fun cancelCoroutine (Ljava/lang/Throwable;)Z
+	public fun cancelInternal (Ljava/lang/Throwable;)Z
 	public fun childCancelled (Ljava/lang/Throwable;)Z
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
@@ -384,6 +397,8 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	public fun plus (Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/Job;
 	public final fun registerSelectClause0 (Lkotlinx/coroutines/selects/SelectInstance;Lkotlin/jvm/functions/Function1;)V
 	public final fun start ()Z
+	protected final fun toCancellationException (Ljava/lang/Throwable;Ljava/lang/String;)Ljava/util/concurrent/CancellationException;
+	public static synthetic fun toCancellationException$default (Lkotlinx/coroutines/JobSupport;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CancellationException;
 	public final fun toDebugString ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }
@@ -396,9 +411,9 @@ public abstract class kotlinx/coroutines/MainCoroutineDispatcher : kotlinx/corou
 public final class kotlinx/coroutines/NonCancellable : kotlin/coroutines/AbstractCoroutineContextElement, kotlinx/coroutines/Job {
 	public static final field INSTANCE Lkotlinx/coroutines/NonCancellable;
 	public fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
-	public fun cancel ()V
-	public synthetic fun cancel ()Z
-	public fun cancel (Ljava/lang/Throwable;)Z
+	public synthetic fun cancel ()V
+	public synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public fun cancel (Ljava/util/concurrent/CancellationException;)V
 	public fun getCancellationException ()Ljava/util/concurrent/CancellationException;
 	public fun getChildren ()Lkotlin/sequences/Sequence;
 	public fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
@@ -427,7 +442,7 @@ public abstract interface class kotlinx/coroutines/ParentJob : kotlinx/coroutine
 }
 
 public final class kotlinx/coroutines/ParentJob$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/ParentJob;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/ParentJob;)V
 	public static fun fold (Lkotlinx/coroutines/ParentJob;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun get (Lkotlinx/coroutines/ParentJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public static fun minusKey (Lkotlinx/coroutines/ParentJob;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
@@ -491,16 +506,18 @@ public abstract interface class kotlinx/coroutines/channels/ActorScope : kotlinx
 }
 
 public final class kotlinx/coroutines/channels/ActorScope$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ActorScope;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ActorScope;)V
 }
 
 public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : kotlinx/coroutines/channels/SendChannel {
-	public abstract fun cancel (Ljava/lang/Throwable;)Z
+	public abstract synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public abstract fun cancel (Ljava/util/concurrent/CancellationException;)V
 	public abstract fun openSubscription ()Lkotlinx/coroutines/channels/ReceiveChannel;
 }
 
 public final class kotlinx/coroutines/channels/BroadcastChannel$DefaultImpls {
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 }
 
 public final class kotlinx/coroutines/channels/BroadcastChannelKt {
@@ -522,7 +539,7 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 }
 
 public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)V
 }
 
 public final class kotlinx/coroutines/channels/Channel$Factory {
@@ -551,6 +568,7 @@ public final class kotlinx/coroutines/channels/ChannelsKt {
 	public static final fun associateByTo (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun associateByTo (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun associateTo (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun cancelConsumed (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/Throwable;)V
 	public static final fun consume (Lkotlinx/coroutines/channels/BroadcastChannel;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun consume (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun consumeEach (Lkotlinx/coroutines/channels/BroadcastChannel;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -670,7 +688,8 @@ public final class kotlinx/coroutines/channels/ClosedSendChannelException : java
 public final class kotlinx/coroutines/channels/ConflatedBroadcastChannel : kotlinx/coroutines/channels/BroadcastChannel {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Object;)V
-	public fun cancel (Ljava/lang/Throwable;)Z
+	public synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public fun cancel (Ljava/util/concurrent/CancellationException;)V
 	public fun close (Ljava/lang/Throwable;)Z
 	public fun getOnSend ()Lkotlinx/coroutines/selects/SelectClause2;
 	public final fun getValue ()Ljava/lang/Object;
@@ -695,9 +714,9 @@ public abstract interface class kotlinx/coroutines/channels/ProducerScope : kotl
 }
 
 public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
-	public abstract fun cancel ()V
-	public abstract synthetic fun cancel ()Z
-	public abstract fun cancel (Ljava/lang/Throwable;)Z
+	public abstract synthetic fun cancel ()V
+	public abstract synthetic fun cancel (Ljava/lang/Throwable;)Z
+	public abstract fun cancel (Ljava/util/concurrent/CancellationException;)V
 	public abstract fun getOnReceive ()Lkotlinx/coroutines/selects/SelectClause1;
 	public abstract fun getOnReceiveOrNull ()Lkotlinx/coroutines/selects/SelectClause1;
 	public abstract fun isClosedForReceive ()Z
@@ -709,8 +728,9 @@ public abstract interface class kotlinx/coroutines/channels/ReceiveChannel {
 }
 
 public final class kotlinx/coroutines/channels/ReceiveChannel$DefaultImpls {
-	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ReceiveChannel;)Z
+	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ReceiveChannel;)V
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 }
 
 public abstract interface class kotlinx/coroutines/channels/SendChannel {

--- a/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
+++ b/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
@@ -47,9 +47,8 @@ public fun <T> CoroutineScope.future(
 
 private class ListenableFutureCoroutine<T>(
     context: CoroutineContext,
-    private val completion: SettableFuture<T>
+    private val future: SettableFuture<T>
 ) : AbstractCoroutine<T>(context), FutureCallback<T> {
-
     /*
      * We register coroutine as callback to the future this coroutine completes.
      * But when future is cancelled externally, we'd like to cancel coroutine,
@@ -66,12 +65,13 @@ private class ListenableFutureCoroutine<T>(
     }
 
     override fun onCompleted(value: T) {
-        completion.set(value)
+        future.set(value)
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!completion.setException(exception)) {
-            handleCoroutineException(parentContext, exception, this)
+    override fun handleJobException(exception: Throwable, handled: Boolean) {
+        if (!future.setException(exception) && !handled) {
+            // prevents loss of exception that was not handled by parent & could not be set to SettableFuture
+            handleCoroutineException(context, exception)
         }
     }
 }

--- a/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
+++ b/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
@@ -46,7 +46,7 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testAwaitWithContextCancellation() = runTest(expected = {it is IOException}) {
+    fun testAwaitWithCancellation() = runTest(expected = {it is TestCancellationException}) {
         val future = SettableFuture.create<Int>()
         val deferred = async {
             withContext(Dispatchers.Default) {
@@ -54,8 +54,9 @@ class ListenableFutureTest : TestBase() {
             }
         }
 
-        deferred.cancel(IOException())
-        deferred.await()
+        deferred.cancel(TestCancellationException())
+        deferred.await() // throws TCE
+        expectUnreached()
     }
 
     @Test

--- a/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
@@ -46,20 +46,20 @@ public fun <T> CoroutineScope.future(
 
 private class CompletableFutureCoroutine<T>(
     context: CoroutineContext,
-    private val completion: CompletableFuture<T>
+    private val future: CompletableFuture<T>
 ) : AbstractCoroutine<T>(context), BiConsumer<T?, Throwable?> {
-
     override fun accept(value: T?, exception: Throwable?) {
         cancel()
     }
 
     override fun onCompleted(value: T) {
-        completion.complete(value)
+        future.complete(value)
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!completion.completeExceptionally(exception)) {
-            handleCoroutineException(parentContext, exception, this)
+    override fun handleJobException(exception: Throwable, handled: Boolean) {
+        if (!future.completeExceptionally(exception) && !handled) {
+            // prevents loss of exception that was not handled by parent & could not be set to CompletableFuture
+            handleCoroutineException(context, exception)
         }
     }
 }

--- a/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
@@ -73,7 +73,7 @@ public fun <T> Deferred<T>.asCompletableFuture(): CompletableFuture<T> {
     val future = CompletableFuture<T>()
     future.whenComplete { _, exception ->
         cancel(exception?.let {
-            it as? CancellationException ?: CancellationException("Future failed", it)
+            it as? CancellationException ?: CancellationException("CompletableFuture was completed exceptionally", it)
         })
     }
     invokeOnCompletion {

--- a/integration/kotlinx-coroutines-jdk8/test/examples/ExplicitJob-example.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/examples/ExplicitJob-example.kt
@@ -26,7 +26,7 @@ fun main(args: Array<String>) {
         log("g should not execute this line")
     }
     log("Started futures f && g... will not wait -- cancel them!!!")
-    job.cancel(CancellationException("I don't want it"))
+    job.cancel()
     check(f.isCancelled)
     check(g.isCancelled)
     log("f result = ${Try<Unit> { f.get() }}")

--- a/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
@@ -117,7 +117,7 @@ public abstract class AbstractCoroutine<in T>(
     }
 
     internal final override fun handleOnCompletionException(exception: Throwable) {
-        handleCoroutineException(parentContext, exception, this)
+        handleCoroutineException(context, exception)
     }
 
     internal override fun nameString(): String {

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -94,7 +94,6 @@ private open class DeferredCoroutine<T>(
     parentContext: CoroutineContext,
     active: Boolean
 ) : AbstractCoroutine<T>(parentContext, active), Deferred<T>, SelectClause1<T> {
-    override val cancelsParent: Boolean get() = true
     override fun getCompleted(): T = getCompletedInternal() as T
     override suspend fun await(): T = awaitInternal() as T
     override val onAwait: SelectClause1<T> get() = this
@@ -169,8 +168,9 @@ private open class StandaloneCoroutine(
     parentContext: CoroutineContext,
     active: Boolean
 ) : AbstractCoroutine<Unit>(parentContext, active) {
-    override val cancelsParent: Boolean get() = true
-    override fun handleJobException(exception: Throwable) = handleExceptionViaHandler(parentContext, exception)
+    override fun handleJobException(exception: Throwable, handled: Boolean) {
+        if (!handled) handleCoroutineException(context, exception)
+    }
 }
 
 private class LazyStandaloneCoroutine(

--- a/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
@@ -121,6 +121,7 @@ internal open class CancellableContinuationImpl<in T>(
         try {
             block()
         } catch (ex: Throwable) {
+            // Handler should never fail, if it does -- it is an unhandled exception
             handleCoroutineException(
                 context,
                 CompletionHandlerException("Exception in cancellation handler for $this", ex)

--- a/kotlinx-coroutines-core/common/src/CompletableDeferred.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableDeferred.kt
@@ -66,7 +66,6 @@ private class CompletableDeferredImpl<T>(
     parent: Job?
 ) : JobSupport(true), CompletableDeferred<T>, SelectClause1<T> {
     init { initParentJobInternal(parent) }
-    override val cancelsParent: Boolean get() = true
     override val onCancelComplete get() = true
     override fun getCompleted(): T = getCompletedInternal() as T
     override suspend fun await(): T = awaitInternal() as T

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -196,10 +196,12 @@ public fun CoroutineScope(context: CoroutineContext): CoroutineScope =
     ContextScope(if (context[Job] != null) context else context + Job())
 
 /**
- * Cancels this scope, including its job and all its children.
+ * Cancels this scope, including its job and all its children with an optional cancellation [cause].
+ * A cause can be used to specify an error message or to provide other details on
+ * a cancellation reason for debugging purposes.
  * Throws [IllegalStateException] if the scope does not have a job in it.
- **/
-public fun CoroutineScope.cancel() {
+ */
+public fun CoroutineScope.cancel(cause: CancellationException? = null) {
     val job = coroutineContext[Job] ?: error("Scope cannot be cancelled because it does not have a job: $this")
-    job.cancel()
+    job.cancel(cause)
 }

--- a/kotlinx-coroutines-core/common/src/Exceptions.common.kt
+++ b/kotlinx-coroutines-core/common/src/Exceptions.common.kt
@@ -12,6 +12,9 @@ public expect class CompletionHandlerException(message: String, cause: Throwable
 
 public expect open class CancellationException(message: String?) : IllegalStateException
 
+@Suppress("FunctionName")
+public expect fun CancellationException(message: String?, cause: Throwable?) : CancellationException
+
 internal expect class JobCancellationException(
     message: String,
     cause: Throwable?,

--- a/kotlinx-coroutines-core/common/src/Exceptions.common.kt
+++ b/kotlinx-coroutines-core/common/src/Exceptions.common.kt
@@ -26,3 +26,6 @@ internal expect class JobCancellationException(
 internal expect class DispatchException(message: String, cause: Throwable) : RuntimeException
 
 internal expect fun Throwable.addSuppressedThrowable(other: Throwable)
+
+// For use in tests
+internal expect val RECOVER_STACK_TRACES: Boolean

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -166,13 +166,13 @@ public interface Job : CoroutineContext.Element {
     /**
      * @suppress This method implements old version of JVM ABI. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     public fun cancel() = cancel(null)
 
     /**
      * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     public fun cancel(cause: Throwable? = null): Boolean
 
     // ------------ parent-child ------------
@@ -358,7 +358,7 @@ public fun Job(parent: Job? = null): CompletableJob = JobImpl(parent)
 
 /** @suppress Binary compatibility only */
 @Suppress("FunctionName")
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 @JvmName("Job")
 public fun Job0(parent: Job? = null): Job = Job(parent)
 
@@ -488,13 +488,13 @@ public fun Job.cancelChildren(cause: CancellationException? = null) {
 /**
  * @suppress This method implements old version of JVM ABI. Use [cancel].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun Job.cancelChildren() = cancelChildren(null)
 
 /**
  * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [Job.cancelChildren].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun Job.cancelChildren(cause: Throwable? = null) {
     children.forEach { (it as? JobSupport)?.cancelInternal(cause) }
 }
@@ -531,13 +531,13 @@ public fun CoroutineContext.cancel(cause: CancellationException? = null) {
 /**
  * @suppress This method implements old version of JVM ABI. Use [CoroutineContext.cancel].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun CoroutineContext.cancel() = cancel(null)
 
 /**
  * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [CoroutineContext.cancel].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun CoroutineContext.cancel(cause: Throwable? = null): Boolean =
     @Suppress("DEPRECATION")
     (this[Job] as? JobSupport)?.cancelInternal(cause) ?: false
@@ -554,13 +554,13 @@ public fun CoroutineContext.cancelChildren(cause: CancellationException? = null)
 /**
  * @suppress This method implements old version of JVM ABI. Use [CoroutineContext.cancelChildren].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun CoroutineContext.cancelChildren() = cancelChildren(null)
 
 /**
  * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [CoroutineContext.cancelChildren].
  */
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 public fun CoroutineContext.cancelChildren(cause: Throwable? = null) {
     this[Job]?.children?.forEach { (it as? JobSupport)?.cancelInternal(cause) }
 }

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -573,12 +573,12 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
 
     // HIDDEN in Job interface. Invoked only by legacy compiled code.
     // external cancel with (optional) cause, never invoked implicitly from internal machinery
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Added since 1.2.0 for binary compatibility with versions <= 1.1.x")
     public override fun cancel(cause: Throwable?): Boolean =
         cancelInternal(cause)
 
     // It is overridden in channel-linked implementation
-    // Note: Boolean result is used only in DEPRECATED functions
+    // Note: Boolean result is used only in HIDDEN DEPRECATED functions that were public in versions <= 1.1.x
     public open fun cancelInternal(cause: Throwable?): Boolean =
         cancelImpl(cause) && handlesException
 

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -584,6 +584,10 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
     public open fun childCancelled(cause: Throwable): Boolean =
         cancelImpl(cause) && handlesException
 
+    // For AbstractCoroutine implementations
+    protected fun cancelCoroutine(cause: Throwable?) =
+        cancelImpl(cause)
+
     // cause is Throwable or ParentJob when cancelChild was invoked
     // returns true is exception was handled, false otherwise
     private fun cancelImpl(cause: Any?): Boolean {

--- a/kotlinx-coroutines-core/common/src/NonCancellable.kt
+++ b/kotlinx-coroutines-core/common/src/NonCancellable.kt
@@ -92,15 +92,13 @@ public object NonCancellable : AbstractCoroutineContextElement(Job), Job {
      * @suppress **This an internal API and should not be used from general code.**
      */
     @InternalCoroutinesApi
-    @Suppress("RETURN_TYPE_MISMATCH_ON_OVERRIDE")
-    override fun cancel(): Unit {
-    }
+    override fun cancel(cause: CancellationException?) {}
 
     /**
      * Always returns `false`.
-     * @suppress **This an internal API and should not be used from general code.**
+     * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @InternalCoroutinesApi
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
     override fun cancel(cause: Throwable?): Boolean = false // never handles exceptions
 
     /**

--- a/kotlinx-coroutines-core/common/src/NonCancellable.kt
+++ b/kotlinx-coroutines-core/common/src/NonCancellable.kt
@@ -98,7 +98,7 @@ public object NonCancellable : AbstractCoroutineContextElement(Job), Job {
      * Always returns `false`.
      * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     override fun cancel(cause: Throwable?): Boolean = false // never handles exceptions
 
     /**

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -33,7 +33,7 @@ public fun SupervisorJob(parent: Job? = null) : CompletableJob = SupervisorJobIm
 
 /** @suppress Binary compatibility only */
 @Suppress("FunctionName")
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility")
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
 @JvmName("SupervisorJob")
 public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
 

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -91,7 +91,7 @@ private open class TimeoutCoroutine<U, in T: U>(
 
     @Suppress("LeakingThis", "Deprecation")
     override fun run() {
-        cancel(TimeoutCancellationException(time, this))
+        cancelCoroutine(TimeoutCancellationException(time, this))
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -85,6 +85,10 @@ private open class TimeoutCoroutine<U, in T: U>(
     override val defaultResumeMode: Int get() = MODE_DIRECT
     override val callerFrame: CoroutineStackFrame? get() = (uCont as? CoroutineStackFrame)?.callerFrame
     override fun getStackTraceElement(): StackTraceElement? = (uCont as? CoroutineStackFrame)?.getStackTraceElement()
+
+    override val cancelsParent: Boolean
+        get() = false // it throws exception to parent instead of cancelling it
+
     @Suppress("LeakingThis", "Deprecation")
     override fun run() {
         cancel(TimeoutCancellationException(time, this))

--- a/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
@@ -655,7 +655,7 @@ internal abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E
         return if (result === POLL_FAILED) null else receiveOrNullResult(result)
     }
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     final override fun cancel(cause: Throwable?): Boolean =
         cancelInternal(cause)
 

--- a/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
@@ -655,12 +655,16 @@ internal abstract class AbstractChannel<E> : AbstractSendChannel<E>(), Channel<E
         return if (result === POLL_FAILED) null else receiveOrNullResult(result)
     }
 
-    override fun cancel() {
-        @Suppress("DEPRECATION")
-        cancel(null)
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    final override fun cancel(cause: Throwable?): Boolean =
+        cancelInternal(cause)
+
+    final override fun cancel(cause: CancellationException?) {
+        cancelInternal(cause)
     }
 
-    override fun cancel(cause: Throwable?): Boolean =
+    // It needs to be internal to support deprecated cancel(Throwable?) API
+    internal open fun cancelInternal(cause: Throwable?): Boolean =
         close(cause).also {
             cleanupSendQueueOnCancel()
         }

--- a/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
@@ -67,7 +67,7 @@ internal class ArrayBroadcastChannel<E>(
         return true
     }
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     override fun cancel(cause: Throwable?): Boolean =
         cancelInternal(cause)
 

--- a/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
@@ -67,10 +67,17 @@ internal class ArrayBroadcastChannel<E>(
         return true
     }
 
-    public override fun cancel(cause: Throwable?): Boolean =
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    override fun cancel(cause: Throwable?): Boolean =
+        cancelInternal(cause)
+
+    override fun cancel(cause: CancellationException?) {
+        cancelInternal(cause)
+    }
+
+    private fun cancelInternal(cause: Throwable?): Boolean =
         close(cause).also {
-            @Suppress("DEPRECATION")
-            for (sub in subscribers) sub.cancel(cause)
+            for (sub in subscribers) sub.cancelInternal(cause)
         }
 
     // result is `OFFER_SUCCESS | OFFER_FAILED | Closed`
@@ -201,7 +208,7 @@ internal class ArrayBroadcastChannel<E>(
         override val isBufferAlwaysFull: Boolean get() = error("Should not be used")
         override val isBufferFull: Boolean get() = error("Should not be used")
 
-        override fun cancel(cause: Throwable?): Boolean =
+        override fun cancelInternal(cause: Throwable?): Boolean =
             close(cause).also { closed ->
                 if (closed) broadcastChannel.updateHead(removeSub = this)
                 clearBuffer()

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -90,7 +90,6 @@ private open class BroadcastCoroutine<E>(
     protected val _channel: BroadcastChannel<E>,
     active: Boolean
 ) : AbstractCoroutine<Unit>(parentContext, active), ProducerScope<E>, BroadcastChannel<E> by _channel {
-    override val cancelsParent: Boolean get() = true
     override val isActive: Boolean get() = super.isActive
 
     override val channel: SendChannel<E>
@@ -106,7 +105,7 @@ private open class BroadcastCoroutine<E>(
     override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
         val cause = (state as? CompletedExceptionally)?.cause
         val processed = _channel.close(cause)
-        if (cause != null && !processed && suppressed) handleExceptionViaHandler(context, cause)
+        if (cause != null && !processed && suppressed) handleCoroutineException(context, cause)
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -95,7 +95,7 @@ private open class BroadcastCoroutine<E>(
     override val channel: SendChannel<E>
         get() = this
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     final override fun cancel(cause: Throwable?): Boolean =
         cancelInternal(cause)
 

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -95,11 +95,18 @@ private open class BroadcastCoroutine<E>(
     override val channel: SendChannel<E>
         get() = this
 
-    override fun cancel(cause: Throwable?): Boolean {
-        val wasCancelled = _channel.cancel(cause)
-        @Suppress("DEPRECATION")
-        if (wasCancelled) cancelCoroutine(cause) // cancel the job
-        return wasCancelled
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    final override fun cancel(cause: Throwable?): Boolean =
+        cancelInternal(cause)
+
+    final override fun cancel(cause: CancellationException?) {
+        cancelInternal(cause)
+    }
+
+    override fun cancelInternal(cause: Throwable?): Boolean {
+        _channel.cancel(cause?.toCancellationException()) // cancel the channel
+        cancelCoroutine(cause) // cancel the job
+        return true // does not matter - result is used in DEPRECATED functions only
     }
 
     override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -98,7 +98,7 @@ private open class BroadcastCoroutine<E>(
     override fun cancel(cause: Throwable?): Boolean {
         val wasCancelled = _channel.cancel(cause)
         @Suppress("DEPRECATION")
-        if (wasCancelled) super.cancel(cause) // cancel the job
+        if (wasCancelled) cancelCoroutine(cause) // cancel the job
         return wasCancelled
     }
 

--- a/kotlinx-coroutines-core/common/src/channels/BroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BroadcastChannel.kt
@@ -30,14 +30,19 @@ public interface BroadcastChannel<E> : SendChannel<E> {
     public fun openSubscription(): ReceiveChannel<E>
 
     /**
-     * Cancels reception of remaining elements from this channel. This function closes the channel with
+     * Cancels reception of remaining elements from this channel with an optional cause.
+     * This function closes the channel with
      * the specified cause (unless it was already closed), removes all buffered sent elements from it,
      * and [cancels][ReceiveChannel.cancel] all open subscriptions.
-     * This function returns `true` if the channel was not closed previously, or `false` otherwise.
-     *
-     * A channel that was cancelled with non-null [cause] is called a _failed_ channel. Attempts to send or
-     * receive on a failed channel throw the specified [cause] exception.
+     * A cause can be used to specify an error message or to provide other details on
+     * a cancellation reason for debugging purposes.
      */
+    public fun cancel(cause: CancellationException? = null)
+
+    /**
+     * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
+     */
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
     public fun cancel(cause: Throwable? = null): Boolean
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -241,8 +241,10 @@ public interface ReceiveChannel<out E> {
     public operator fun iterator(): ChannelIterator<E>
 
     /**
-     * Cancels reception of remaining elements from this channel. This function closes the channel
-     * and removes all buffered sent elements from it.
+     * Cancels reception of remaining elements from this channel with an optional [cause].
+     * This function closes the channel and removes all buffered sent elements from it.
+     * A cause can be used to specify an error message or to provide other details on
+     * a cancellation reason for debugging purposes.
      *
      * Immediately after invocation of this function [isClosedForReceive] and
      * [isClosedForSend][SendChannel.isClosedForSend]
@@ -250,21 +252,18 @@ public interface ReceiveChannel<out E> {
      * afterwards will throw [ClosedSendChannelException], while attempts to receive will throw
      * [ClosedReceiveChannelException].
      */
-    public fun cancel(): Unit
+    public fun cancel(cause: CancellationException? = null)
 
     /**
-     * @suppress
+     * @suppress This method implements old version of JVM ABI. Use [cancel].
      */
-    @Suppress("INAPPLICABLE_JVM_NAME", "DEPRECATION")
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Left here for binary compatibility")
-    @JvmName("cancel")
-    public fun cancel0(): Boolean = cancel(null)
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    public fun cancel() = cancel(null)
 
     /**
-     * @suppress
+     * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @ObsoleteCoroutinesApi
-    @Deprecated(level = DeprecationLevel.WARNING, message = "Use cancel without cause", replaceWith = ReplaceWith("cancel()"))
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
     public fun cancel(cause: Throwable? = null): Boolean
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -257,13 +257,13 @@ public interface ReceiveChannel<out E> {
     /**
      * @suppress This method implements old version of JVM ABI. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     public fun cancel() = cancel(null)
 
     /**
      * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     public fun cancel(cause: Throwable? = null): Boolean
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -19,7 +19,7 @@ internal open class ChannelCoroutine<E>(
         cancelInternal(null)
     }
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     final override fun cancel(cause: Throwable?): Boolean =
         cancelInternal(cause)
 

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -23,7 +23,7 @@ internal open class ChannelCoroutine<E>(
 
     override fun cancel(cause: Throwable?): Boolean {
         val wasCancelled = _channel.cancel(cause)
-        if (wasCancelled) super.cancel(cause) // cancel the job
+        if (wasCancelled) cancelCoroutine(cause) // cancel the job
         return wasCancelled
     }
 }

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -13,8 +13,6 @@ internal open class ChannelCoroutine<E>(
     protected val _channel: Channel<E>,
     active: Boolean
 ) : AbstractCoroutine<Unit>(parentContext, active), Channel<E> by _channel {
-    override val cancelsParent: Boolean get() = true
-
     val channel: Channel<E> get() = this
 
     override fun cancel() {

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -16,14 +16,20 @@ internal open class ChannelCoroutine<E>(
     val channel: Channel<E> get() = this
 
     override fun cancel() {
-        cancel(null)
+        cancelInternal(null)
     }
 
-    override fun cancel0(): Boolean = cancel(null)
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    final override fun cancel(cause: Throwable?): Boolean =
+        cancelInternal(cause)
 
-    override fun cancel(cause: Throwable?): Boolean {
-        val wasCancelled = _channel.cancel(cause)
-        if (wasCancelled) cancelCoroutine(cause) // cancel the job
-        return wasCancelled
+    final override fun cancel(cause: CancellationException?) {
+        cancelInternal(cause)
+    }
+
+    override fun cancelInternal(cause: Throwable?): Boolean {
+        _channel.cancel(cause?.toCancellationException()) // cancel the channel
+        cancelCoroutine(cause) // cancel the job
+        return true // does not matter - result is used in DEPRECATED functions only
     }
 }

--- a/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
@@ -67,7 +67,7 @@ public fun ReceiveChannel<*>.consumes(): CompletionHandler = { cause: Throwable?
 @PublishedApi
 internal fun ReceiveChannel<*>.cancelConsumed(cause: Throwable?) {
     cancel(cause?.let {
-        it as? CancellationException ?: CancellationException("Consumed", it)
+        it as? CancellationException ?: CancellationException("Channel was consumed, consumer had failed", it)
     })
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
@@ -204,7 +204,7 @@ public class ConflatedBroadcastChannel<E>() : BroadcastChannel<E> {
     /**
      * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     public override fun cancel(cause: Throwable?): Boolean = close(cause)
 
     /**

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
@@ -202,9 +202,22 @@ public class ConflatedBroadcastChannel<E>() : BroadcastChannel<E> {
     }
 
     /**
-     * Closes this broadcast channel. Same as [close].
+     * @suppress This method has bad semantics when cause is not a [CancellationException]. Use [cancel].
      */
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
     public override fun cancel(cause: Throwable?): Boolean = close(cause)
+
+    /**
+     * Cancels this conflated broadcast channel with an optional cause, same as [close].
+     * This function closes the channel with
+     * the specified cause (unless it was already closed),
+     * and [cancels][ReceiveChannel.cancel] all open subscriptions.
+     * A cause can be used to specify an error message or to provide other details on
+     * a cancellation reason for debugging purposes.
+     */
+    public override fun cancel(cause: CancellationException?) {
+        close(cause)
+    }
 
     /**
      * Sends the value to all subscribed receives and stores this value as the most recent state for
@@ -268,11 +281,10 @@ public class ConflatedBroadcastChannel<E>() : BroadcastChannel<E> {
         block.startCoroutineUnintercepted(receiver = this, completion = select.completion)
     }
 
-    @Suppress("DEPRECATION")
     private class Subscriber<E>(
         private val broadcastChannel: ConflatedBroadcastChannel<E>
     ) : ConflatedChannel<E>(), ReceiveChannel<E> {
-        override fun cancel(cause: Throwable?): Boolean =
+        override fun cancelInternal(cause: Throwable?): Boolean =
             close(cause).also { closed ->
                 if (closed) broadcastChannel.closeSubscriber(this)
             }

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -97,6 +97,6 @@ private class ProducerCoroutine<E>(
     override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
         val cause = (state as? CompletedExceptionally)?.cause
         val processed = _channel.close(cause)
-        if (cause != null && !processed && suppressed) handleExceptionViaHandler(context, cause)
+        if (cause != null && !processed && suppressed) handleCoroutineException(context, cause)
     }
 }

--- a/kotlinx-coroutines-core/common/src/internal/Scopes.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Scopes.kt
@@ -19,6 +19,9 @@ internal open class ScopeCoroutine<in T>(
     final override fun getStackTraceElement(): StackTraceElement? = null
     override val defaultResumeMode: Int get() = MODE_DIRECT
 
+    override val cancelsParent: Boolean
+        get() = false // it throws exception to parent instead of cancelling it
+
     @Suppress("UNCHECKED_CAST")
     internal override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
         if (state is CompletedExceptionally) {

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -309,10 +309,13 @@ internal class SelectBuilderImpl<in R>(
 
     @PublishedApi
     internal fun handleBuilderException(e: Throwable) {
-        if (trySelect(null))
+        if (trySelect(null)) {
             resumeWithException(e)
-        else
+        } else {
+            // Cannot handle this exception -- builder was already resumed with a different exception,
+            // so treat it as "unhandled exception"
             handleCoroutineException(context, e)
+        }
     }
 
     override val isSelected: Boolean get() = state !== this

--- a/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
+++ b/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
@@ -86,7 +86,7 @@ class AbstractCoroutineTest : TestBase() {
         expect(2)
         coroutine.start()
         expect(4)
-        coroutine.cancel(TestException1())
+        coroutine.cancelCoroutine(TestException1())
         expect(7)
         coroutine.resumeWithException(TestException2())
         finish(10)

--- a/kotlinx-coroutines-core/common/test/AsyncTest.kt
+++ b/kotlinx-coroutines-core/common/test/AsyncTest.kt
@@ -52,16 +52,20 @@ class AsyncTest : TestBase() {
     }
 
     @Test
-    fun testCancellationWithCause() = runTest(expected = { it is TestException }) {
+    fun testCancellationWithCause() = runTest {
         expect(1)
         val d = async(NonCancellable, start = CoroutineStart.ATOMIC) {
-            finish(3)
+            expect(3)
             yield()
         }
-
         expect(2)
-        d.cancel(TestException())
-        d.await()
+        d.cancel(TestCancellationException("TEST"))
+        try {
+            d.await()
+        } catch (e: TestCancellationException) {
+            finish(4)
+            assertEquals("TEST", e.message)
+        }
     }
 
     @Test
@@ -155,7 +159,7 @@ class AsyncTest : TestBase() {
             throw TestException()
         }
         expect(1)
-        deferred.cancel(TestException())
+        deferred.cancel()
         try {
             deferred.await()
         } catch (e: TestException) {

--- a/kotlinx-coroutines-core/common/test/AwaitTest.kt
+++ b/kotlinx-coroutines-core/common/test/AwaitTest.kt
@@ -37,11 +37,11 @@ class AwaitTest : TestBase() {
     fun testAwaitAllLazy() = runTest {
         expect(1)
         val d = async(start = CoroutineStart.LAZY) {
-            expect(2);
+            expect(2)
             1
         }
         val d2 = async(start = CoroutineStart.LAZY) {
-            expect(3);
+            expect(3)
             2
         }
         assertEquals(listOf(1, 2), awaitAll(d, d2))
@@ -203,9 +203,9 @@ class AwaitTest : TestBase() {
     @Test
     fun testAwaitAllFullyCompletedExceptionally() = runTest {
         val d1 = CompletableDeferred<Unit>(parent = null)
-            .apply { cancel(TestException()) }
+            .apply { completeExceptionally(TestException()) }
         val d2 = CompletableDeferred<Unit>(parent = null)
-            .apply { cancel(TestException()) }
+            .apply { completeExceptionally(TestException()) }
         val job = async { expect(3) }
         expect(1)
         try {

--- a/kotlinx-coroutines-core/common/test/CancellableContinuationHandlersTest.kt
+++ b/kotlinx-coroutines-core/common/test/CancellableContinuationHandlersTest.kt
@@ -2,6 +2,8 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED") // KT-21913
+
 package kotlinx.coroutines
 
 import kotlin.coroutines.*
@@ -77,10 +79,18 @@ class CancellableContinuationHandlersTest : TestBase() {
     }
 
     @Test
-    fun testExceptionInHandler() = runTest({it is CompletionHandlerException}) {
-        suspendCancellableCoroutine<Unit> { c ->
-            c.invokeOnCancellation { throw AssertionError() }
-            c.cancel()
+    fun testExceptionInHandler() = runTest(
+        unhandled = listOf({ it -> it is CompletionHandlerException })
+    ) {
+        expect(1)
+        try {
+            suspendCancellableCoroutine<Unit> { c ->
+                c.invokeOnCancellation { throw AssertionError() }
+                c.cancel()
+            }
+        } catch (e: CancellationException) {
+            expect(2)
         }
+        finish(3)
     }
 }

--- a/kotlinx-coroutines-core/common/test/CompletableDeferredTest.kt
+++ b/kotlinx-coroutines-core/common/test/CompletableDeferredTest.kt
@@ -64,9 +64,9 @@ class CompletableDeferredTest : TestBase() {
     @Test
     fun testCancelWithException() {
         val c = CompletableDeferred<String>()
-        assertEquals(true, c.cancel(TestException()))
+        assertEquals(true, c.completeExceptionally(TestException()))
         checkCancelWithException(c)
-        assertEquals(false, c.cancel(TestException()))
+        assertEquals(false, c.completeExceptionally(TestException()))
         checkCancelWithException(c)
     }
 
@@ -111,7 +111,7 @@ class CompletableDeferredTest : TestBase() {
         val c = CompletableDeferred<String>(parent)
         checkFresh(c)
         assertEquals(true, parent.isActive)
-        assertEquals(true, c.cancel(TestException()))
+        assertEquals(true, c.completeExceptionally(TestException()))
         checkCancelWithException(c)
         assertEquals(false, parent.isActive)
         assertEquals(true, parent.isCancelled)

--- a/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
+++ b/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
@@ -120,9 +120,14 @@ class CoroutineScopeTest : TestBase() {
             try {
                 callJobScoped()
                 expectUnreached()
-            } catch (e: CancellationException) {
+            } catch (e: JobCancellationException) {
                 expect(5)
-                assertNull(e.cause)
+                if (RECOVER_STACK_TRACES) {
+                    val cause = e.cause as JobCancellationException // shall be recovered JCE
+                    assertNull(cause.cause)
+                } else {
+                    assertNull(e.cause)
+                }
             }
         }
         repeat(3) { yield() } // let everything to start properly

--- a/kotlinx-coroutines-core/common/test/CoroutinesTest.kt
+++ b/kotlinx-coroutines-core/common/test/CoroutinesTest.kt
@@ -313,7 +313,9 @@ class CoroutinesTest : TestBase() {
     }
 
     @Test
-    fun testNotCancellableChildWithExceptionCancelled() = runTest(expected = { it is IllegalArgumentException }) {
+    fun testNotCancellableChildWithExceptionCancelled() = runTest(
+        expected = { it is TestException }
+    ) {
         expect(1)
         // CoroutineStart.ATOMIC makes sure it will not get cancelled for it starts executing
         val d = async(NonCancellable, start = CoroutineStart.ATOMIC) {
@@ -323,8 +325,8 @@ class CoroutinesTest : TestBase() {
         }
         expect(2)
         // now cancel with some other exception
-        d.cancel(IllegalArgumentException())
-        // now await to see how it got crashed -- IAE should have been suppressed by TestException
+        d.cancel(TestCancellationException())
+        // now await to see how it got crashed -- TestCancellationException should have been suppressed by TestException
         expect(3)
         d.await()
     }

--- a/kotlinx-coroutines-core/common/test/JobTest.kt
+++ b/kotlinx-coroutines-core/common/test/JobTest.kt
@@ -203,7 +203,7 @@ class JobTest : TestBase() {
     fun testJobWithParentCancelException() {
         val parent = Job()
         val job = Job(parent)
-        job.cancel(TestException())
+        job.completeExceptionally(TestException())
         assertTrue(job.isCancelled)
         assertTrue(parent.isCancelled)
     }

--- a/kotlinx-coroutines-core/common/test/NonCancellableTest.kt
+++ b/kotlinx-coroutines-core/common/test/NonCancellableTest.kt
@@ -51,13 +51,14 @@ class NonCancellableTest : TestBase() {
         }
 
         yield()
-        deferred.cancel(TestException())
+        deferred.cancel(TestCancellationException("TEST"))
         expect(3)
         assertTrue(deferred.isCancelled)
         try {
             deferred.await()
             expectUnreached()
-        } catch (e: TestException) {
+        } catch (e: TestCancellationException) {
+            assertEquals("TEST", e.message)
             finish(6)
         }
     }

--- a/kotlinx-coroutines-core/common/test/NonCancellableTest.kt
+++ b/kotlinx-coroutines-core/common/test/NonCancellableTest.kt
@@ -29,8 +29,13 @@ class NonCancellableTest : TestBase() {
         try {
             job.await()
             expectUnreached()
-        } catch (e: CancellationException) {
-            assertNull(e.cause)
+        } catch (e: JobCancellationException) {
+            if (RECOVER_STACK_TRACES) {
+                val cause = e.cause as JobCancellationException // shall be recovered JCE
+                assertNull(cause.cause)
+            } else {
+                assertNull(e.cause)
+            }
             finish(6)
         }
     }
@@ -119,8 +124,13 @@ class NonCancellableTest : TestBase() {
         try {
             job.await()
             expectUnreached()
-        } catch (e: CancellationException) {
-            assertNull(e.cause)
+        } catch (e: JobCancellationException) {
+            if (RECOVER_STACK_TRACES) {
+                val cause = e.cause as JobCancellationException // shall be recovered JCE
+                assertNull(cause.cause)
+            } else {
+                assertNull(e.cause)
+            }
             finish(7)
         }
     }

--- a/kotlinx-coroutines-core/common/test/SupervisorTest.kt
+++ b/kotlinx-coroutines-core/common/test/SupervisorTest.kt
@@ -168,7 +168,7 @@ class SupervisorTest : TestBase() {
         }
         expect(1)
         yield()
-        parent.cancel(TestException1())
+        parent.completeExceptionally(TestException1())
         try {
             deferred.await()
             expectUnreached()
@@ -190,7 +190,7 @@ class SupervisorTest : TestBase() {
     fun testSupervisorWithParentCancelException() {
         val parent = Job()
         val supervisor = SupervisorJob(parent)
-        supervisor.cancel(TestException1())
+        supervisor.completeExceptionally(TestException1())
         assertTrue(supervisor.isCancelled)
         assertTrue(parent.isCancelled)
     }

--- a/kotlinx-coroutines-core/common/test/TestBase.common.kt
+++ b/kotlinx-coroutines-core/common/test/TestBase.common.kt
@@ -28,8 +28,10 @@ public class TestException(message: String? = null) : Throwable(message), NonRec
 public class TestException1(message: String? = null) : Throwable(message), NonRecoverableThrowable
 public class TestException2(message: String? = null) : Throwable(message), NonRecoverableThrowable
 public class TestException3(message: String? = null) : Throwable(message), NonRecoverableThrowable
+public class TestCancellationException(message: String? = null) : CancellationException(message), NonRecoverableThrowable
 public class TestRuntimeException(message: String? = null) : RuntimeException(message), NonRecoverableThrowable
 public class RecoverableTestException(message: String? = null) : RuntimeException(message)
+public class RecoverableTestCancellationException(message: String? = null) : CancellationException(message)
 
 public fun wrapperDispatcher(context: CoroutineContext): CoroutineContext {
     val dispatcher = context[ContinuationInterceptor] as CoroutineDispatcher

--- a/kotlinx-coroutines-core/common/test/WithContextTest.kt
+++ b/kotlinx-coroutines-core/common/test/WithContextTest.kt
@@ -198,7 +198,7 @@ class WithContextTest : TestBase() {
     }
 
     @Test
-    fun testRunSelfCancellationWithException() = runTest(unhandled = listOf({e -> e is AssertionError})) {
+    fun testRunSelfCancellationWithException() = runTest {
         expect(1)
         var job: Job? = null
         job = launch(Job()) {
@@ -208,13 +208,12 @@ class WithContextTest : TestBase() {
                     require(isActive)
                     expect(5)
                     job!!.cancel()
-                    require(job!!.cancel(AssertionError())) // cancel again, no success here
                     require(!isActive)
-                    throw TestException() // but throw a different exception
+                    throw TestException() // but throw an exception
                 }
             } catch (e: Throwable) {
                 expect(7)
-                // make sure TestException, not CancellationException or AssertionError is thrown
+                // make sure TestException, not CancellationException is thrown
                 assertTrue(e is TestException, "Caught $e")
             }
         }
@@ -228,7 +227,7 @@ class WithContextTest : TestBase() {
     }
 
     @Test
-    fun testRunSelfCancellation() = runTest(unhandled = listOf({e -> e is AssertionError})) {
+    fun testRunSelfCancellation() = runTest {
         expect(1)
         var job: Job? = null
         job = launch(Job()) {
@@ -238,14 +237,13 @@ class WithContextTest : TestBase() {
                     require(isActive)
                     expect(5)
                     job!!.cancel() // cancel itself
-                    require(job!!.cancel(AssertionError()))
                     require(!isActive)
                     "OK".wrap()
                 }
                 expectUnreached()
             } catch (e: Throwable) {
                 expect(7)
-                // make sure JCE is thrown
+                // make sure CancellationException is thrown
                 assertTrue(e is CancellationException, "Caught $e")
             }
         }

--- a/kotlinx-coroutines-core/common/test/channels/ArrayBroadcastChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ArrayBroadcastChannelTest.kt
@@ -162,7 +162,9 @@ class ArrayBroadcastChannelTest : TestBase() {
         val channel = BroadcastChannel<Int>(1)
         // launch generator (for later) in this context
         launch {
-            for (x in 1..5) channel.send(x)
+            for (x in 1..5) {
+                channel.send(x)
+            }
             channel.close()
         }
         // start consuming
@@ -188,10 +190,10 @@ class ArrayBroadcastChannelTest : TestBase() {
     }
 
     @Test
-    fun testCancelWithCause() = runTest({ it is TestException }) {
+    fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = BroadcastChannel<Int>(1)
         val subscription = channel.openSubscription()
-        subscription.cancel(TestException())
+        subscription.cancel(TestCancellationException())
         subscription.receiveOrNull()
     }
 

--- a/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
@@ -139,9 +139,9 @@ class ArrayChannelTest : TestBase() {
     }
 
     @Test
-    fun testCancelWithCause() = runTest({ it is TestException }) {
+    fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(5)
-        channel.cancel(TestException())
+        channel.cancel(TestCancellationException())
         channel.receiveOrNull()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/ConflatedChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ConflatedChannelTest.kt
@@ -78,9 +78,9 @@ class ConflatedChannelTest : TestBase() {
     }
 
     @Test
-    fun testCancelWithCause() = runTest({ it is TestException }) {
+    fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(Channel.CONFLATED)
-        channel.cancel(TestException())
+        channel.cancel(TestCancellationException())
         channel.receiveOrNull()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/LinkedListChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/LinkedListChannelTest.kt
@@ -35,9 +35,9 @@ class LinkedListChannelTest : TestBase() {
     }
 
     @Test
-    fun testCancelWithCause() = runTest({ it is TestException }) {
+    fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(Channel.UNLIMITED)
-        channel.cancel(TestException())
+        channel.cancel(TestCancellationException())
         channel.receiveOrNull()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
@@ -65,7 +65,7 @@ class ProduceTest : TestBase() {
                 expectUnreached()
             } catch (e: Throwable) {
                 expect(6)
-                check(e is TestException)
+                check(e is TestCancellationException)
                 throw e
             }
             expectUnreached()
@@ -73,11 +73,11 @@ class ProduceTest : TestBase() {
         expect(1)
         check(c.receive() == 1)
         expect(4)
-        c.cancel(TestException())
+        c.cancel(TestCancellationException())
         try {
             assertNull(c.receiveOrNull())
             expectUnreached()
-        } catch (e: TestException) {
+        } catch (e: TestCancellationException) {
             expect(5)
         }
         yield() // to produce

--- a/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
@@ -277,9 +277,9 @@ class RendezvousChannelTest : TestBase() {
     }
 
     @Test
-    fun testCancelWithCause() = runTest({ it is TestException }) {
+    fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(Channel.RENDEZVOUS)
-        channel.cancel(TestException())
+        channel.cancel(TestCancellationException())
         channel.receiveOrNull()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
+++ b/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines.channels
 
+import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
 
 enum class TestChannelKind {
@@ -59,8 +60,13 @@ private class ChannelViaBroadcast<E>(
     override suspend fun receiveOrNull(): E? = sub.receiveOrNull()
     override fun poll(): E? = sub.poll()
     override fun iterator(): ChannelIterator<E> = sub.iterator()
-    override fun cancel(): Unit = sub.cancel()
-    override fun cancel(cause: Throwable?): Boolean = sub.cancel(cause)
+    
+    override fun cancel(cause: CancellationException?) = sub.cancel(cause)
+
+    // implementing hidden method anyway, so can cast to an internal class
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    override fun cancel(cause: Throwable?): Boolean = (sub as AbstractChannel).cancelInternal(cause)
+
     override val onReceive: SelectClause1<E>
         get() = sub.onReceive
     override val onReceiveOrNull: SelectClause1<E?>

--- a/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
+++ b/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
@@ -64,7 +64,7 @@ private class ChannelViaBroadcast<E>(
     override fun cancel(cause: CancellationException?) = sub.cancel(cause)
 
     // implementing hidden method anyway, so can cast to an internal class
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility only")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     override fun cancel(cause: Throwable?): Boolean = (sub as AbstractChannel).cancelInternal(cause)
 
     override val onReceive: SelectClause1<E>

--- a/kotlinx-coroutines-core/js/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/js/src/Exceptions.kt
@@ -55,7 +55,11 @@ internal fun IllegalStateException(message: String, cause: Throwable?) =
     IllegalStateException(message.withCause(cause))
 
 private fun String?.withCause(cause: Throwable?) =
-    if (cause == null) this else "$this; caused by $cause"
+    when {
+        cause == null -> this
+        this == null -> "caused by $cause"
+        else -> "$this; caused by $cause"
+    }
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun Throwable.addSuppressedThrowable(other: Throwable) { /* empty */ }

--- a/kotlinx-coroutines-core/js/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/js/src/Exceptions.kt
@@ -59,3 +59,6 @@ private fun String?.withCause(cause: Throwable?) =
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun Throwable.addSuppressedThrowable(other: Throwable) { /* empty */ }
+
+// For use in tests
+internal actual val RECOVER_STACK_TRACES: Boolean = false

--- a/kotlinx-coroutines-core/js/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/js/src/Exceptions.kt
@@ -24,6 +24,13 @@ public actual class CompletionHandlerException public actual constructor(
 public actual open class CancellationException actual constructor(message: String?) : IllegalStateException(message)
 
 /**
+ * Creates a cancellation exception with a specified message and [cause].
+ */
+@Suppress("FunctionName")
+public actual fun CancellationException(message: String?, cause: Throwable?) : CancellationException =
+    CancellationException(message.withCause(cause))
+
+/**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed
  * without cause, or with a cause or exception that is not [CancellationException]
  * (see [Job.getCancellationException]).
@@ -47,7 +54,7 @@ internal actual class DispatchException actual constructor(message: String, caus
 internal fun IllegalStateException(message: String, cause: Throwable?) =
     IllegalStateException(message.withCause(cause))
 
-private fun String.withCause(cause: Throwable?) =
+private fun String?.withCause(cause: Throwable?) =
     if (cause == null) this else "$this; caused by $cause"
 
 @Suppress("NOTHING_TO_INLINE")

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -75,7 +75,7 @@ private class BlockingCoroutine<T>(
             try {
                 while (true) {
                     @Suppress("DEPRECATION")
-                    if (Thread.interrupted()) throw InterruptedException().also { cancel(it) }
+                    if (Thread.interrupted()) throw InterruptedException().also { cancelCoroutine(it) }
                     val parkNanos = eventLoop?.processNextEvent() ?: Long.MAX_VALUE
                     // note: process next even may loose unpark flag, so check if completed before parking
                     if (isCompleted) break

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -58,6 +58,9 @@ private class BlockingCoroutine<T>(
     private val blockedThread: Thread,
     private val eventLoop: EventLoop?
 ) : AbstractCoroutine<T>(parentContext, true) {
+    override val cancelsParent: Boolean
+        get() = false // it throws exception to parent instead of cancelling it
+
     override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
         // wake up blocked thread
         if (Thread.currentThread() != blockedThread)

--- a/kotlinx-coroutines-core/jvm/src/Debug.kt
+++ b/kotlinx-coroutines-core/jvm/src/Debug.kt
@@ -48,8 +48,9 @@ public interface CopyableThrowable<T> where T : Throwable, T : CopyableThrowable
      * Creates a copy of the current instance.
      * For better debuggability, it is recommended to use original exception as [cause][Throwable.cause] of the resulting one.
      * Stacktrace of copied exception will be overwritten by stacktrace recovery machinery by [Throwable.setStackTrace] call.
+     * An exception can opt-out of copying by returning `null` from this function.
      */
-    public fun createCopy(): T
+    public fun createCopy(): T?
 }
 
 /**
@@ -77,8 +78,9 @@ internal val DEBUG = systemProp(DEBUG_PROPERTY_NAME).let { value ->
     }
 }
 
+// Note: stack-trace recovery is enabled only in debug mode
 @JvmField
-internal val RECOVER_STACKTRACES = systemProp(STACKTRACE_RECOVERY_PROPERTY_NAME, true)
+internal actual val RECOVER_STACK_TRACES = DEBUG && systemProp(STACKTRACE_RECOVERY_PROPERTY_NAME, true)
 
 // internal debugging tools
 

--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -41,7 +41,7 @@ internal actual class JobCancellationException public actual constructor(
     message: String,
     cause: Throwable?,
     @JvmField internal actual val job: Job
-) : CancellationException(message) {
+) : CancellationException(message), CopyableThrowable<JobCancellationException> {
 
     init {
         if (cause != null) initCause(cause)
@@ -58,6 +58,17 @@ internal actual class JobCancellationException public actual constructor(
          * and hurts performance.
          */
         return this
+    }
+
+    override fun createCopy(): JobCancellationException? {
+        if (DEBUG) {
+            return JobCancellationException(message!!, this, job)
+        }
+
+        /*
+         * In non-debug mode we don't copy JCE for speed as it does not have the stack trace anyway.
+         */
+        return null
     }
 
     override fun toString(): String = "${super.toString()}; job=$job"

--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -2,6 +2,8 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("FunctionName")
+
 package kotlinx.coroutines
 
 /**
@@ -22,6 +24,13 @@ public actual class CompletionHandlerException actual constructor(
  * See [CoroutineExceptionHandler]
 */
 public actual typealias CancellationException = java.util.concurrent.CancellationException
+
+/**
+ * Creates a cancellation exception with a specified message and [cause].
+ */
+@Suppress("FunctionName")
+public actual fun CancellationException(message: String?, cause: Throwable?) : CancellationException =
+    CancellationException(message).apply { initCause(cause) }
 
 /**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed

--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -133,7 +133,10 @@ private open class ActorCoroutine<E>(
     }
 
     override val cancelsParent: Boolean get() = true
-    override fun handleJobException(exception: Throwable) = handleExceptionViaHandler(parentContext, exception)
+
+    override fun handleJobException(exception: Throwable, handled: Boolean) {
+        if (!handled) handleCoroutineException(context, exception)
+    }
 }
 
 private class LazyActorCoroutine<E>(

--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -128,8 +128,9 @@ private open class ActorCoroutine<E>(
     active: Boolean
 ) : ChannelCoroutine<E>(parentContext, channel, active), ActorScope<E> {
     override fun onCancellation(cause: Throwable?) {
-        @Suppress("DEPRECATION")
-        _channel.cancel(cause)
+        _channel.cancel(cause?.let {
+            it as? CancellationException ?: CancellationException("$classSimpleName was cancelled", it)
+        })
     }
 
     override val cancelsParent: Boolean get() = true

--- a/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstuctor.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstuctor.kt
@@ -20,7 +20,7 @@ private val exceptionCtors: WeakHashMap<Class<out Throwable>, Ctor> = WeakHashMa
 internal fun <E : Throwable> tryCopyException(exception: E): E? {
     // Fast path for CopyableThrowable
     if (exception is CopyableThrowable<*>) {
-        return runCatching { exception.createCopy() as E }.getOrNull()
+        return runCatching { exception.createCopy() as E? }.getOrNull()
     }
     // Use cached ctor if found
     cacheLock.read { exceptionCtors[exception.javaClass] }?.let { cachedCtor ->

--- a/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
@@ -165,7 +165,7 @@ internal actual fun <E : Throwable> unwrap(exception: E): E {
 }
 
 private fun <E : Throwable> recoveryDisabled(exception: E) =
-    !RECOVER_STACKTRACES || !DEBUG || exception is CancellationException || exception is NonRecoverableThrowable
+    !RECOVER_STACKTRACES || !DEBUG || exception is NonRecoverableThrowable
 
 private fun createStackTrace(continuation: CoroutineStackFrame): ArrayDeque<StackTraceElement> {
     val stack = ArrayDeque<StackTraceElement>()

--- a/kotlinx-coroutines-core/jvm/test/AwaitJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/AwaitJvmTest.kt
@@ -12,7 +12,7 @@ class AwaitJvmTest : TestBase() {
         // This test is to make sure that handlers installed on the second deferred do not leak
         val d1 = CompletableDeferred<Int>()
         val d2 = CompletableDeferred<Int>()
-        d1.cancel(TestException()) // first is crashed
+        d1.completeExceptionally(TestException()) // first is crashed
         val iterations = 3_000_000 * stressTestMultiplier
         for (iter in 1..iterations) {
             try {

--- a/kotlinx-coroutines-core/jvm/test/JoinStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/JoinStressTest.kt
@@ -6,7 +6,6 @@ package kotlinx.coroutines
 
 import org.junit.*
 import org.junit.Test
-import java.io.*
 import java.util.concurrent.*
 import kotlin.test.*
 
@@ -71,14 +70,15 @@ class JoinStressTest : TestBase() {
                     exceptionalJob.await()
                 } catch (e: TestException) {
                     0
-                } catch (e: IOException) {
+                } catch (e: TestException1) {
                     1
                 }
             }
 
             val canceller = async(pool + NonCancellable) {
                 barrier.await()
-                exceptionalJob.cancel(IOException())
+                // cast for test purposes only
+                (exceptionalJob as AbstractCoroutine<*>).cancelInternal(TestException1())
             }
 
             barrier.await()

--- a/kotlinx-coroutines-core/jvm/test/exceptions/JobBasicCancellationTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/JobBasicCancellationTest.kt
@@ -149,8 +149,8 @@ class JobBasicCancellationTest : TestBase() {
     @Test
     fun testConsecutiveCancellation() {
         val deferred = CompletableDeferred<Int>()
-        assertTrue(deferred.cancel(IndexOutOfBoundsException()))
-        assertFalse(deferred.cancel(AssertionError())) // second cancelled is too late
+        assertTrue(deferred.completeExceptionally(IndexOutOfBoundsException()))
+        assertFalse(deferred.completeExceptionally(AssertionError())) // second is too late
         val cause = deferred.getCancellationException().cause!!
         assertTrue(cause is IndexOutOfBoundsException)
         assertNull(cause.cause)

--- a/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
@@ -99,11 +99,11 @@ class ProduceExceptionsTest : TestBase() {
         var channel: ReceiveChannel<Int>? = null
         channel = produce(NonCancellable) {
             expect(2)
-            channel!!.cancel(TestException())
+            channel!!.cancel(TestCancellationException())
             try {
                 send(1)
                 // Not a ClosedForSendException
-            } catch (e: TestException) {
+            } catch (e: TestCancellationException) {
                 expect(3)
                 throw e
             }
@@ -113,7 +113,7 @@ class ProduceExceptionsTest : TestBase() {
         yield()
         try {
             channel.receive()
-        } catch (e: TestException) {
+        } catch (e: TestCancellationException) {
             assertTrue(e.suppressed.isEmpty())
             finish(4)
         }
@@ -148,7 +148,7 @@ class ProduceExceptionsTest : TestBase() {
         val job = Job()
         val channel = produce(job) {
             expect(2)
-            job.cancel(TestException2())
+            job.completeExceptionally(TestException2())
             try {
                 send(1)
             } catch (e: CancellationException) { // Not a TestException2

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryNestedChannelsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryNestedChannelsTest.kt
@@ -111,7 +111,7 @@ class StackTraceRecoveryNestedChannelsTest : TestBase() {
                 sendFromScope()
             } catch (e: Exception) {
                 verifyStackTrace(e,
-                    "kotlinx.coroutines.RecoverableTestException\n" +
+                    "kotlinx.coroutines.RecoverableTestCancellationException\n" +
                         "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryNestedChannelsTest\$testSendFromScope\$1.invokeSuspend(StackTraceRecoveryNestedChannelsTest.kt:118)\n" +
                         "\t(Coroutine boundary)\n" +
                         "\tat kotlinx.coroutines.channels.AbstractSendChannel.offer(AbstractChannel.kt:180)\n" +
@@ -120,7 +120,7 @@ class StackTraceRecoveryNestedChannelsTest : TestBase() {
                         "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryNestedChannelsTest\$sendWithContext\$2.invokeSuspend(StackTraceRecoveryNestedChannelsTest.kt:19)\n" +
                         "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryNestedChannelsTest\$sendFromScope\$2.invokeSuspend(StackTraceRecoveryNestedChannelsTest.kt:29)\n" +
                         "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryNestedChannelsTest\$testSendFromScope\$1\$deferred\$1.invokeSuspend(StackTraceRecoveryNestedChannelsTest.kt:109)\n" +
-                    "Caused by: kotlinx.coroutines.RecoverableTestException\n" +
+                    "Caused by: kotlinx.coroutines.RecoverableTestCancellationException\n" +
                         "\tat kotlinx.coroutines.exceptions.StackTraceRecoveryNestedChannelsTest\$testSendFromScope\$1.invokeSuspend(StackTraceRecoveryNestedChannelsTest.kt:118)\n" +
                         "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)")
             }
@@ -129,7 +129,7 @@ class StackTraceRecoveryNestedChannelsTest : TestBase() {
         yield()
         expect(2)
         // Cancel is an analogue of `produce` failure, just a shorthand
-        channel.cancel(RecoverableTestException())
+        channel.cancel(RecoverableTestCancellationException())
         finish(3)
         deferred.await()
     }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
@@ -12,25 +12,6 @@ import kotlin.test.*
 
 @Suppress("DEPRECATION")
 class SuppressionTests : TestBase() {
-
-    @Test
-    fun testCancellationTransparency() = runTest {
-        val deferred = async(NonCancellable, start = CoroutineStart.ATOMIC) {
-            expect(2)
-            throw ArithmeticException()
-        }
-
-        expect(1)
-        deferred.cancel(TestException("Message"))
-
-        try {
-            deferred.await()
-        } catch (e: TestException) {
-            checkException<ArithmeticException>(e.suppressed[0])
-            finish(3)
-        }
-    }
-
     @Test
     fun testNotificationsWithException() = runTest {
         expect(1)
@@ -72,7 +53,7 @@ class SuppressionTests : TestBase() {
         expect(2)
         coroutine.start()
         expect(4)
-        coroutine.cancel(ArithmeticException())
+        coroutine.cancelInternal(ArithmeticException())
         expect(7)
         coroutine.resumeWithException(IOException())
         finish(10)
@@ -88,7 +69,7 @@ class SuppressionTests : TestBase() {
             }
 
             launch {
-                val exception = RecoverableTestException()
+                val exception = RecoverableTestCancellationException()
                 channel.cancel(exception)
                 throw exception
             }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/WithContextExceptionHandlingTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/WithContextExceptionHandlingTest.kt
@@ -171,8 +171,10 @@ class WithContextExceptionHandlingTest(private val mode: Mode) : TestBase() {
     @Test
     fun testCancel() = runTest {
         runOnlyCancellation(null) { e ->
-            assertNull(e.cause)
+            val cause = e.cause as JobCancellationException // shall be recovered JCE
+            assertNull(cause.cause)
             assertTrue(e.suppressed.isEmpty())
+            assertTrue(cause.suppressed.isEmpty())
         }
     }
 

--- a/kotlinx-coroutines-core/native/src/Builders.kt
+++ b/kotlinx-coroutines-core/native/src/Builders.kt
@@ -52,6 +52,9 @@ private class BlockingCoroutine<T>(
     parentContext: CoroutineContext,
     private val eventLoop: EventLoop?
 ) : AbstractCoroutine<T>(parentContext, true) {
+    override val cancelsParent: Boolean
+        get() = false // it throws exception to parent instead of cancelling it
+
     @Suppress("UNCHECKED_CAST")
     fun joinBlocking(): T {
         try {

--- a/kotlinx-coroutines-core/native/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/native/src/Exceptions.kt
@@ -55,7 +55,11 @@ internal fun IllegalStateException(message: String, cause: Throwable?) =
     IllegalStateException(message.withCause(cause))
 
 private fun String?.withCause(cause: Throwable?) =
-    if (cause == null) this else "$this; caused by $cause"
+    when {
+        cause == null -> this
+        this == null -> "caused by $cause"
+        else -> "$this; caused by $cause"
+    }
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun Throwable.addSuppressedThrowable(other: Throwable) { /* empty */ }

--- a/kotlinx-coroutines-core/native/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/native/src/Exceptions.kt
@@ -59,3 +59,6 @@ private fun String?.withCause(cause: Throwable?) =
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun Throwable.addSuppressedThrowable(other: Throwable) { /* empty */ }
+
+// For use in tests
+internal actual val RECOVER_STACK_TRACES: Boolean = false

--- a/kotlinx-coroutines-core/native/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/native/src/Exceptions.kt
@@ -24,6 +24,13 @@ public actual class CompletionHandlerException public actual constructor(
 public actual open class CancellationException actual constructor(message: String?) : IllegalStateException(message)
 
 /**
+ * Creates a cancellation exception with a specified message and [cause].
+ */
+@Suppress("FunctionName")
+public actual fun CancellationException(message: String?, cause: Throwable?) : CancellationException =
+    CancellationException(message.withCause(cause))
+
+/**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed
  * without cause, or with a cause or exception that is not [CancellationException]
  * (see [Job.getCancellationException]).
@@ -47,7 +54,7 @@ internal actual class DispatchException actual constructor(message: String, caus
 internal fun IllegalStateException(message: String, cause: Throwable?) =
     IllegalStateException(message.withCause(cause))
 
-private fun String.withCause(cause: Throwable?) =
+private fun String?.withCause(cause: Throwable?) =
     if (cause == null) this else "$this; caused by $cause"
 
 @Suppress("NOTHING_TO_INLINE")

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -260,6 +260,6 @@ private class PublisherCoroutine<in T>(
         // Specification requires that after cancellation publisher stops signalling
         // This flag distinguishes subscription cancellation request from the job crash
         cancelled = true
-        super.cancel()
+        super.cancel(null)
     }
 }

--- a/reactive/kotlinx-coroutines-reactor/src/Mono.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Mono.kt
@@ -42,8 +42,6 @@ private class MonoCoroutine<in T>(
     parentContext: CoroutineContext,
     private val sink: MonoSink<T>
 ) : AbstractCoroutine<T>(parentContext, true), Disposable {
-    override val cancelsParent: Boolean get() = true
-
     var disposed = false
 
     override fun onCompleted(value: T) {

--- a/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
@@ -40,7 +40,6 @@ private class RxCompletableCoroutine(
     parentContext: CoroutineContext,
     private val subscriber: CompletableEmitter
 ) : AbstractCoroutine<Unit>(parentContext, true) {
-    override val cancelsParent: Boolean get() = true
     override fun onCompleted(value: Unit) {
         if (!subscriber.isDisposed) subscriber.onComplete()
     }

--- a/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
@@ -43,7 +43,6 @@ private class RxMaybeCoroutine<T>(
     parentContext: CoroutineContext,
     private val subscriber: MaybeEmitter<T>
 ) : AbstractCoroutine<T>(parentContext, true) {
-    override val cancelsParent: Boolean get() = true
     override fun onCompleted(value: T) {
         if (!subscriber.isDisposed) {
             if (value == null) subscriber.onComplete() else subscriber.onSuccess(value)

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -65,7 +65,7 @@ private class RxObservableCoroutine<T: Any>(
 
     override val isClosedForSend: Boolean get() = isCompleted
     override val isFull: Boolean = mutex.isLocked
-    override fun close(cause: Throwable?): Boolean = cancel(cause)
+    override fun close(cause: Throwable?): Boolean = cancelCoroutine(cause)
     override fun invokeOnClose(handler: (Throwable?) -> Unit) =
         throw UnsupportedOperationException("RxObservableCoroutine doesn't support invokeOnClose")
 
@@ -113,7 +113,7 @@ private class RxObservableCoroutine<T: Any>(
             // If onNext fails with exception, then we cancel coroutine (with this exception) and then rethrow it
             // to abort the corresponding send/offer invocation. From the standpoint of coroutines machinery,
             // this failure is essentially equivalent to a failure of a child coroutine.
-            childCancelled(e)
+            cancelCoroutine(e)
             doLockedSignalCompleted()
             throw e
         }

--- a/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
@@ -40,7 +40,6 @@ private class RxSingleCoroutine<T: Any>(
     parentContext: CoroutineContext,
     private val subscriber: SingleEmitter<T>
 ) : AbstractCoroutine<T>(parentContext, true) {
-    override val cancelsParent: Boolean get() = true
     override fun onCompleted(value: T) {
         if (!subscriber.isDisposed) subscriber.onSuccess(value)
     }


### PR DESCRIPTION
Structured concurrency for Completable/Listenable futures

BREAKING BEHAVIOR CHANGE:

* kotlinx-coroutines-jdk8 and -guava integration modules
  future { ... } builders now honor structured concurrency in
  the same way as all other builders -- a failure inside the child
  (builder) code now cancels parent coroutine.
  Note that is does not affect non-structured (typical) usage like
  GlobalScope.future { ... }

MINOR BEHAVIOR CHANGE:

* Exception in installed CancellableCoroutine.invokeOnCancellation
  handler does not cancel the parent job, but is considered to be an
  uncaught exception, so it goes to CoroutineExceptionHandler.

Internal changes:

* JobSupport.cancelsParents=true is now a default, since there are
  only a fewer exceptions for builder that throw their exception from block
* JobSupport.handleJobException has additional "handled" parameter to
  distinguish cases when parent did/did-not handle it.
* handleCoroutineException logic is updated. It never cancels parent,
  since parent cancellation is taken care of by structured concurrency.
* handleCoroutineException is always invoked with current coroutine's
  context (as opposed to parent)

Fixes #1007

Hide cancel(Throwable), introduce cancel(CancellationException)

Job/ReceiveChannel/BroadcastChannel.cancel(Throwable) is now hidden and
cannot be invoked from a newly compiled code. This function had broken
semantics when used with an arbitrary exception. A safe replacement
is available in the form of cancel(CancellationException) where
CancellationException can be used to supply additional information
for debugging purposes.

Fixes #975