### PR TITLE
Move `systemProp` function to the common module

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/SystemProps.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SystemProps.common.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:JvmName("SystemPropsKt")
+@file:JvmMultifileClass
+
+package kotlinx.coroutines.internal
+
+import kotlin.jvm.*
+
+/**
+ * Gets the system property indicated by the specified [property name][propertyName],
+ * or returns [defaultValue] if there is no property with that key.
+ *
+ * **Note: this function should be used in JVM tests only, other platforms use the default value.**
+ */
+internal fun systemProp(
+    propertyName: String,
+    defaultValue: Boolean
+): Boolean = systemProp(propertyName)?.toBoolean() ?: defaultValue
+
+/**
+ * Gets the system property indicated by the specified [property name][propertyName],
+ * or returns [defaultValue] if there is no property with that key. It also checks that the result
+ * is between [minValue] and [maxValue] (inclusively), throws [IllegalStateException] if it is not.
+ *
+ * **Note: this function should be used in JVM tests only, other platforms use the default value.**
+ */
+internal fun systemProp(
+    propertyName: String,
+    defaultValue: Int,
+    minValue: Int = 1,
+    maxValue: Int = Int.MAX_VALUE
+): Int = systemProp(propertyName, defaultValue.toLong(), minValue.toLong(), maxValue.toLong()).toInt()
+
+/**
+ * Gets the system property indicated by the specified [property name][propertyName],
+ * or returns [defaultValue] if there is no property with that key. It also checks that the result
+ * is between [minValue] and [maxValue] (inclusively), throws [IllegalStateException] if it is not.
+ *
+ * **Note: this function should be used in JVM tests only, other platforms use the default value.**
+ */
+internal fun systemProp(
+    propertyName: String,
+    defaultValue: Long,
+    minValue: Long = 1,
+    maxValue: Long = Long.MAX_VALUE
+): Long {
+    val value = systemProp(propertyName) ?: return defaultValue
+    val parsed = value.toLongOrNull()
+        ?: error("System property '$propertyName' has unrecognized value '$value'")
+    if (parsed !in minValue..maxValue) {
+        error("System property '$propertyName' should be in range $minValue..$maxValue, but is '$parsed'")
+    }
+    return parsed
+}
+
+/**
+ * Gets the system property indicated by the specified [property name][propertyName],
+ * or returns `null` if there is no property with that key.
+ *
+ * **Note: this function should be used in JVM tests only, other platforms use the default value.**
+ */
+internal expect fun systemProp(propertyName: String): String?

--- a/kotlinx-coroutines-core/js/src/internal/SystemProps.kt
+++ b/kotlinx-coroutines-core/js/src/internal/SystemProps.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+internal actual fun systemProp(propertyName: String): String? = null

--- a/kotlinx-coroutines-core/jvm/src/internal/SystemProps.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/SystemProps.kt
@@ -1,13 +1,16 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+@file:JvmName("SystemPropsKt")
+@file:JvmMultifileClass
 
 package kotlinx.coroutines.internal
 
 // number of processors at startup for consistent prop initialization
 internal val AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors()
 
-internal fun systemProp(
+internal actual fun systemProp(
     propertyName: String
 ): String? =
     try {
@@ -15,36 +18,3 @@ internal fun systemProp(
     } catch (e: SecurityException) {
         null
     }
-
-internal fun systemProp(
-    propertyName: String,
-    defaultValue: Boolean
-): Boolean =
-    try {
-        System.getProperty(propertyName)?.toBoolean() ?: defaultValue
-    } catch (e: SecurityException) {
-        defaultValue
-    }
-
-internal fun systemProp(
-    propertyName: String,
-    defaultValue: Int,
-    minValue: Int = 1,
-    maxValue: Int = Int.MAX_VALUE
-): Int
-    = systemProp(propertyName, defaultValue.toLong(), minValue.toLong(), maxValue.toLong()).toInt()
-
-internal fun systemProp(
-    propertyName: String,
-    defaultValue: Long,
-    minValue: Long = 1,
-    maxValue: Long = Long.MAX_VALUE
-): Long {
-    val value = systemProp(propertyName) ?: return defaultValue
-    val parsed = value.toLongOrNull()
-        ?: error("System property '$propertyName' has unrecognized value '$value'")
-    if (parsed !in minValue..maxValue) {
-        error("System property '$propertyName' should be in range $minValue..$maxValue, but is '$parsed'")
-    }
-    return parsed
-}

--- a/kotlinx-coroutines-core/native/src/internal/SystemProps.kt
+++ b/kotlinx-coroutines-core/native/src/internal/SystemProps.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+internal actual fun systemProp(propertyName: String): String? = null


### PR DESCRIPTION
Move `systemProp` function to the common module; only the JVM platform implements it properly while others always use provided default value. This change makes it possible to use different constants in production and tests not only in JVM code but in common code as well.