### PR TITLE
Improve coroutine exception handling logic

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -382,7 +382,7 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public final fun getCancellationException ()Ljava/util/concurrent/CancellationException;
 	protected fun getCancelsParent ()Z
-	public fun getChildJobCancellationCause ()Ljava/lang/Throwable;
+	public fun getChildJobCancellationCause ()Ljava/util/concurrent/CancellationException;
 	public final fun getChildren ()Lkotlin/sequences/Sequence;
 	protected final fun getCompletionCause ()Ljava/lang/Throwable;
 	protected final fun getCompletionCauseHandled ()Z
@@ -447,7 +447,7 @@ public abstract interface annotation class kotlinx/coroutines/ObsoleteCoroutines
 }
 
 public abstract interface class kotlinx/coroutines/ParentJob : kotlinx/coroutines/Job {
-	public abstract fun getChildJobCancellationCause ()Ljava/lang/Throwable;
+	public abstract fun getChildJobCancellationCause ()Ljava/util/concurrent/CancellationException;
 }
 
 public final class kotlinx/coroutines/ParentJob$DefaultImpls {

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -387,7 +387,6 @@ public class kotlinx/coroutines/JobSupport : kotlinx/coroutines/ChildJob, kotlin
 	protected final fun getCompletionCause ()Ljava/lang/Throwable;
 	protected final fun getCompletionCauseHandled ()Z
 	public final fun getCompletionExceptionOrNull ()Ljava/lang/Throwable;
-	protected fun getHandlesException ()Z
 	public final fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
 	public final fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
 	protected fun handleJobException (Ljava/lang/Throwable;)Z

--- a/kotlinx-coroutines-core/common/src/CompletableJob.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableJob.kt
@@ -24,6 +24,7 @@ public interface CompletableJob : Job {
     /**
      * Completes this job exceptionally with a given [exception]. The result is `true` if this job was
      * completed as a result of this invocation and `false` otherwise (if it was already completed).
+     * [exception] parameter is used as an additional debug information that is not handled by any exception handlers.
      *
      * Subsequent invocations of this function have no effect and always produce `false`.
      *

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -422,10 +422,13 @@ public interface ParentJob : Job {
      * Child job is using this method to learn its cancellation cause when the parent cancels it with [ChildJob.parentCancelled].
      * This method is invoked only if the child was not already being cancelled.
      *
+     * Note that [CancellationException] is the method's return type: if child is cancelled by its parent,
+     * then the original exception is **already** handled by either the parent or the original source of failure.
+     *
      * @suppress **This is unstable API and it is subject to change.**
      */
     @InternalCoroutinesApi
-    public fun getChildJobCancellationCause(): Throwable
+    public fun getChildJobCancellationCause(): CancellationException
 }
 
 /**

--- a/kotlinx-coroutines-core/common/test/ParentCancellationTest.kt
+++ b/kotlinx-coroutines-core/common/test/ParentCancellationTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.*
 class ParentCancellationTest : TestBase() {
     @Test
     fun testJobChild() = runTest {
-        testParentCancellation(expectUnhandled = true) { fail ->
+        testParentCancellation(expectUnhandled = false) { fail ->
             val child = Job(coroutineContext[Job])
             CoroutineScope(coroutineContext + child).fail()
         }

--- a/kotlinx-coroutines-core/common/test/SupervisorTest.kt
+++ b/kotlinx-coroutines-core/common/test/SupervisorTest.kt
@@ -171,7 +171,8 @@ class SupervisorTest : TestBase() {
         try {
             deferred.await()
             expectUnreached()
-        } catch (e: TestException1) {
+        } catch (e: CancellationException) {
+            assertTrue(e.cause?.cause is TestException1)
             finish(3)
         }
     }

--- a/kotlinx-coroutines-core/common/test/SupervisorTest.kt
+++ b/kotlinx-coroutines-core/common/test/SupervisorTest.kt
@@ -172,7 +172,8 @@ class SupervisorTest : TestBase() {
             deferred.await()
             expectUnreached()
         } catch (e: CancellationException) {
-            assertTrue(e.cause?.cause is TestException1)
+            val cause = if (RECOVER_STACK_TRACES) e.cause?.cause!! else e.cause
+            assertTrue(cause is TestException1)
             finish(3)
         }
     }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/Exceptions.kt
@@ -54,7 +54,7 @@ class CapturingHandler : AbstractCoroutineContextElement(CoroutineExceptionHandl
     }
 }
 
-internal fun runBlock(
+internal fun captureExceptionsRun(
     context: CoroutineContext = EmptyCoroutineContext,
     block: suspend CoroutineScope.() -> Unit
 ): Throwable {
@@ -63,7 +63,7 @@ internal fun runBlock(
     return handler.getException()
 }
 
-internal fun runBlockForMultipleExceptions(
+internal fun captureMultipleExceptionsRun(
     context: CoroutineContext = EmptyCoroutineContext,
     block: suspend CoroutineScope.() -> Unit
 ): List<Throwable> {

--- a/kotlinx-coroutines-core/jvm/test/exceptions/JobExceptionHandlingTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/JobExceptionHandlingTest.kt
@@ -18,9 +18,9 @@ class JobExceptionHandlingTest : TestBase() {
         /*
          * Root parent: JobImpl()
          * Child: throws ISE
-         * Result: ISE in exception handler
+         * Result: ISE in exception handlerWithContextExceptionHandlingTest
          */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job, start = ATOMIC) {
                 expect(2)
@@ -33,26 +33,6 @@ class JobExceptionHandlingTest : TestBase() {
         }
 
         checkException<IllegalStateException>(exception)
-    }
-
-    @Test
-    fun testAsyncCancellationWithCause() = runTest {
-        val deferred = async(NonCancellable) {
-            expect(2)
-            delay(Long.MAX_VALUE)
-        }
-
-        expect(1)
-        yield()
-        deferred.cancel(TestCancellationException("TEST"))
-        try {
-            deferred.await()
-            expectUnreached()
-        } catch (e: TestCancellationException) {
-            assertEquals("TEST", e.message)
-            assertTrue(e.suppressed.isEmpty())
-            finish(3)
-        }
     }
 
     @Test
