### PR TITLE
Fix atomicfu post-processing and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,15 @@ buildscript {
         if (kotlin_version == null) {
             throw new IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with snapshot compiler")
         }
+    }
+
+    if (build_snapshot_train || atomicfu_version.endsWith("-SNAPSHOT")) {
         repositories {
             mavenLocal()
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         }
     }
+
     repositories {
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
@@ -83,6 +87,9 @@ allprojects {
         }
 
         kotlin_version = rootProject.properties['kotlin_snapshot_version']
+    }
+
+    if (build_snapshot_train || atomicfu_version.endsWith("-SNAPSHOT")) {
         repositories {
             mavenLocal()
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
@@ -91,7 +98,7 @@ allprojects {
 }
 
 allprojects {
-    apply plugin: 'kotlinx-atomicfu'
+    apply plugin: 'kotlinx-atomicfu' // it also adds all the necessary dependencies
     def projectName = it.name
     repositories {
         /*
@@ -120,7 +127,6 @@ allprojects {
     dependencies {
         // See comment below for rationale, it will be replaced with "project" dependency
         compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
-        compileOnly "org.jetbrains.kotlinx:atomicfu:$atomicfu_version"
 
         // the only way IDEA can resolve test classes
         testCompile project(":$coreModule").kotlin.targets.jvm.compilations.test.output.allOutputs

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin_version=1.3.30
 
 # Dependencies
 junit_version=4.12
-atomicfu_version=0.12.3
+atomicfu_version=0.12.4
 html_version=0.6.8
 lincheck_version=2.0
 dokka_version=0.9.16-rdev-2-mpp-hacks

--- a/gradle/compile-common.gradle
+++ b/gradle/compile-common.gradle
@@ -5,7 +5,6 @@
 kotlin.sourceSets {
     commonMain.dependencies {
         api "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
-        api "org.jetbrains.kotlinx:atomicfu-common:$atomicfu_version"
     }
 
     commonTest.dependencies {

--- a/gradle/compile-js-multiplatform.gradle
+++ b/gradle/compile-js-multiplatform.gradle
@@ -12,7 +12,6 @@ kotlin {
     sourceSets {
         jsMain.dependencies {
             api group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-js', version: kotlin_version
-            api "org.jetbrains.kotlinx:atomicfu-js:$atomicfu_version"
         }
 
         jsTest.dependencies {

--- a/gradle/compile-jvm-multiplatform.gradle
+++ b/gradle/compile-jvm-multiplatform.gradle
@@ -16,7 +16,6 @@ kotlin {
     sourceSets {
         jvmMain.dependencies {
             api 'org.jetbrains.kotlin:kotlin-stdlib'
-            api "org.jetbrains.kotlinx:atomicfu:$atomicfu_version"
         }
 
         jvmTest.dependencies {

--- a/gradle/compile-native-multiplatform.gradle
+++ b/gradle/compile-native-multiplatform.gradle
@@ -13,10 +13,6 @@ kotlin {
     }
 
     sourceSets {
-        nativeMain.dependencies {
-            api "org.jetbrains.kotlinx:atomicfu-native:$atomicfu_version"
-        }
-
         nativeMain { dependsOn commonMain }
         // Empty source set is required in order to have native tests task 
         nativeTest {}

--- a/kotlinx-coroutines-core/common/src/flow/operators/Merge.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Merge.kt
@@ -130,8 +130,10 @@ private class SerializingFlatMapCollector<T>(
     }
 }
 
-private fun AtomicBoolean.tryAcquire(): Boolean = compareAndSet(false, true)
+@Suppress("NOTHING_TO_INLINE")
+private inline fun AtomicBoolean.tryAcquire(): Boolean = compareAndSet(false, true)
 
-private fun AtomicBoolean.release() {
+@Suppress("NOTHING_TO_INLINE")
+private inline fun AtomicBoolean.release() {
     value = false
 }


### PR DESCRIPTION
* Update to atomicfu 0.12.4, which fixes plugin operation with
  kotlin-multiplatform
* Remove explicit dependencies (plugins adds them automatically)
* There will be no atomicfu dependency in the resulting artefacts

Fixes #1116
Fixes #1064