### PR TITLE
Provide CoroutineScope into flowViaChannel block, but make it non-sus…

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/channels/FlowViaChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/channels/FlowViaChannelTest.kt
@@ -12,8 +12,20 @@ class FlowViaChannelTest : TestBase() {
     @Test
     fun testRegular() = runTest {
         val flow = flowViaChannel<Int> {
-            it.send(1)
-            it.send(2)
+            assertTrue(it.offer(1))
+            assertTrue(it.offer(2))
+            assertTrue(it.offer(3))
+            it.close()
+        }
+        assertEquals(listOf(1, 2, 3), flow.toList())
+    }
+
+    @Test
+    fun testBuffer() = runTest {
+        val flow = flowViaChannel<Int>(bufferSize = 1) {
+            assertTrue(it.offer(1))
+            assertTrue(it.offer(2))
+            assertFalse(it.offer(3))
             it.close()
         }
         assertEquals(listOf(1, 2), flow.toList())
@@ -22,10 +34,51 @@ class FlowViaChannelTest : TestBase() {
     @Test
     fun testConflated() = runTest {
         val flow = flowViaChannel<Int>(bufferSize = Channel.CONFLATED) {
-            it.send(1)
-            it.send(2)
+            assertTrue(it.offer(1))
+            assertTrue(it.offer(2))
             it.close()
         }
         assertEquals(listOf(1), flow.toList())
+    }
+
+    @Test
+    fun testFailureCancelsChannel() = runTest {
+        val flow = flowViaChannel<Int> {
+            it.offer(1)
+            it.invokeOnClose {
+                expect(2)
+            }
+        }.onEach { throw TestException() }
+
+        expect(1)
+        assertFailsWith<TestException>(flow)
+        finish(3)
+    }
+
+    @Test
+    fun testFailureInSourceCancelsConsumer() = runTest {
+        val flow = flowViaChannel<Int> {
+            expect(2)
+            throw TestException()
+        }.onEach { expectUnreached() }
+
+        expect(1)
+        assertFailsWith<TestException>(flow)
+        finish(3)
+    }
+
+    @Test
+    fun testScopedCancellation() = runTest {
+        val flow = flowViaChannel<Int> {
+            expect(2)
+            launch(start = CoroutineStart.ATOMIC) {
+                hang { expect(3) }
+            }
+            throw TestException()
+        }.onEach { expectUnreached() }
+
+        expect(1)
+        assertFailsWith<TestException>(flow)
+        finish(4)
     }
 }


### PR DESCRIPTION
…pending.

    * It allows using flowViaChannel for integration with Java callbacks
    * CoroutineScope is provided to provide a lifecycle object (that is not otherwise accessible)
    * Suspending use-cases are covered with flow builder

Fixes #1081