### PR TITLE
Improved coroutine exception handling logic

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -6,8 +6,8 @@ public abstract class kotlinx/coroutines/AbstractCoroutine : kotlinx/coroutines/
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun isActive ()Z
 	protected fun onCancellation (Ljava/lang/Throwable;)V
+	protected fun onCancelled (Ljava/lang/Throwable;Z)V
 	protected fun onCompleted (Ljava/lang/Object;)V
-	protected fun onCompletedExceptionally (Ljava/lang/Throwable;)V
 	protected fun onStart ()V
 	public final fun resumeWith (Ljava/lang/Object;)V
 	public final fun start (Lkotlinx/coroutines/CoroutineStart;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
@@ -382,11 +382,12 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	public fun getChildJobCancellationCause ()Ljava/lang/Throwable;
 	public final fun getChildren ()Lkotlin/sequences/Sequence;
 	protected final fun getCompletionCause ()Ljava/lang/Throwable;
+	protected final fun getCompletionCauseHandled ()Z
 	public final fun getCompletionExceptionOrNull ()Ljava/lang/Throwable;
 	protected fun getHandlesException ()Z
 	public final fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
 	public final fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
-	protected fun handleJobException (Ljava/lang/Throwable;Z)V
+	protected fun handleJobException (Ljava/lang/Throwable;)Z
 	public final fun invokeOnCompletion (Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
 	public final fun invokeOnCompletion (ZZLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
 	public fun isActive ()Z

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -5,9 +5,9 @@ public abstract class kotlinx/coroutines/AbstractCoroutine : kotlinx/coroutines/
 	public final fun getContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun isActive ()Z
-	protected fun onCancellation (Ljava/lang/Throwable;)V
 	protected fun onCancelled (Ljava/lang/Throwable;Z)V
 	protected fun onCompleted (Ljava/lang/Object;)V
+	protected final fun onCompletionInternal (Ljava/lang/Object;)V
 	protected fun onStart ()V
 	public final fun resumeWith (Ljava/lang/Object;)V
 	public final fun start (Lkotlinx/coroutines/CoroutineStart;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
@@ -368,6 +368,7 @@ public final class kotlinx/coroutines/JobKt {
 
 public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlinx/coroutines/Job, kotlinx/coroutines/ParentJob, kotlinx/coroutines/selects/SelectClause0 {
 	public fun <init> (Z)V
+	protected fun afterCompletionInternal (Ljava/lang/Object;I)V
 	public final fun attachChild (Lkotlinx/coroutines/ChildJob;)Lkotlinx/coroutines/ChildHandle;
 	public synthetic fun cancel ()V
 	public synthetic fun cancel (Ljava/lang/Throwable;)Z
@@ -396,7 +397,8 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	public final fun isCompletedExceptionally ()Z
 	public final fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
-	protected fun onCancellation (Ljava/lang/Throwable;)V
+	protected fun onCancelling (Ljava/lang/Throwable;)V
+	protected fun onCompletionInternal (Ljava/lang/Object;)V
 	public final fun parentCancelled (Lkotlinx/coroutines/ParentJob;)V
 	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
 	public fun plus (Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/Job;

--- a/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
+++ b/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
@@ -68,10 +68,10 @@ private class ListenableFutureCoroutine<T>(
         future.set(value)
     }
 
-    override fun handleJobException(exception: Throwable, handled: Boolean) {
-        if (!future.setException(exception) && !handled) {
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!future.setException(cause) && !handled) {
             // prevents loss of exception that was not handled by parent & could not be set to SettableFuture
-            handleCoroutineException(context, exception)
+            handleCoroutineException(context, cause)
         }
     }
 }

--- a/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/future/Future.kt
@@ -57,10 +57,10 @@ private class CompletableFutureCoroutine<T>(
         future.complete(value)
     }
 
-    override fun handleJobException(exception: Throwable, handled: Boolean) {
-        if (!future.completeExceptionally(exception) && !handled) {
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!future.completeExceptionally(cause) && !handled) {
             // prevents loss of exception that was not handled by parent & could not be set to CompletableFuture
-            handleCoroutineException(context, exception)
+            handleCoroutineException(context, cause)
         }
     }
 }

--- a/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.*
  * * [onCancellation] is invoked as soon as coroutine is _failing_, or is cancelled,
  *   or when it completes for any reason.
  * * [onCompleted] is invoked when coroutine completes with a value.
- * * [onCompletedExceptionally] in invoked when coroutines completes with exception.
+ * * [onCancelled] in invoked when coroutines completes with exception (cancelled).
  *
  * @param parentContext context of the parent coroutine.
  * @param active when `true` (by default) coroutine is created in _active_ state, when `false` in _new_ state.
@@ -89,20 +89,21 @@ public abstract class AbstractCoroutine<in T>(
     protected override fun onCancellation(cause: Throwable?) {}
 
     /**
-     * This function is invoked once when job is completed normally with the specified [value].
+     * This function is invoked once when job was completed normally with the specified [value].
      */
     protected open fun onCompleted(value: T) {}
 
     /**
-     * This function is invoked once when job is completed exceptionally with the specified [exception].
+     * This function is invoked once when job was cancelled with the specified [cause].
+     * @param cause The cancellation (failure) cause
+     * @param handled `true` if the exception was handled by parent (always `true` when it is a [CancellationException])
      */
-    // todo: rename to onCancelled
-    protected open fun onCompletedExceptionally(exception: Throwable) {}
+    protected open fun onCancelled(cause: Throwable, handled: Boolean) {}
 
     @Suppress("UNCHECKED_CAST")
-    internal override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
+    internal override fun onCompletionInternal(state: Any?, mode: Int) {
         if (state is CompletedExceptionally)
-            onCompletedExceptionally(state.cause)
+            onCancelled(state.cause, state.handled)
         else
             onCompleted(state as T)
     }

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -179,8 +179,9 @@ private open class StandaloneCoroutine(
     parentContext: CoroutineContext,
     active: Boolean
 ) : AbstractCoroutine<Unit>(parentContext, active) {
-    override fun handleJobException(exception: Throwable, handled: Boolean) {
-        if (!handled) handleCoroutineException(context, exception)
+    override fun handleJobException(exception: Throwable): Boolean {
+        handleCoroutineException(context, exception)
+        return true
     }
 }
 
@@ -240,10 +241,10 @@ private class DispatchedCoroutine<in T>(
         }
     }
 
-    override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
+    override fun onCompletionInternal(state: Any?, mode: Int) {
         if (tryResume()) return // completed before getResult invocation -- bail out
         // otherwise, getResult has already commenced, i.e. completed later or in other thread
-        super.onCompletionInternal(state, mode, suppressed)
+        super.onCompletionInternal(state, mode)
     }
 
     fun getResult(): Any? {

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -241,10 +241,10 @@ private class DispatchedCoroutine<in T>(
         }
     }
 
-    override fun onCompletionInternal(state: Any?, mode: Int) {
+    override fun afterCompletionInternal(state: Any?, mode: Int) {
         if (tryResume()) return // completed before getResult invocation -- bail out
         // otherwise, getResult has already commenced, i.e. completed later or in other thread
-        super.onCompletionInternal(state, mode)
+        super.afterCompletionInternal(state, mode)
     }
 
     fun getResult(): Any? {

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -95,7 +95,7 @@ private open class TimeoutCoroutine<U, in T: U>(
     }
 
     @Suppress("UNCHECKED_CAST")
-    internal override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
+    internal override fun onCompletionInternal(state: Any?, mode: Int) {
         if (state is CompletedExceptionally)
             uCont.resumeUninterceptedWithExceptionMode(state.cause, mode)
         else

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -95,7 +95,7 @@ private open class TimeoutCoroutine<U, in T: U>(
     }
 
     @Suppress("UNCHECKED_CAST")
-    internal override fun onCompletionInternal(state: Any?, mode: Int) {
+    override fun afterCompletionInternal(state: Any?, mode: Int) {
         if (state is CompletedExceptionally)
             uCont.resumeUninterceptedWithExceptionMode(state.cause, mode)
         else

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -109,10 +109,13 @@ private open class BroadcastCoroutine<E>(
         return true // does not matter - result is used in DEPRECATED functions only
     }
 
-    override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
-        val cause = (state as? CompletedExceptionally)?.cause
+    override fun onCompleted(value: Unit) {
+        _channel.close()
+    }
+
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
         val processed = _channel.close(cause)
-        if (cause != null && !processed && suppressed) handleCoroutineException(context, cause)
+        if (!processed && !handled) handleCoroutineException(context, cause)
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -94,9 +94,12 @@ private class ProducerCoroutine<E>(
     override val isActive: Boolean
         get() = super.isActive
 
-    override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
-        val cause = (state as? CompletedExceptionally)?.cause
+    override fun onCompleted(value: Unit) {
+        _channel.close()
+    }
+
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
         val processed = _channel.close(cause)
-        if (cause != null && !processed && suppressed) handleCoroutineException(context, cause)
+        if (!processed && !handled) handleCoroutineException(context, cause)
     }
 }

--- a/kotlinx-coroutines-core/common/src/internal/Scopes.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Scopes.kt
@@ -23,7 +23,7 @@ internal open class ScopeCoroutine<in T>(
         get() = false // it throws exception to parent instead of cancelling it
 
     @Suppress("UNCHECKED_CAST")
-    internal override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
+    internal override fun onCompletionInternal(state: Any?, mode: Int) {
         if (state is CompletedExceptionally) {
             val exception = if (mode == MODE_IGNORE) state.cause else recoverStackTrace(state.cause, uCont)
             uCont.resumeUninterceptedWithExceptionMode(exception, mode)

--- a/kotlinx-coroutines-core/common/src/internal/Scopes.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Scopes.kt
@@ -23,7 +23,7 @@ internal open class ScopeCoroutine<in T>(
         get() = false // it throws exception to parent instead of cancelling it
 
     @Suppress("UNCHECKED_CAST")
-    internal override fun onCompletionInternal(state: Any?, mode: Int) {
+    override fun afterCompletionInternal(state: Any?, mode: Int) {
         if (state is CompletedExceptionally) {
             val exception = if (mode == MODE_IGNORE) state.cause else recoverStackTrace(state.cause, uCont)
             uCont.resumeUninterceptedWithExceptionMode(exception, mode)

--- a/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
+++ b/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
@@ -28,7 +28,7 @@ class AbstractCoroutineTest : TestBase() {
                 expect(8)
             }
 
-            override fun onCompletedExceptionally(exception: Throwable) {
+            override fun onCancelled(cause: Throwable, handled: Boolean) {
                 expectUnreached()
             }
         }
@@ -67,8 +67,8 @@ class AbstractCoroutineTest : TestBase() {
                 expectUnreached()
             }
 
-            override fun onCompletedExceptionally(exception: Throwable) {
-                assertTrue(exception is TestException1)
+            override fun onCancelled(cause: Throwable, handled: Boolean) {
+                assertTrue(cause is TestException1)
                 expect(9)
             }
         }

--- a/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
+++ b/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
@@ -18,14 +18,14 @@ class AbstractCoroutineTest : TestBase() {
                 expect(3)
             }
 
-            override fun onCancellation(cause: Throwable?) {
+            override fun onCancelling(cause: Throwable?) {
                 assertEquals(null, cause)
                 expect(5)
             }
 
             override fun onCompleted(value: String) {
                 assertEquals("OK", value)
-                expect(8)
+                expect(6)
             }
 
             override fun onCancelled(cause: Throwable, handled: Boolean) {
@@ -35,12 +35,12 @@ class AbstractCoroutineTest : TestBase() {
 
         coroutine.invokeOnCompletion(onCancelling = true) {
             assertEquals(null, it)
-            expect(6)
+            expect(7)
         }
 
         coroutine.invokeOnCompletion {
             assertEquals(null, it)
-            expect(7)
+            expect(8)
         }
         expect(2)
         coroutine.start()
@@ -58,7 +58,7 @@ class AbstractCoroutineTest : TestBase() {
                 expect(3)
             }
 
-            override fun onCancellation(cause: Throwable?) {
+            override fun onCancelling(cause: Throwable?) {
                 assertTrue(cause is TestException1)
                 expect(5)
             }
@@ -69,7 +69,7 @@ class AbstractCoroutineTest : TestBase() {
 
             override fun onCancelled(cause: Throwable, handled: Boolean) {
                 assertTrue(cause is TestException1)
-                expect(9)
+                expect(8)
             }
         }
 
@@ -80,7 +80,7 @@ class AbstractCoroutineTest : TestBase() {
 
         coroutine.invokeOnCompletion {
             assertTrue(it is TestException1)
-            expect(8)
+            expect(9)
         }
 
         expect(2)

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -61,7 +61,7 @@ private class BlockingCoroutine<T>(
     override val cancelsParent: Boolean
         get() = false // it throws exception to parent instead of cancelling it
 
-    override fun onCompletionInternal(state: Any?, mode: Int) {
+    override fun afterCompletionInternal(state: Any?, mode: Int) {
         // wake up blocked thread
         if (Thread.currentThread() != blockedThread)
             LockSupport.unpark(blockedThread)

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -61,7 +61,7 @@ private class BlockingCoroutine<T>(
     override val cancelsParent: Boolean
         get() = false // it throws exception to parent instead of cancelling it
 
-    override fun onCompletionInternal(state: Any?, mode: Int, suppressed: Boolean) {
+    override fun onCompletionInternal(state: Any?, mode: Int) {
         // wake up blocked thread
         if (Thread.currentThread() != blockedThread)
             LockSupport.unpark(blockedThread)

--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -129,7 +129,7 @@ private open class ActorCoroutine<E>(
 ) : ChannelCoroutine<E>(parentContext, channel, active), ActorScope<E> {
     override val cancelsParent: Boolean get() = true
 
-    override fun onCancellation(cause: Throwable?) {
+    override fun onCancelling(cause: Throwable?) {
         _channel.cancel(cause?.let {
             it as? CancellationException ?: CancellationException("$classSimpleName was cancelled", it)
         })

--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -127,16 +127,17 @@ private open class ActorCoroutine<E>(
     channel: Channel<E>,
     active: Boolean
 ) : ChannelCoroutine<E>(parentContext, channel, active), ActorScope<E> {
+    override val cancelsParent: Boolean get() = true
+
     override fun onCancellation(cause: Throwable?) {
         _channel.cancel(cause?.let {
             it as? CancellationException ?: CancellationException("$classSimpleName was cancelled", it)
         })
     }
 
-    override val cancelsParent: Boolean get() = true
-
-    override fun handleJobException(exception: Throwable, handled: Boolean) {
-        if (!handled) handleCoroutineException(context, exception)
+    override fun handleJobException(exception: Throwable): Boolean {
+        handleCoroutineException(context, exception)
+        return true
     }
 }
 

--- a/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
@@ -51,17 +51,16 @@ class ProduceExceptionsTest : TestBase() {
 
     @Test
     fun testSuppressedException() = runTest {
-        val produce = produce<Int>(Job()) {
+        val produce = produce<Int>(NonCancellable) {
             launch(start = CoroutineStart.ATOMIC) {
-                throw TestException()
+                throw TestException() // child coroutine fails
             }
             try {
                 delay(Long.MAX_VALUE)
             } finally {
-                throw TestException2()
+                throw TestException2() // but parent throws another exception while cleaning up
             }
         }
-
         try {
             produce.receive()
             expectUnreached()

--- a/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
@@ -21,7 +21,7 @@ class SuppressionTests : TestBase() {
                 expect(3)
             }
 
-            override fun onCancellation(cause: Throwable?) {
+            override fun onCancelling(cause: Throwable?) {
                 assertTrue(cause is ArithmeticException)
                 assertTrue(cause.suppressed.isEmpty())
                 expect(5)
@@ -34,7 +34,7 @@ class SuppressionTests : TestBase() {
             override fun onCancelled(cause: Throwable, handled: Boolean) {
                 assertTrue(cause is ArithmeticException)
                 checkException<IOException>(cause.suppressed[0])
-                expect(9)
+                expect(8)
             }
         }
 
@@ -47,7 +47,7 @@ class SuppressionTests : TestBase() {
         coroutine.invokeOnCompletion {
             assertTrue(it is ArithmeticException)
             checkException<IOException>(it.suppressed[0])
-            expect(8)
+            expect(9)
         }
 
         expect(2)

--- a/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/SuppressionTests.kt
@@ -31,9 +31,9 @@ class SuppressionTests : TestBase() {
                 expectUnreached()
             }
 
-            override fun onCompletedExceptionally(exception: Throwable) {
-                assertTrue(exception is ArithmeticException)
-                checkException<IOException>(exception.suppressed[0])
+            override fun onCancelled(cause: Throwable, handled: Boolean) {
+                assertTrue(cause is ArithmeticException)
+                checkException<IOException>(cause.suppressed[0])
                 expect(9)
             }
         }

--- a/reactive/kotlinx-coroutines-reactor/src/Mono.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Mono.kt
@@ -50,8 +50,12 @@ private class MonoCoroutine<in T>(
         }
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!disposed) sink.error(exception)
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!disposed) {
+            sink.error(cause)
+        } else if (!handled) {
+            handleCoroutineException(context, cause)
+        }
     }
     
     override fun dispose() {

--- a/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
@@ -44,7 +44,11 @@ private class RxCompletableCoroutine(
         if (!subscriber.isDisposed) subscriber.onComplete()
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!subscriber.isDisposed) subscriber.onError(exception)
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!subscriber.isDisposed) {
+            subscriber.onError(cause)
+        } else if (!handled) {
+            handleCoroutineException(context, cause)
+        }
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
@@ -5,10 +5,8 @@
 package kotlinx.coroutines.rx2
 
 import io.reactivex.*
-import io.reactivex.functions.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
-import kotlin.experimental.*
 
 /**
  * Creates cold [maybe][Maybe] that will run a given [block] in a coroutine.
@@ -49,7 +47,11 @@ private class RxMaybeCoroutine<T>(
         }
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!subscriber.isDisposed) subscriber.onError(exception)
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!subscriber.isDisposed) {
+            subscriber.onError(cause)
+        } else if (!handled) {
+            handleCoroutineException(context, cause)
+        }
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -103,7 +103,7 @@ private class RxObservableCoroutine<T: Any>(
     private fun doLockedNext(elem: T) {
         // check if already closed for send
         if (!isActive) {
-            doLockedSignalCompleted()
+            doLockedSignalCompleted(completionCause, completionCauseHandled)
             throw getCancellationException()
         }
         // notify subscriber
@@ -114,27 +114,28 @@ private class RxObservableCoroutine<T: Any>(
             // to abort the corresponding send/offer invocation. From the standpoint of coroutines machinery,
             // this failure is essentially equivalent to a failure of a child coroutine.
             cancelCoroutine(e)
-            doLockedSignalCompleted()
+            doLockedSignalCompleted(e, false)
             throw e
         }
         /*
            There is no sense to check for `isActive` before doing `unlock`, because cancellation/completion might
-           happen after this check and before `unlock` (see `onCancellation` that does not do anything
+           happen after this check and before `unlock` (see signalCompleted that does not do anything
            if it fails to acquire the lock that we are still holding).
            We have to recheck `isCompleted` after `unlock` anyway.
          */
         mutex.unlock()
         // recheck isActive
         if (!isActive && mutex.tryLock())
-            doLockedSignalCompleted()
+            doLockedSignalCompleted(completionCause, completionCauseHandled)
     }
 
     // assert: mutex.isLocked()
-    private fun doLockedSignalCompleted() {
+    private fun doLockedSignalCompleted(cause: Throwable?, handled: Boolean) {
+        // todo: handled is ignored here, might need something like in PublisherCoroutine to process
+        // cancellation failures
         try {
             if (_signal.value >= CLOSED) {
                 _signal.value = SIGNALLED // we'll signal onError/onCompleted (that the final state -- no CAS needed)
-                val cause = completionCause
                 try {
                     if (cause != null && cause !is CancellationException)
                         subscriber.onError(cause)
@@ -150,17 +151,17 @@ private class RxObservableCoroutine<T: Any>(
         }
     }
 
-    private fun signalCompleted() {
+    private fun signalCompleted(cause: Throwable?, handled: Boolean) {
         if (!_signal.compareAndSet(OPEN, CLOSED)) return // abort, other thread invoked doLockedSignalCompleted
         if (mutex.tryLock()) // if we can acquire the lock
-            doLockedSignalCompleted()
+            doLockedSignalCompleted(cause, handled)
     }
 
     override fun onCompleted(value: Unit) {
-        signalCompleted()
+        signalCompleted(null, false)
     }
 
     override fun onCancelled(cause: Throwable, handled: Boolean) {
-        signalCompleted()
+        signalCompleted(cause, handled)
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
@@ -44,7 +44,11 @@ private class RxSingleCoroutine<T: Any>(
         if (!subscriber.isDisposed) subscriber.onSuccess(value)
     }
 
-    override fun onCompletedExceptionally(exception: Throwable) {
-        if (!subscriber.isDisposed) subscriber.onError(exception)
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        if (!subscriber.isDisposed) {
+            subscriber.onError(cause)
+        } else if (!handled) {
+            handleCoroutineException(context, cause)
+        }
     }
 }


### PR DESCRIPTION
* JobSupport.handleJobException (which is called before the coroutine goes
  to the final state) is now called only when parent did not handle
  exception and is used only in launch-like coroutines (launch and actor)
  to report uncaught exception.
* The final result of other types coroutines that, by default, have an
  object "to store exceptions" is consistently processed after all
  other notifications when the coroutine state is already complete and
  is reported as uncaught exception as a last-resort processing tactic
  when it cannot be otherwise handled.
* The above change makes the order of notifications for future { ... } and
  other async-like coroutine builders consistent with the order in which
  async { ... }.await() is notified.
* The "handled" state of exception (whether it was processed or not)
  is now stored in CompletedExceptionally marker class (pulled this
  field up from CancelledContinuation).
* AbstractCoroutine.onCompletedExceptionally is renamed to onCancelled
  and includes "handled" flag.
* protected val JobSupport.completionCauseHandled is introduced to access
  "handled" flag, which simplified reactive streams integration.
* "suppressed" flag is dropped from JobSupport.onCompletionInternal.
* Fixed exception processing in reactive integrations -- exception that
  is thrown from a cancelled (disposed) coroutine is not lost anymore.