### PR TITLE
Deprecate consumeEach on Publisher, ObservableSource and MaybeSource,…

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-reactive.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-reactive.txt
@@ -8,6 +8,7 @@ public final class kotlinx/coroutines/reactive/AwaitKt {
 }
 
 public final class kotlinx/coroutines/reactive/ChannelKt {
+	public static final fun collect (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun consumeEach (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun openSubscription (Lorg/reactivestreams/Publisher;I)Lkotlinx/coroutines/channels/ReceiveChannel;
 	public static synthetic fun openSubscription$default (Lorg/reactivestreams/Publisher;IILjava/lang/Object;)Lkotlinx/coroutines/channels/ReceiveChannel;

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-rx2.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-rx2.txt
@@ -12,6 +12,8 @@ public final class kotlinx/coroutines/rx2/RxAwaitKt {
 }
 
 public final class kotlinx/coroutines/rx2/RxChannelKt {
+	public static final fun collect (Lio/reactivex/MaybeSource;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun collect (Lio/reactivex/ObservableSource;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun consumeEach (Lio/reactivex/MaybeSource;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun consumeEach (Lio/reactivex/ObservableSource;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun openSubscription (Lio/reactivex/MaybeSource;)Lkotlinx/coroutines/channels/ReceiveChannel;

--- a/reactive/kotlinx-coroutines-reactive/src/Channel.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Channel.kt
@@ -27,10 +27,17 @@ public fun <T> Publisher<T>.openSubscription(request: Int = 0): ReceiveChannel<T
     return channel
 }
 
+// Will be promoted to error in 1.3.0, removed in 1.4.0
+@Deprecated(message = "Use collect instead", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("this.collect(action)"))
+public suspend inline fun <T> Publisher<T>.consumeEach(action: (T) -> Unit) =
+    openSubscription().consumeEach(action)
+
 /**
  * Subscribes to this [Publisher] and performs the specified action for each received element.
+ * Cancels subscription if any exception happens during collect.
  */
-public suspend inline fun <T> Publisher<T>.consumeEach(action: (T) -> Unit) =
+@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
+public suspend inline fun <T> Publisher<T>.collect(action: (T) -> Unit) =
     openSubscription().consumeEach(action)
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")

--- a/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
@@ -50,7 +50,7 @@ class IntegrationTest(
         assertNSE { pub.awaitLast() }
         assertNSE { pub.awaitSingle() }
         var cnt = 0
-        pub.consumeEach { cnt++ }
+        pub.collect { cnt++ }
         assertThat(cnt, IsEqual(0))
     }
 
@@ -67,7 +67,7 @@ class IntegrationTest(
         assertThat(pub.awaitLast(), IsEqual("OK"))
         assertThat(pub.awaitSingle(), IsEqual("OK"))
         var cnt = 0
-        pub.consumeEach {
+        pub.collect {
             assertThat(it, IsEqual("OK"))
             cnt++
         }
@@ -125,7 +125,7 @@ class IntegrationTest(
 
     private suspend fun checkNumbers(n: Int, pub: Publisher<Int>) {
         var last = 0
-        pub.consumeEach {
+        pub.collect {
             assertThat(it, IsEqual(++last))
         }
         assertThat(last, IsEqual(n))

--- a/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
@@ -262,7 +262,7 @@ class PublishTest : TestBase() {
             }
         }
         try {
-            pub.consumeEach {
+            pub.collect {
                 throw TestException()
             }
         } catch (e: TestException) {

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherCompletionStressTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherCompletionStressTest.kt
@@ -24,7 +24,7 @@ class PublisherCompletionStressTest : TestBase() {
             runBlocking {
                 withTimeout(5000) {
                     var received = 0
-                    range(Dispatchers.Default, 1, count).consumeEach { x ->
+                    range(Dispatchers.Default, 1, count).collect { x ->
                         received++
                         if (x != received) error("$x != $received")
                     }

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherMultiTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherMultiTest.kt
@@ -24,7 +24,7 @@ class PublisherMultiTest : TestBase() {
             jobs.forEach { it.join() }
         }
         val resultSet = mutableSetOf<Int>()
-        observable.consumeEach {
+        observable.collect {
             assertTrue(resultSet.add(it))
         }
         assertThat(resultSet.size, IsEqual(n))

--- a/reactive/kotlinx-coroutines-reactor/test/FluxCompletionStressTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxCompletionStressTest.kt
@@ -25,7 +25,7 @@ class FluxCompletionStressTest : TestBase() {
             runBlocking {
                 withTimeout(5000) {
                     var received = 0
-                    range(Dispatchers.Default, 1, count).consumeEach { x ->
+                    range(Dispatchers.Default, 1, count).collect { x ->
                         received++
                         if (x != received) error("$x != $received")
                     }

--- a/reactive/kotlinx-coroutines-reactor/test/FluxMultiTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxMultiTest.kt
@@ -46,7 +46,7 @@ class FluxMultiTest : TestBase() {
     fun testIteratorResendUnconfined() {
         val n = 10_000 * stressTestMultiplier
         val flux = GlobalScope.flux(Dispatchers.Unconfined) {
-            Flux.range(0, n).consumeEach { send(it) }
+            Flux.range(0, n).collect { send(it) }
         }
         checkMonoValue(flux.collectList()) { list ->
             assertEquals((0 until n).toList(), list)
@@ -57,7 +57,7 @@ class FluxMultiTest : TestBase() {
     fun testIteratorResendPool() {
         val n = 10_000 * stressTestMultiplier
         val flux = GlobalScope.flux {
-            Flux.range(0, n).consumeEach { send(it) }
+            Flux.range(0, n).collect { send(it) }
         }
         checkMonoValue(flux.collectList()) { list ->
             assertEquals((0 until n).toList(), list)

--- a/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
@@ -180,7 +180,7 @@ class FluxSingleTest {
     fun testFluxIteration() {
         val flux = GlobalScope.flux {
             var result = ""
-            Flux.just("O", "K").consumeEach { result += it }
+            Flux.just("O", "K").collect { result += it }
             send(result)
         }
 
@@ -193,7 +193,7 @@ class FluxSingleTest {
     fun testFluxIterationFailure() {
         val flux = GlobalScope.flux {
             try {
-                Flux.error<String>(RuntimeException("OK")).consumeEach { fail("Should not be here") }
+                Flux.error<String>(RuntimeException("OK")).collect { fail("Should not be here") }
                 send("Fail")
             } catch (e: RuntimeException) {
                 send(e.message!!)

--- a/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
@@ -107,7 +107,7 @@ class FluxTest : TestBase() {
         expect(2)
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(3)
-            observable.consumeEach {
+            observable.collect {
                 expect(8)
                 assertEquals("OK", it)
             }
@@ -131,7 +131,7 @@ class FluxTest : TestBase() {
             }
         }
         try {
-            pub.consumeEach {
+            pub.collect {
                 throw TestException()
             }
         } catch (e: TestException) {

--- a/reactive/kotlinx-coroutines-rx2/src/RxChannel.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxChannel.kt
@@ -41,16 +41,30 @@ public fun <T> ObservableSource<T>.openSubscription(): ReceiveChannel<T> {
     return channel
 }
 
+// Will be promoted to error in 1.3.0, removed in 1.4.0
+@Deprecated(message = "Use collect instead", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("this.collect(action)"))
+public suspend inline fun <T> MaybeSource<T>.consumeEach(action: (T) -> Unit) =
+    openSubscription().consumeEach(action)
+
+// Will be promoted to error in 1.3.0, removed in 1.4.0
+@Deprecated(message = "Use collect instead", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("this.collect(action)"))
+public suspend inline fun <T> ObservableSource<T>.consumeEach(action: (T) -> Unit) =
+    openSubscription().consumeEach(action)
+
 /**
  * Subscribes to this [MaybeSource] and performs the specified action for each received element.
+ * Cancels subscription if any exception happens during collect.
  */
-public suspend inline fun <T> MaybeSource<T>.consumeEach(action: (T) -> Unit) =
+@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
+public suspend inline fun <T> MaybeSource<T>.collect(action: (T) -> Unit) =
     openSubscription().consumeEach(action)
 
 /**
  * Subscribes to this [ObservableSource] and performs the specified action for each received element.
+ * Cancels subscription if any exception happens during collect.
  */
-public suspend inline fun <T> ObservableSource<T>.consumeEach(action: (T) -> Unit) =
+@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
+public suspend inline fun <T> ObservableSource<T>.collect(action: (T) -> Unit) =
     openSubscription().consumeEach(action)
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")

--- a/reactive/kotlinx-coroutines-rx2/test/FlowAsObservableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowAsObservableTest.kt
@@ -82,7 +82,7 @@ class FlowAsObservableTest : TestBase() {
         expect(1)
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(2)
-            observable.consumeEach {
+            observable.collect {
                 expect(5)
                 assertEquals("OK", it)
             }
@@ -106,7 +106,7 @@ class FlowAsObservableTest : TestBase() {
         }.asObservable()
 
         try {
-            observable.consumeEach {
+            observable.collect {
                 expect(3)
                 throw TestException()
             }

--- a/reactive/kotlinx-coroutines-rx2/test/FlowableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowableTest.kt
@@ -107,7 +107,7 @@ class FlowableTest : TestBase() {
         expect(2)
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(3)
-            observable.consumeEach{
+            observable.collect {
                 expect(8)
                 assertEquals("OK", it)
             }
@@ -131,7 +131,7 @@ class FlowableTest : TestBase() {
             }
         }
         try {
-            pub.consumeEach {
+            pub.collect {
                 throw TestException()
             }
         } catch (e: TestException) {

--- a/reactive/kotlinx-coroutines-rx2/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/IntegrationTest.kt
@@ -50,7 +50,7 @@ class IntegrationTest(
         assertNSE { observable.awaitLast() }
         assertNSE { observable.awaitSingle() }
         var cnt = 0
-        observable.consumeEach {
+        observable.collect {
             cnt++
         }
         assertThat(cnt, IsEqual(0))
@@ -69,7 +69,7 @@ class IntegrationTest(
         assertThat(observable.awaitLast(), IsEqual("OK"))
         assertThat(observable.awaitSingle(), IsEqual("OK"))
         var cnt = 0
-        observable.consumeEach {
+        observable.collect {
             assertThat(it, IsEqual("OK"))
             cnt++
         }
@@ -127,7 +127,7 @@ class IntegrationTest(
 
     private suspend fun checkNumbers(n: Int, observable: Observable<Int>) {
         var last = 0
-        observable.consumeEach {
+        observable.collect {
             assertThat(it, IsEqual(++last))
         }
         assertThat(last, IsEqual(n))

--- a/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
@@ -229,7 +229,7 @@ class MaybeTest : TestBase() {
         expect(2)
         val timeout = withTimeoutOrNull(100) {
             expect(3)
-            maybe.consumeEach {
+            maybe.collect {
                 expectUnreached()
             }
             expectUnreached()

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableCompletionStressTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableCompletionStressTest.kt
@@ -24,7 +24,7 @@ class ObservableCompletionStressTest : TestBase() {
             runBlocking {
                 withTimeout(5000) {
                     var received = 0
-                    range(Dispatchers.Default, 1, count).consumeEach { x ->
+                    range(Dispatchers.Default, 1, count).collect { x ->
                         received++
                         if (x != received) error("$x != $received")
                     }

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableMultiTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableMultiTest.kt
@@ -52,7 +52,7 @@ class ObservableMultiTest : TestBase() {
     fun testIteratorResendUnconfined() {
         val n = 10_000 * stressTestMultiplier
         val observable = GlobalScope.rxObservable(Dispatchers.Unconfined) {
-            Observable.range(0, n).consumeEach { send(it) }
+            Observable.range(0, n).collect { send(it) }
         }
         checkSingleValue(observable.toList()) { list ->
             assertEquals((0 until n).toList(), list)
@@ -63,7 +63,7 @@ class ObservableMultiTest : TestBase() {
     fun testIteratorResendPool() {
         val n = 10_000 * stressTestMultiplier
         val observable = GlobalScope.rxObservable {
-            Observable.range(0, n).consumeEach { send(it) }
+            Observable.range(0, n).collect { send(it) }
         }
         checkSingleValue(observable.toList()) { list ->
             assertEquals((0 until n).toList(), list)

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableSingleTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableSingleTest.kt
@@ -179,7 +179,7 @@ class ObservableSingleTest {
     fun testObservableIteration() {
         val observable = GlobalScope.rxObservable {
             var result = ""
-            Observable.just("O", "K").consumeEach { result += it }
+            Observable.just("O", "K").collect { result += it }
             send(result)
         }
 
@@ -192,7 +192,7 @@ class ObservableSingleTest {
     fun testObservableIterationFailure() {
         val observable = GlobalScope.rxObservable {
             try {
-                Observable.error<String>(RuntimeException("OK")).consumeEach { fail("Should not be here") }
+                Observable.error<String>(RuntimeException("OK")).collect { fail("Should not be here") }
                 send("Fail")
             } catch (e: RuntimeException) {
                 send(e.message!!)

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableTest.kt
@@ -106,7 +106,7 @@ class ObservableTest : TestBase() {
         expect(2)
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(3)
-            observable.consumeEach{
+            observable.collect {
                 expect(8)
                 assertEquals("OK", it)
             }
@@ -134,7 +134,7 @@ class ObservableTest : TestBase() {
             }
         }
         try {
-            pub.consumeEach {
+            pub.collect {
                 expect(3)
                 throw TestException()
             }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-02.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-02.kt
@@ -21,12 +21,12 @@ fun main() = runBlocking<Unit> {
     }
     // print elements from the source
     println("Elements:")
-    source.consumeEach { // consume elements from it
+    source.collect { // collect elements from it
         println(it)
     }
     // print elements from the source AGAIN
     println("Again:")
-    source.consumeEach { // consume elements from it
+    source.collect { // collect elements from it
         println(it)
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-04.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-04.kt
@@ -16,5 +16,5 @@ fun main() = runBlocking<Unit> {
         .doOnComplete { println("OnComplete") }   // ...
         .doFinally { println("Finally") }         // ... into what's going on
     // iterate over the source fully
-    source.consumeEach { println(it) }
+    source.collect { println(it) }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-04.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-04.kt
@@ -15,6 +15,6 @@ fun main() = runBlocking<Unit> {
         .doOnSubscribe { println("OnSubscribe") } // provide some insight
         .doOnComplete { println("OnComplete") }   // ...
         .doFinally { println("Finally") }         // ... into what's going on
-    // iterate over the source fully
+    // collect the source fully
     source.collect { println(it) }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-07.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-07.kt
@@ -7,7 +7,7 @@ package kotlinx.coroutines.rx2.guide.basic07
 
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.*
-import kotlinx.coroutines.rx2.consumeEach
+import kotlinx.coroutines.rx2.collect
 
 fun main() = runBlocking<Unit> {
     val subject = BehaviorSubject.create<String>()
@@ -15,7 +15,7 @@ fun main() = runBlocking<Unit> {
     subject.onNext("two")
     // now launch a coroutine to print everything
     GlobalScope.launch(Dispatchers.Unconfined) { // launch coroutine in unconfined context
-        subject.consumeEach { println(it) }
+        subject.collect { println(it) }
     }
     subject.onNext("three")
     subject.onNext("four")

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-08.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-basic-08.kt
@@ -16,7 +16,7 @@ fun main() = runBlocking<Unit> {
     subject.onNext("two")
     // now launch a coroutine to print the most recent update
     launch { // use the context of the main thread for a coroutine
-        subject.consumeEach { println(it) }
+        subject.collect { println(it) }
     }
     subject.onNext("three")
     subject.onNext("four")

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-context-04.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-context-04.kt
@@ -20,5 +20,5 @@ fun rangeWithIntervalRx(scheduler: Scheduler, time: Long, start: Int, count: Int
 
 fun main() = runBlocking<Unit> {
     rangeWithIntervalRx(Schedulers.computation(), 100, 1, 3)
-        .consumeEach { println("$it on thread ${Thread.currentThread().name}") }
+        .collect { println("$it on thread ${Thread.currentThread().name}") }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-context-05.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-context-05.kt
@@ -21,7 +21,7 @@ fun rangeWithIntervalRx(scheduler: Scheduler, time: Long, start: Int, count: Int
 fun main() = runBlocking<Unit> {
     val job = launch(Dispatchers.Unconfined) { // launch a new coroutine in Unconfined context (without its own thread pool)
         rangeWithIntervalRx(Schedulers.computation(), 100, 1, 3)
-            .consumeEach { println("$it on thread ${Thread.currentThread().name}") }
+            .collect { println("$it on thread ${Thread.currentThread().name}") }
     }
     job.join() // wait for our coroutine to complete
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-01.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-01.kt
@@ -15,5 +15,5 @@ fun CoroutineScope.range(context: CoroutineContext, start: Int, count: Int) = pu
 
 fun main() = runBlocking<Unit> {
     // Range inherits parent job from runBlocking, but overrides dispatcher with Dispatchers.Default
-    range(Dispatchers.Default, 1, 5).consumeEach { println(it) }
+    range(Dispatchers.Default, 1, 5).collect { println(it) }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-02.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-02.kt
@@ -15,7 +15,7 @@ fun <T, R> Publisher<T>.fusedFilterMap(
     predicate: (T) -> Boolean,   // the filter predicate
     mapper: (T) -> R             // the mapper function
 ) = GlobalScope.publish<R>(context) {
-    consumeEach {                // consume the source stream 
+    collect {                // consume the source stream 
         if (predicate(it))       // filter part
             send(mapper(it))     // map part
     }        
@@ -28,5 +28,5 @@ fun CoroutineScope.range(start: Int, count: Int) = publish<Int> {
 fun main() = runBlocking<Unit> {
    range(1, 5)
        .fusedFilterMap(coroutineContext, { it % 2 == 0}, { "$it is even" })
-       .consumeEach { println(it) } // print all the resulting strings
+       .collect { println(it) } // print all the resulting strings
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-02.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-02.kt
@@ -15,7 +15,7 @@ fun <T, R> Publisher<T>.fusedFilterMap(
     predicate: (T) -> Boolean,   // the filter predicate
     mapper: (T) -> R             // the mapper function
 ) = GlobalScope.publish<R>(context) {
-    collect {                // consume the source stream 
+    collect {                    // collect the source stream 
         if (predicate(it))       // filter part
             send(mapper(it))     // map part
     }        

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-03.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-03.kt
@@ -35,5 +35,5 @@ fun CoroutineScope.rangeWithInterval(time: Long, start: Int, count: Int) = publi
 fun main() = runBlocking<Unit> {
     val slowNums = rangeWithInterval(200, 1, 10)         // numbers with 200ms interval
     val stop = rangeWithInterval(500, 1, 10)             // the first one after 500ms
-    slowNums.takeUntil(coroutineContext, stop).consumeEach { println(it) } // let's test it
+    slowNums.takeUntil(coroutineContext, stop).collect { println(it) } // let's test it
 }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-03.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-03.kt
@@ -18,8 +18,8 @@ fun <T, U> Publisher<T>.takeUntil(context: CoroutineContext, other: Publisher<U>
         other.openSubscription().consume { // explicitly open channel to Publisher<U>
             val other = this
             whileSelect {
-                other.onReceive { false }          // bail out on any received element from `other`
-                current.onReceive { send(it); true }  // resend element from this channel and continue
+                other.onReceive { false }            // bail out on any received element from `other`
+                current.onReceive { send(it); true } // resend element from this channel and continue
             }
         }
     }

--- a/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-04.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/guide/example-reactive-operators-04.kt
@@ -11,9 +11,9 @@ import org.reactivestreams.*
 import kotlin.coroutines.*
 
 fun <T> Publisher<Publisher<T>>.merge(context: CoroutineContext) = GlobalScope.publish<T>(context) {
-  consumeEach { pub ->                 // for each publisher received on the source channel
+  collect { pub -> // for each publisher collected
       launch {  // launch a child coroutine
-          pub.consumeEach { send(it) } // resend all element from this publisher
+          pub.collect { send(it) } // resend all element from this publisher
       }
   }
 }
@@ -33,5 +33,5 @@ fun CoroutineScope.testPub() = publish<Publisher<Int>> {
 }
 
 fun main() = runBlocking<Unit> {
-    testPub().merge(coroutineContext).consumeEach { println(it) } // print the whole stream
+    testPub().merge(coroutineContext).collect { println(it) } // print the whole stream
 }


### PR DESCRIPTION
… introduce collect extension instead to be aligned with Flow

First wave of #1080