### PR TITLE
Update Tasks to support recent Play Services builds

### DIFF
--- a/integration/kotlinx-coroutines-play-services/build.gradle
+++ b/integration/kotlinx-coroutines-play-services/build.gradle
@@ -7,7 +7,7 @@ import java.util.zip.ZipFile
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-ext.tasks_version = '15.0.1'
+ext.tasks_version = '16.0.1'
 
 def attr = Attribute.of("artifactType", String.class)
 configurations {

--- a/integration/kotlinx-coroutines-play-services/src/Tasks.kt
+++ b/integration/kotlinx-coroutines-play-services/src/Tasks.kt
@@ -50,7 +50,8 @@ public fun <T> Task<T>.asDeferred(): Deferred<T> {
     if (isComplete) {
         val e = exception
         return if (e == null) {
-            CompletableDeferred<T>().apply { if (isCanceled) cancel() else complete(result) }
+            @Suppress("UNCHECKED_CAST")
+            CompletableDeferred<T>().apply { if (isCanceled) cancel() else complete(result as T) }
         } else {
             CompletableDeferred<T>().apply { completeExceptionally(e) }
         }
@@ -60,7 +61,8 @@ public fun <T> Task<T>.asDeferred(): Deferred<T> {
     addOnCompleteListener {
         val e = it.exception
         if (e == null) {
-            if (isCanceled) result.cancel() else result.complete(it.result)
+            @Suppress("UNCHECKED_CAST")
+            if (isCanceled) result.cancel() else result.complete(it.result as T)
         } else {
             result.completeExceptionally(e)
         }
@@ -83,7 +85,8 @@ public suspend fun <T> Task<T>.await(): T {
             if (isCanceled) {
                 throw CancellationException("Task $this was cancelled normally.")
             } else {
-                result
+                @Suppress("UNCHECKED_CAST")
+                result as T
             }
         } else {
             throw e
@@ -94,7 +97,8 @@ public suspend fun <T> Task<T>.await(): T {
         addOnCompleteListener {
             val e = exception
             if (e == null) {
-                if (isCanceled) cont.cancel() else cont.resume(result)
+                @Suppress("UNCHECKED_CAST")
+                if (isCanceled) cont.cancel() else cont.resume(result as T)
             } else {
                 cont.resumeWithException(e)
             }

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -93,6 +93,11 @@ class TaskTest : TestBase() {
     }
 
     @Test
+    fun testNullResultTaskAsDeferred() = runTest {
+        assertNull(Tasks.forResult(null).asDeferred().await())
+    }
+
+    @Test
     fun testCancelledTaskAsDeferred() = runTest {
         val deferred = Tasks.forCanceled<Int>().asDeferred()
 


### PR DESCRIPTION
Play Services 16 changed the `task.result` to `@Nullable`, so some additional casting is
required to compile.

Note that the generic `T` in `Task<T>` is not currently annotated. The nullability of `result` should match that of `T`.