### PR TITLE
Amortize the cost of coroutine dispatch using message queue in all JS…

### DIFF
--- a/kotlinx-coroutines-core/js/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/js/src/CoroutineContext.kt
@@ -16,16 +16,16 @@ internal actual fun createDefaultDispatcher(): CoroutineDispatcher = when {
     // For details see https://github.com/Kotlin/kotlinx.coroutines/issues/236
     // The check for ReactNative is based on https://github.com/facebook/react-native/commit/3c65e62183ce05893be0822da217cb803b121c61
     jsTypeOf(navigator) != UNDEFINED && navigator != null && navigator.product == "ReactNative" ->
-        NodeDispatcher()
+        NodeDispatcher
     // Check if we are running under jsdom. WindowDispatcher doesn't work under jsdom because it accesses MessageEvent#source.
     // It is not implemented in jsdom, see https://github.com/jsdom/jsdom/blob/master/Changelog.md
     // "It's missing a few semantics, especially around origins, as well as MessageEvent source."
-    isJsdom() -> NodeDispatcher()
+    isJsdom() -> NodeDispatcher
     // Check if we are in the browser and must use window.postMessage to avoid setTimeout throttling
     jsTypeOf(window) != UNDEFINED && window.asDynamic() != null && jsTypeOf(window.asDynamic().addEventListener) != UNDEFINED ->
         window.asCoroutineDispatcher()
     // Fallback to NodeDispatcher when browser environment is not detected
-    else -> NodeDispatcher()
+    else -> NodeDispatcher
 }
 
 private fun isJsdom() = jsTypeOf(navigator) != UNDEFINED &&

--- a/kotlinx-coroutines-core/js/test/MessageQueueTest.kt
+++ b/kotlinx-coroutines-core/js/test/MessageQueueTest.kt
@@ -15,6 +15,10 @@ class MessageQueueTest {
             assertFalse(scheduled)
             scheduled = true
         }
+
+        override fun reschedule() {
+            schedule()
+        }
     }
 
     inner class Box(val i: Int): Runnable {


### PR DESCRIPTION
… dispatchers.

Use Promise.resolve and process.nextTick as dispatch mechanism for cold starts.

Fixes #820 


[Corresponding benchmarks](https://gist.github.com/qwwdfsad/06c69d6e576541575c17edf6e426ac15) is not part of this PR until https://github.com/orangy/gradle-benchmarks/pull/4 is integrated