### PR TITLE
Add combineLatest with multiple flows

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -799,6 +799,10 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static synthetic fun broadcastIn$default (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/CoroutineStart;ILjava/lang/Object;)Lkotlinx/coroutines/channels/BroadcastChannel;
 	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function4;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function5;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function6;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;[Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun count (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun count (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun debounce (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;

--- a/kotlinx-coroutines-core/common/test/flow/operators/CombineLatestVarargTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/CombineLatestVarargTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow.operators
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlin.test.*
+
+class CombineLatestVarargTest : TestBase() {
+
+    @Test
+    fun testThreeParameters() = runTest {
+        val flow = flowOf("1").combineLatest(flowOf(2), flowOf(null)) { a, b, c ->
+            a + b + c
+        }
+
+        assertEquals("12null", flow.single())
+    }
+
+    @Test
+    fun testFourParameters() = runTest {
+        val flow = flowOf("1").combineLatest(flowOf(2), flowOf("3"), flowOf(null)) { a, b, c, d ->
+            a + b + c + d
+        }
+
+        assertEquals("123null", flow.single())
+    }
+
+    @Test
+    fun testFiveParameters() = runTest {
+        val flow =
+            flowOf("1").combineLatest(flowOf(2), flowOf("3"), flowOf(4.toByte()), flowOf(null)) { a, b, c, d, e ->
+                a + b + c + d + e
+            }
+
+        assertEquals("1234null", flow.single())
+    }
+
+    @Test
+    fun testVararg() = runTest {
+        val flow = flowOf("1").combineLatest(
+            flowOf(2),
+            flowOf("3"),
+            flowOf(4.toByte()),
+            flowOf("5"),
+            flowOf(null)
+        ) { arr -> arr.joinToString("") }
+        assertEquals("12345null", flow.single())
+    }
+
+    @Test
+    fun testEmptyVararg() = runTest {
+        val list = flowOf(1, 2, 3).combineLatest { args: Array<Any?> -> args[0] }.toList()
+        assertEquals(listOf(1, 2, 3), list)
+    }
+
+    @Test
+    fun testNonNullableAny() = runTest {
+        val value = flowOf(1).combineLatest(flowOf(2)) { args: Array<Int> ->
+            @Suppress("USELESS_IS_CHECK")
+            assertTrue(args is Array<Int>)
+            args[0] + args[1]
+        }.single()
+        assertEquals(3, value)
+    }
+}


### PR DESCRIPTION
  * combineLatest(Iterable<Flow<T>>) is not added deliberately, use-case is unclear
  * All specific overloads are marked as inline to reduce binary compatibility pressure

Fixes #1193