### PR TITLE
kotlinx-coroutines-test cleanup

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-test.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-test.txt
@@ -23,6 +23,7 @@ public final class kotlinx/coroutines/test/TestCoroutineDispatcher : kotlinx/cor
 	public fun cleanupTestCoroutines ()V
 	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dispatch (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
+	public fun dispatchYield (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
 	public fun getCurrentTime ()J
 	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
 	public fun pauseDispatcher ()V

--- a/kotlinx-coroutines-test/README.md
+++ b/kotlinx-coroutines-test/README.md
@@ -274,8 +274,8 @@ important to ensure that [cleanupTestCoroutines][TestCoroutineScope.cleanupTestC
 
 ```kotlin
 class TestClass {
-    val testScope = TestCoroutineScope()
-    lateinit var subject: Subject = null 
+    private val testScope = TestCoroutineScope()
+    private lateinit var subject: Subject = null 
     
     @Before
     fun setup() {

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -136,6 +136,7 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
     // Storing time in nanoseconds internally.
     private val _time = atomic(0L)
 
+    /** @suppress */
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         if (dispatchImmediately) {
             block.run()
@@ -144,10 +145,18 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         }
     }
 
+    /** @suppress */
+    @InternalCoroutinesApi
+    override fun dispatchYield(context: CoroutineContext, block: Runnable) {
+        post(block)
+    }
+
+    /** @suppress */
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         postDelayed(CancellableContinuationRunnable(continuation) { resumeUndispatched(Unit) }, timeMillis)
     }
 
+    /** @suppress */
     override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
         val node = postDelayed(block, timeMillis)
         return object : DisposableHandle {
@@ -157,6 +166,7 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         }
     }
 
+    /** @suppress */
     override fun toString(): String {
         return "TestCoroutineDispatcher[currentTime=${currentTime}ms, queued=${queue.size}]"
     }
@@ -186,8 +196,10 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         }
     }
 
+    /** @suppress */
     override val currentTime get() = _time.value
 
+    /** @suppress */
     override fun advanceTimeBy(delayTimeMillis: Long): Long {
         val oldTime = currentTime
         advanceUntilTime(oldTime + delayTimeMillis)
@@ -204,6 +216,7 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         _time.update { currentValue -> max(currentValue, targetTime) }
     }
 
+    /** @suppress */
     override fun advanceUntilIdle(): Long {
         val oldTime = currentTime
         while(!queue.isEmpty) {
@@ -214,8 +227,10 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         return currentTime - oldTime
     }
 
+    /** @suppress */
     override fun runCurrent() = doActionsUntil(currentTime)
 
+    /** @suppress */
     override suspend fun pauseDispatcher(block: suspend () -> Unit) {
         val previous = dispatchImmediately
         dispatchImmediately = false
@@ -226,14 +241,17 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
         }
     }
 
+    /** @suppress */
     override fun pauseDispatcher() {
         dispatchImmediately = false
     }
 
+    /** @suppress */
     override fun resumeDispatcher() {
         dispatchImmediately = true
     }
 
+    /** @suppress */
     override fun cleanupTestCoroutines() {
         // process any pending cancellations or completions, but don't advance time
         doActionsUntil(currentTime)

--- a/kotlinx-coroutines-test/src/TestCoroutineExceptionHandler.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineExceptionHandler.kt
@@ -35,20 +35,22 @@ public interface UncaughtExceptionCaptor {
  * An exception handler that captures uncaught exceptions in tests.
  */
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
-public class TestCoroutineExceptionHandler:
+public class TestCoroutineExceptionHandler :
     AbstractCoroutineContextElement(CoroutineExceptionHandler), UncaughtExceptionCaptor, CoroutineExceptionHandler
 {
+    private val _exceptions = mutableListOf<Throwable>()
+
     override fun handleException(context: CoroutineContext, exception: Throwable) {
         synchronized(_exceptions) {
             _exceptions += exception
         }
     }
 
-    private val _exceptions = mutableListOf<Throwable>()
-
+    /** @suppress **/
     override val uncaughtExceptions
         get() = synchronized(_exceptions) { _exceptions.toList() }
 
+    /** @suppress **/
     override fun cleanupTestCoroutines() {
         synchronized(_exceptions) {
             val exception = _exceptions.firstOrNull() ?: return

--- a/kotlinx-coroutines-test/test/TestRunBlockingOrderTest.kt
+++ b/kotlinx-coroutines-test/test/TestRunBlockingOrderTest.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
 import org.junit.*
+import kotlin.coroutines.*
 
 class TestRunBlockingOrderTest : TestBase() {
     @Test
@@ -15,6 +16,17 @@ class TestRunBlockingOrderTest : TestBase() {
             expect(2)
         }
         finish(3)
+    }
+
+    @Test
+    fun testYield() = runBlockingTest {
+        expect(1)
+        launch {
+            expect(2)
+            yield()
+            finish(4)
+        }
+        expect(3)
     }
 
     @Test

--- a/kotlinx-coroutines-test/test/TestRunBlockingTest.kt
+++ b/kotlinx-coroutines-test/test/TestRunBlockingTest.kt
@@ -5,8 +5,6 @@
 package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
-import org.junit.Assert.*
-import org.junit.Test
 import kotlin.coroutines.*
 import kotlin.test.*
 
@@ -370,5 +368,30 @@ class TestRunBlockingTest {
         }
         runCurrent()
         assertEquals(true, result.isSuccess)
+    }
+
+
+    private val exceptionHandler = TestCoroutineExceptionHandler()
+
+    @Test
+    fun testPartialContextOverride() = runBlockingTest(CoroutineName("named")) {
+        assertEquals(CoroutineName("named"), coroutineContext[CoroutineName])
+        assertNotNull(coroutineContext[CoroutineExceptionHandler])
+        assertNotSame(coroutineContext[CoroutineExceptionHandler], exceptionHandler)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testPartialDispatcherOverride() = runBlockingTest(Dispatchers.Unconfined) {
+        fail("Unreached")
+    }
+
+    @Test
+    fun testOverrideExceptionHandler() = runBlockingTest(exceptionHandler) {
+        assertSame(coroutineContext[CoroutineExceptionHandler], exceptionHandler)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testOverrideExceptionHandlerError() = runBlockingTest(CoroutineExceptionHandler { _, _ -> }) {
+        fail("Unreached")
     }
 }


### PR DESCRIPTION
  * Get rid of ThreadSafeHeap usages, make it internal again
  * Yield support in test dispatcher
  * Allow partial override of coroutine context
  * Code style fixes