### PR TITLE
Do not use reflective exception pre-handler on newer Androids, since …

### DIFF
--- a/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
+++ b/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
@@ -4,30 +4,42 @@
 
 package kotlinx.coroutines.android
 
+import android.os.*
 import android.support.annotation.*
 import kotlinx.coroutines.*
 import java.lang.reflect.*
 import kotlin.coroutines.*
 
-private val getter =
-    try {
-        Thread::class.java.getDeclaredMethod("getUncaughtExceptionPreHandler").takeIf {
-            Modifier.isPublic(it.modifiers) && Modifier.isStatic(it.modifiers)
-        }
-    }
-    catch (e: Throwable) { null /* not found */ }
+private val getter by lazy {
+     try {
+         Thread::class.java.getDeclaredMethod("getUncaughtExceptionPreHandler").takeIf {
+             Modifier.isPublic(it.modifiers) && Modifier.isStatic(it.modifiers)
+         }
+     } catch (e: Throwable) {
+         null /* not found */
+     }
+ }
 
-/**
- * Uses Android's `Thread.getUncaughtExceptionPreHandler()` whose default behavior is to log exception.
- * See
- * [here](https://github.com/aosp-mirror/platform_frameworks_base/blob/2efbc7239f419c931784acf98960ed6abc38c3f2/core/java/com/android/internal/os/RuntimeInit.java#L142)
- */
 @Keep
 internal class AndroidExceptionPreHandler :
     AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler
 {
     override fun handleException(context: CoroutineContext, exception: Throwable) {
-        (getter?.invoke(null) as? Thread.UncaughtExceptionHandler)
-            ?.uncaughtException(Thread.currentThread(), exception)
+        /*
+         * If we are on old SDK, then use Android's `Thread.getUncaughtExceptionPreHandler()` that ensures that
+         * an exception is logged before crashing the application.
+         *
+         * Since Android Pie default uncaught exception handler always ensures that exception is logged without interfering with
+         * pre-handler, so reflection hack is no longer needed.
+         *
+         * See https://android-review.googlesource.com/c/platform/frameworks/base/+/654578/
+         */
+        val thread = Thread.currentThread()
+        if (Build.VERSION.SDK_INT >= 28) {
+            thread.uncaughtExceptionHandler.uncaughtException(thread, exception)
+        } else {
+            (getter?.invoke(null) as? Thread.UncaughtExceptionHandler)
+                ?.uncaughtException(thread, exception)
+        }
     }
 }

--- a/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
+++ b/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
@@ -10,20 +10,21 @@ import kotlinx.coroutines.*
 import java.lang.reflect.*
 import kotlin.coroutines.*
 
-private val getter by lazy {
-     try {
-         Thread::class.java.getDeclaredMethod("getUncaughtExceptionPreHandler").takeIf {
-             Modifier.isPublic(it.modifiers) && Modifier.isStatic(it.modifiers)
-         }
-     } catch (e: Throwable) {
-         null /* not found */
-     }
- }
-
 @Keep
 internal class AndroidExceptionPreHandler :
-    AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler
-{
+    AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler, Function0<Method?> {
+
+    private val preHandler by lazy(this)
+
+    // Reflectively lookup pre-handler. Implement Function0 to avoid generating second class for lambda
+    override fun invoke(): Method? = try {
+        Thread::class.java.getDeclaredMethod("getUncaughtExceptionPreHandler").takeIf {
+            Modifier.isPublic(it.modifiers) && Modifier.isStatic(it.modifiers)
+        }
+    } catch (e: Throwable) {
+        null /* not found */
+    }
+
     override fun handleException(context: CoroutineContext, exception: Throwable) {
         /*
          * If we are on old SDK, then use Android's `Thread.getUncaughtExceptionPreHandler()` that ensures that
@@ -38,7 +39,7 @@ internal class AndroidExceptionPreHandler :
         if (Build.VERSION.SDK_INT >= 28) {
             thread.uncaughtExceptionHandler.uncaughtException(thread, exception)
         } else {
-            (getter?.invoke(null) as? Thread.UncaughtExceptionHandler)
+            (preHandler?.invoke(null) as? Thread.UncaughtExceptionHandler)
                 ?.uncaughtException(thread, exception)
         }
     }


### PR DESCRIPTION
…Pie runtime ensures that uncaught exception is always logged

Fixes #822