### PR TITLE
Introduce CancellableContinuation.resume with onCancelling lambda

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -40,6 +40,7 @@ public abstract interface class kotlinx/coroutines/CancellableContinuation : kot
 	public abstract fun isActive ()Z
 	public abstract fun isCancelled ()Z
 	public abstract fun isCompleted ()Z
+	public abstract fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public abstract fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
@@ -58,20 +59,18 @@ public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/
 	public fun getCallerFrame ()Lkotlin/coroutines/jvm/internal/CoroutineStackFrame;
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getContinuationCancellationCause (Lkotlinx/coroutines/Job;)Ljava/lang/Throwable;
-	public final fun getDelegate ()Lkotlin/coroutines/Continuation;
 	public final fun getResult ()Ljava/lang/Object;
 	public fun getStackTraceElement ()Ljava/lang/StackTraceElement;
-	public fun getSuccessfulResult (Ljava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun initCancellability ()V
 	public fun invokeOnCancellation (Lkotlin/jvm/functions/Function1;)V
 	public fun isActive ()Z
 	public fun isCancelled ()Z
 	public fun isCompleted ()Z
 	protected fun nameString ()Ljava/lang/String;
+	public fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
 	public fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public fun resumeWith (Ljava/lang/Object;)V
-	public fun takeState ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -273,7 +273,9 @@ public interface Job : CoroutineContext.Element {
      * Installed [handler] should not throw any exceptions. If it does, they will get caught,
      * wrapped into [CompletionHandlerException], and rethrown, potentially causing crash of unrelated code.
      *
-     * **Note**: Implementations of `CompletionHandler` must be fast and _lock-free_.
+     * **Note**: Implementation of `CompletionHandler` must be fast, non-blocking, and thread-safe.
+     * This handler can be invoked concurrently with the surrounding code.
+     * There is no guarantee on the execution context in which the [handler] is invoked.
      */
     public fun invokeOnCompletion(handler: CompletionHandler): DisposableHandle
 
@@ -304,7 +306,9 @@ public interface Job : CoroutineContext.Element {
      * **Note**: This function is a part of internal machinery that supports parent-child hierarchies
      * and allows for implementation of suspending functions that wait on the Job's state.
      * This function should not be used in general application code.
-     * Implementations of `CompletionHandler` must be fast and _lock-free_.
+     * Implementation of `CompletionHandler` must be fast, non-blocking, and thread-safe.
+     * This handler can be invoked concurrently with the surrounding code.
+     * There is no guarantee on the execution context in which the [handler] is invoked.
      *
      * @param onCancelling when `true`, then the [handler] is invoked as soon as this job transitions to _cancelling_ state;
      *        when `false` then the [handler] is invoked only when it transitions to _completed_ state.

--- a/kotlinx-coroutines-core/common/test/CancellableResumeTest.kt
+++ b/kotlinx-coroutines-core/common/test/CancellableResumeTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED") // KT-21913
+
+package kotlinx.coroutines
+
+import kotlin.test.*
+
+/**
+ * Test for [CancellableContinuation.resume] with `onCancellation` parameter.
+ */
+class CancellableResumeTest : TestBase() {
+    @Test
+    fun testResumeImmediateNormally() = runTest {
+        expect(1)
+        val ok = suspendCancellableCoroutine<String> { cont ->
+            expect(2)
+            cont.invokeOnCancellation { expectUnreached() }
+            cont.resume("OK") { expectUnreached() }
+            expect(3)
+        }
+        assertEquals("OK", ok)
+        finish(4)
+    }
+
+    @Test
+    fun testResumeImmediateAfterCancel() = runTest(
+        expected = { it is TestException }
+    ) {
+        expect(1)
+        val ok = suspendCancellableCoroutine<String> { cont ->
+            expect(2)
+            cont.invokeOnCancellation { expect(3) }
+            cont.cancel(TestException("FAIL"))
+            expect(4)
+            cont.resume("OK") { cause ->
+                expect(5)
+                assertTrue(cause is TestException)
+            }
+            finish(6)
+        }
+        expectUnreached()
+    }
+
+    @Test
+    fun testResumeLaterNormally() = runTest {
+        expect(1)
+        lateinit var cc: CancellableContinuation<String>
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            expect(2)
+            val ok = suspendCancellableCoroutine<String> { cont ->
+                expect(3)
+                cont.invokeOnCancellation { expectUnreached() }
+                cc = cont
+            }
+            assertEquals("OK", ok)
+            finish(6)
+        }
+        expect(4)
+        cc.resume("OK") { expectUnreached() }
+        expect(5)
+    }
+
+    @Test
+    fun testResumeLaterAfterCancel() = runTest {
+        expect(1)
+        lateinit var cc: CancellableContinuation<String>
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            expect(2)
+            try {
+                suspendCancellableCoroutine<String> { cont ->
+                    expect(3)
+                    cont.invokeOnCancellation { expect(5) }
+                    cc = cont
+                }
+                expectUnreached()
+            } catch (e: CancellationException) {
+                finish(9)
+            }
+        }
+        expect(4)
+        job.cancel(TestCancellationException())
+        expect(6)
+        cc.resume("OK") { cause ->
+            expect(7)
+            assertTrue(cause is TestCancellationException)
+        }
+        expect(8)
+    }
+
+    @Test
+    fun testResumeCancelWhileDispatched() = runTest {
+        expect(1)
+        lateinit var cc: CancellableContinuation<String>
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            expect(2)
+            try {
+                suspendCancellableCoroutine<String> { cont ->
+                    expect(3)
+                    // resumed first, then cancelled, so no invokeOnCancellation call
+                    cont.invokeOnCancellation { expectUnreached() }
+                    cc = cont
+                }
+                expectUnreached()
+            } catch (e: CancellationException) {
+                expect(8)
+            }
+        }
+        expect(4)
+        cc.resume("OK") { cause ->
+            expect(7)
+            assertTrue(cause is TestCancellationException)
+        }
+        expect(5)
+        job.cancel(TestCancellationException()) // cancel while execution is dispatched
+        expect(6)
+        yield() // to coroutine -- throws cancellation exception
+        finish(9)
+    }
+}


### PR DESCRIPTION
* Allows safe return of closeable resources from suspending
functions, as it provides a way to close a resource if the
corresponding job was cancelled.
* Documentation on the context and expected behavior of
CompletionHandler implementations is updated.

Fixes #1044