@@ -69,10 +49,26 @@ class JobExceptionHandlingTest : TestBase() {
         try {
             deferred.await()
             expectUnreached()
-        } catch (e: IOException) {
+        } catch (e: CancellationException) {
             assertTrue(e.suppressed.isEmpty())
+            assertTrue(e.cause?.suppressed?.isEmpty() ?: false)
             finish(3)
         }
+    }
+
+    @Test
+    fun testAsyncCancellationWithCauseAndParentDoesNotTriggerHandling() = runTest {
+        val parent = Job()
+        val job = launch(parent) {
+            expect(2)
+            delay(Long.MAX_VALUE)
+        }
+
+        expect(1)
+        yield()
+        parent.completeExceptionally(IOException())
+        job.join()
+        finish(3)
     }
 
     @Test
@@ -85,7 +81,7 @@ class JobExceptionHandlingTest : TestBase() {
          *
          * Github issue #354
          */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             val child = launch(job, start = ATOMIC) {
                 expect(2)
@@ -109,7 +105,7 @@ class JobExceptionHandlingTest : TestBase() {
          * Inner child: throws AE
          * Result: AE in exception handler
          */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job) {
                 expect(2) // <- child is launched successfully
@@ -145,7 +141,7 @@ class JobExceptionHandlingTest : TestBase() {
         * Inner child: throws AE
         * Result: AE
         */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job, start = ATOMIC) {
                 expect(2)
@@ -173,7 +169,7 @@ class JobExceptionHandlingTest : TestBase() {
          * Inner child: throws AE
          * Result: IOE with suppressed AE
          */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job) {
                 expect(2) // <- child is launched successfully
@@ -196,11 +192,9 @@ class JobExceptionHandlingTest : TestBase() {
             finish(5)
         }
 
-        assertTrue(exception is IOException)
+        assertTrue(exception is ArithmeticException)
         assertNull(exception.cause)
-        val suppressed = exception.suppressed
-        assertEquals(1, suppressed.size)
-        checkException<ArithmeticException>(suppressed[0])
+        assertTrue(exception.suppressed.isEmpty())
     }
 
     @Test
@@ -211,7 +205,7 @@ class JobExceptionHandlingTest : TestBase() {
           * Child: launch 3 children, each of them throws an exception (AE, IOE, IAE) and calls delay()
           * Result: AE with suppressed IOE and IAE
           */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job, start = ATOMIC) {
                 expect(2)
@@ -253,7 +247,7 @@ class JobExceptionHandlingTest : TestBase() {
          * Child: launch 2 children (each of them throws an exception (IOE, IAE)), throws AE
          * Result: AE with suppressed IOE and IAE
          */
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job, start = ATOMIC) {
                 expect(2)
@@ -280,6 +274,34 @@ class JobExceptionHandlingTest : TestBase() {
         assertEquals(2, suppressed.size)
         assertTrue(suppressed[0] is IOException)
         assertTrue(suppressed[1] is IllegalArgumentException)
+    }
+
+    @Test
+    fun testExceptionIsHandledOnce() = runTest(unhandled = listOf { e -> e is TestException }) {
+        val job = Job()
+        val j1 = launch(job) {
+            expect(1)
+            delay(Long.MAX_VALUE)
+        }
+
+        val j2 = launch(job) {
+            expect(2)
+            throw TestException()
+        }
+
+        joinAll(j1 ,j2)
+        finish(3)
+    }
+
+    @Test
+    fun testCancelledParent() = runTest {
+        expect(1)
+        val parent = Job()
+        parent.completeExceptionally(TestException())
+        launch(parent) {
+            expectUnreached()
+        }.join()
+        finish(2)
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/exceptions/JobExceptionsStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/JobExceptionsStressTest.kt
@@ -7,7 +7,6 @@ package kotlinx.coroutines.exceptions
 import kotlinx.coroutines.*
 import org.junit.*
 import org.junit.Test
-import java.io.*
 import java.util.concurrent.*
 import kotlin.test.*
 
@@ -28,7 +27,7 @@ class JobExceptionsStressTest : TestBase() {
          * Result: one of the exceptions with the rest two as suppressed
          */
         repeat(1000 * stressTestMultiplier) {
-            val exception = runBlock(executor) {
+            val exception = captureExceptionsRun(executor) {
                 val barrier = CyclicBarrier(4)
                 val job = launch(NonCancellable) {
                     launch(start = CoroutineStart.ATOMIC) {

--- a/kotlinx-coroutines-core/jvm/test/exceptions/JobNestedExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/JobNestedExceptionsTest.kt
@@ -13,7 +13,7 @@ class JobNestedExceptionsTest : TestBase() {
 
     @Test
     fun testExceptionUnwrapping() {
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job) {
                 expect(2)
@@ -37,7 +37,7 @@ class JobNestedExceptionsTest : TestBase() {
 
     @Test
     fun testExceptionUnwrappingWithSuspensions() {
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             val job = Job()
             launch(job) {
                 expect(2)
@@ -66,7 +66,7 @@ class JobNestedExceptionsTest : TestBase() {
 
     @Test
     fun testNestedAtomicThrow() {
-        val exception = runBlock {
+        val exception = captureExceptionsRun {
             expect(1)
             val job = launch(NonCancellable + CoroutineName("outer"), start = CoroutineStart.ATOMIC) {
                 expect(2)
@@ -86,7 +86,7 @@ class JobNestedExceptionsTest : TestBase() {
 
     @Test
     fun testChildThrowsDuringCompletion() {
-        val exceptions = runBlockForMultipleExceptions {
+        val exceptions = captureMultipleExceptionsRun {
             expect(1)
             val job = launch(NonCancellable + CoroutineName("outer"), start = CoroutineStart.ATOMIC) {
                 expect(2)

--- a/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/ProduceExceptionsTest.kt
@@ -160,7 +160,9 @@ class ProduceExceptionsTest : TestBase() {
         yield()
         try {
             channel.receive()
-        } catch (e: TestException2) {
+        } catch (e: CancellationException) {
+            // RECOVER_STACK_TRACES
+            assertTrue(e.cause?.cause is TestException2)
             finish(4)
         }
     }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/WithContextExceptionHandlingTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/WithContextExceptionHandlingTest.kt
@@ -11,7 +11,6 @@ import org.junit.runners.*
 import kotlin.coroutines.*
 import kotlin.test.*
 
-@Suppress("DEPRECATION") // cancel(cause)
 @RunWith(Parameterized::class)
 class WithContextExceptionHandlingTest(private val mode: Mode) : TestBase() {
     enum class Mode { WITH_CONTEXT, ASYNC_AWAIT }


### PR DESCRIPTION
  * Wrap exceptions into CE if parent cancels its child. This is possible because now we can be sure that no one is invoking 'cancel(Throwable)', thus if parent cancels its children, an exception is definitely handled.
  * This changes allows exceptions in hierarchies to be handled only once even when coroutines in the hierarchy are capable of handling exceptions
  * Breaking change: CompletableJob.completeExceptionally(exception) uses its parameter as additional debug information for children ('cause' of CE), thus changing the result of its children. For example, if CJ was a parent of CompleteableDeferred and CJ was completed exceptionally with exception E1, now CD.await() will throw CE instead of E1
  * Recursively check whether parent handles exception to avoid duplicates reporting when Job() is present in the hierarchy

Fixes for #689