### PR TITLE
Support completing the test coroutine from outside the test thread.

### DIFF
--- a/kotlinx-coroutines-test/src/DelayController.kt
+++ b/kotlinx-coroutines-test/src/DelayController.kt
@@ -2,6 +2,7 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 
 /**
  * Control the virtual clock time of a [CoroutineDispatcher].
@@ -112,9 +113,75 @@ public interface DelayController {
      * Resumed dispatchers will automatically progress through all coroutines scheduled at the current time. To advance
      * time and execute coroutines scheduled in the future use, one of [advanceTimeBy],
      * or [advanceUntilIdle].
+     *
+     * When the dispatcher is resumed, all execution be immediate in the thread that triggered it. This means
+     * that the following code will not switch back from Dispatchers.IO after `withContext`
+     *
+     * ```
+     * runBlockingTest {
+     *     withContext(Dispatchers.IO) { doIo() }
+     *     // runBlockingTest is still on Dispatchers.IO here
+     * }
+     * ```
+     *
+     * For tests that need accurate threading behavior, [pauseDispatcher] will ensure that the following test dispatches
+     * on the correct thread.
+     *
+     * ```
+     * runBlockingTest {
+     *     pauseDispatcher()
+     *     withContext(Dispatchers.IO) { doIo() }
+     *     // runBlockingTest has returned to it's starting thread here
+     * }
+     * ```
      */
     @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun resumeDispatcher()
+
+    /**
+     * Represents the queue state of a DelayController.
+     *
+     * Tests do not normally need to use this API. It is exposed for advanced situations like integrating multiple
+     * [TestCoroutineDispatcher] instances or creating alternatives to [runBlockingtest].
+     */
+    public sealed class QueueState {
+        /**
+         * A [DelayController] that is idle does not currently have any tasks to perform.
+         *
+         * This may happen if all coroutines in this [DelayController] have completed, or if they are all suspended
+         * waiting on other dispatchers.
+         */
+        public object Idle: QueueState() {
+            override fun toString() = "Idle"
+        }
+
+        /**
+         * A [DelayController] that has a task that will execute in response to a call to [runCurrent].
+         *
+         * There may also be delayed tasks scheduled, in which case [HasCurrentTask] takes priority since current tasks
+         * will execute at an earlier virtual time.
+         */
+        public object HasCurrentTask: QueueState() {
+            override fun toString() = "HasCurrentTask"
+        }
+
+        /**
+         * A [DelayController] that has delayed tasks has a task scheduled for sometime in the future.
+         *
+         * If there are also tasks at the current time, [HasCurrentTask] will take priority.
+         */
+        public object HasDelayedTask: QueueState(){
+            override fun toString() = "HasDelayedTask"
+        }
+    }
+
+    /**
+     * A ConflatedBroadcastChannel that is up to date with the current [QueueState].
+     *
+     * Tests do not normally need to use this API. It is exposed for advanced situations like integrating multiple
+     * [TestCoroutineDispatcher] instances or creating alternatives to [runBlockingtest].
+     */
+    public val queueState: ConflatedBroadcastChannel<QueueState>
 }
 
 /**

--- a/kotlinx-coroutines-test/src/DelayController.kt
+++ b/kotlinx-coroutines-test/src/DelayController.kt
@@ -94,6 +94,9 @@ public interface DelayController {
      *
      * This is useful when testing functions that start a coroutine. By pausing the dispatcher assertions or
      * setup may be done between the time the coroutine is created and started.
+     *
+     * While in the paused block, the dispatcher will queue all dispatched coroutines and they will be resumed on
+     * whatever thread calls [advanceUntilIdle], [advanceTimeBy], or [runCurrent].
      */
     @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public suspend fun pauseDispatcher(block: suspend () -> Unit)
@@ -103,6 +106,9 @@ public interface DelayController {
      *
      * When paused, the dispatcher will not execute any coroutines automatically, and you must call [runCurrent] or
      * [advanceTimeBy], or [advanceUntilIdle] to execute coroutines.
+     *
+     * While paused, the dispatcher will queue all dispatched coroutines and they will be resumed on whatever thread
+     * calls [advanceUntilIdle], [advanceTimeBy], or [runCurrent].
      */
     @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun pauseDispatcher()
@@ -114,8 +120,9 @@ public interface DelayController {
      * time and execute coroutines scheduled in the future use, one of [advanceTimeBy],
      * or [advanceUntilIdle].
      *
-     * When the dispatcher is resumed, all execution be immediate in the thread that triggered it. This means
-     * that the following code will not switch back from Dispatchers.IO after `withContext`
+     * When the dispatcher is resumed, all execution be immediate in the thread that triggered it similar to
+     * [Dispatchers.Unconfined]. This means that the following code will not switch back from Dispatchers.IO after
+     * `withContext`
      *
      * ```
      * runBlockingTest {
@@ -125,7 +132,7 @@ public interface DelayController {
      * ```
      *
      * For tests that need accurate threading behavior, [pauseDispatcher] will ensure that the following test dispatches
-     * on the correct thread.
+     * on a controlled thread.
      *
      * ```
      * runBlockingTest {

--- a/kotlinx-coroutines-test/src/DelayController.kt
+++ b/kotlinx-coroutines-test/src/DelayController.kt
@@ -137,51 +137,6 @@ public interface DelayController {
      */
     @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun resumeDispatcher()
-
-    /**
-     * Represents the queue state of a DelayController.
-     *
-     * Tests do not normally need to use this API. It is exposed for advanced situations like integrating multiple
-     * [TestCoroutineDispatcher] instances or creating alternatives to [runBlockingtest].
-     */
-    public sealed class QueueState {
-        /**
-         * A [DelayController] that is idle does not currently have any tasks to perform.
-         *
-         * This may happen if all coroutines in this [DelayController] have completed, or if they are all suspended
-         * waiting on other dispatchers.
-         */
-        public object Idle: QueueState() {
-            override fun toString() = "Idle"
-        }
-
-        /**
-         * A [DelayController] that has a task that will execute in response to a call to [runCurrent].
-         *
-         * There may also be delayed tasks scheduled, in which case [HasCurrentTask] takes priority since current tasks
-         * will execute at an earlier virtual time.
-         */
-        public object HasCurrentTask: QueueState() {
-            override fun toString() = "HasCurrentTask"
-        }
-
-        /**
-         * A [DelayController] that has delayed tasks has a task scheduled for sometime in the future.
-         *
-         * If there are also tasks at the current time, [HasCurrentTask] will take priority.
-         */
-        public object HasDelayedTask: QueueState(){
-            override fun toString() = "HasDelayedTask"
-        }
-    }
-
-    /**
-     * A ConflatedBroadcastChannel that is up to date with the current [QueueState].
-     *
-     * Tests do not normally need to use this API. It is exposed for advanced situations like integrating multiple
-     * [TestCoroutineDispatcher] instances or creating alternatives to [runBlockingtest].
-     */
-    public val queueState: ConflatedBroadcastChannel<QueueState>
 }
 
 /**

--- a/kotlinx-coroutines-test/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/src/TestBuilders.kt
@@ -5,7 +5,87 @@
 package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.selects.select
+import java.lang.StringBuilder
 import kotlin.coroutines.*
+
+private const val DEFAULT_TEST_TIMEOUT = 30_000L
+
+/**
+ * A strategy for waiting on coroutines executed on other dispatchers inside a [runBlockingTest].
+ *
+ * Most tests should use [MultiDispatcherWaitConfig]. As an optimization, a test that executes coroutines only on a
+ * [TestCoroutineDispatcher] and never interacts with other dispatchers may use [SingleDispatcherWaitConfig].
+ *
+ * A test may subclass this to customize the wait in advanced cases.
+ */
+interface WaitConfig {
+    /**
+     * How long (in wall-clock time) to wait for other Dispatchers to complete coroutines during a [runBlockingTest].
+     *
+     * This delay is not related to the virtual time of a [TestCoroutineDispatcher], but is how long a test should allow
+     * another dispatcher, like Dispatchers.IO, to perform a time consuming activity such as reading from a database.
+     */
+    val wait: Long
+}
+
+/**
+ * Do not wait for coroutines executing on another [Dispatcher] in [runBlockingTest].
+
+ * Always fails with an uncompleted coroutine when any coroutine in the test executes on any other dispatcher (including
+ * calls to [withContext]). It should not be used for most tests, instead use the default value of
+ * [MultiDispatcherWaitConfig].
+ *
+ * This configuration should only be used as an optimization for tests that intentionally create an uncompleted
+ * coroutine and execute all coroutines on the [TestCoroutineDispatcher] used by [runBlockingTest].
+ *
+ * If in doubt, prefer [MultiDispatcherWaitConfig].
+ */
+object SingleDispatcherWaitConfig : WaitConfig {
+    /**
+     * This value is ignored by [runBlockingTest] on [SingleDispatcherWaitConfig]
+     */
+    override val wait = 0L
+
+    override fun toString() = "SingleDispatcherWaitConfig"
+}
+
+/**
+ * Wait up to 30 seconds for any coroutines running on another [Dispatcher] to complete in [runBlockingTest].
+ *
+ * This is the default value for [runBlockingTest] and the recommendation for most tests. This configuration will allow
+ * for coroutines to be launched on another dispatcher inside the test (e.g. calls to `withContext(Dispatchers.IO)`).
+ *
+ * This allows for code like the following to be tested correctly using [runBlockingTest]:
+ *
+ * ```
+ * suspend fun delayOnDefault() = withContext(Dispatchers.Default) {
+ *      // this delay does not use the virtual-time of runBlockingTest since it's executing on Dispatchers.Default
+ *     delay(50)
+ * }
+ *
+ * runBlockingTest {
+ *     // Note: This test takes at least 50ms (real time) to run
+ *
+ *     // delayOnDefault will suspend the runBlockingTest coroutine for 50ms      [real-time: 0; virtual-time: 0]
+ *     delayOnDefault()
+ *     // runBlockingTest resumes 50ms later (real time)                          [real-time: 50; virtual-time: 0]
+ *
+ *     delay(10)
+ *     //this delay will auto-progress since it's in runBlockingTest              [real-time: 50; virtual-time: 10]
+ * }
+ * ```
+ */
+object MultiDispatcherWaitConfig: WaitConfig {
+    /**
+     * Default wait is 30 seconds.
+     *
+     * {@inheritDoc}
+     */
+    override val wait = DEFAULT_TEST_TIMEOUT
+
+    override fun toString() = "MultiDispatcherWaitConfig[wait = 30s]"
+}
 
 /**
  * Executes a [testBody] inside an immediate execution dispatcher.
@@ -38,64 +118,104 @@ import kotlin.coroutines.*
  * (including coroutines suspended on join/await).
  *
  * @param context additional context elements. If [context] contains [CoroutineDispatcher] or [CoroutineExceptionHandler],
- *        then they must implement [DelayController] and [TestCoroutineExceptionHandler] respectively.
+ * then they must implement [DelayController] and [TestCoroutineExceptionHandler] respectively.
+ * @param waitConfig strategy for waiting on other dispatchers to complete during the test. [SingleDispatcherWaitConfig]
+ * will never wait, other values will wait for [WaitConfig.wait]ms.
  * @param testBody The code of the unit-test.
  */
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
-public fun runBlockingTest(context: CoroutineContext = EmptyCoroutineContext, testBody: suspend TestCoroutineScope.() -> Unit) {
+public fun runBlockingTest(
+        context: CoroutineContext = EmptyCoroutineContext,
+        waitConfig: WaitConfig = MultiDispatcherWaitConfig,
+        testBody: suspend TestCoroutineScope.() -> Unit
+) {
     val (safeContext, dispatcher) = context.checkArguments()
     val startingJobs = safeContext.activeJobs()
-    val scope = TestCoroutineScope(safeContext)
 
-    val deferred = scope.async {
-        scope.testBody()
+    var testScope: TestCoroutineScope? = null
+
+    val deferred = CoroutineScope(safeContext).async {
+        val localTestScope = TestCoroutineScope(coroutineContext)
+        testScope = localTestScope
+        localTestScope.testBody()
     }
 
-    // run any outstanding coroutines that can be completed by advancing virtual-time
-    dispatcher.advanceUntilIdle()
+    val didTimeout = deferred.waitForCompletion(waitConfig, dispatcher)
 
-    // fetch results from the coroutine - this may require a thread hop if some child coroutine was *completed* on
-    // another thread during this test so we must use an invokeOnCompletion handler to retrieve the result.
+    if (deferred.isCompleted) {
+        deferred.getCompletionExceptionOrNull()?.let {
+            throw it
+        }
+    }
 
-    // There are two code paths for fetching the error:
-    //
-    // 1. The job was already completed (happy path, normal test)
-    //    - invokeOnCompletion was executed immediately and errorThrownByTestOrNull is already at it's final value so
-    //      we can throw it
-    // 2. The job has not already completed (always fail the test due to error or time-based non-determinism)
-    //    - invokeOnCompletion will not be triggered right away. To avoid introducing wall non-deterministic  behavior
-    //      (the deferred may complete between here and the call to activeJobs below) this will always be considered a
-    //      test failure.
-    //    - this will not happen if all coroutines are only waiting to complete due to thread hops, but may happen
-    //      if another thread triggers completion concurrently with this cleanup code.
-    //
-    // give test code errors a priority in the happy path, throw here if the error is already known.
-    val (wasCompletedAfterTest, errorThrownByTestOrNull) = deferred.getResultIfKnown()
-    errorThrownByTestOrNull?.let { throw it }
-
-    scope.cleanupTestCoroutines()
+    testScope!!.cleanupTestCoroutines()
     val endingJobs = safeContext.activeJobs()
-    if ((endingJobs - startingJobs).isNotEmpty()) {
-        throw UncompletedCoroutinesError("Test finished with active jobs: $endingJobs")
-    }
 
-    if (!wasCompletedAfterTest) {
-        // Handle path #2, we are going to fail the test in an opinionated way at this point so let the developer know
-        // how to fix it.
-        throw UncompletedCoroutinesError("Test completed all jobs after cleanup code started. This is " +
-                "thrown to avoid non-deterministic behavior in tests (the next execution may fail randomly). Ensure " +
-                "all threads started by the test are completed before returning from runBlockingTest.")
+    // TODO: should these be separate exceptions to allow for tests to detect difference?
+    if (didTimeout) {
+        val message = """
+            runBlockingTest timed out after waiting ${waitConfig.wait}ms for coroutines to complete due waitConfig = $waitConfig. 
+            Active jobs after test (may be empty): $endingJobs
+            """.trimIndent()
+        throw UncompletedCoroutinesError(message)
+    } else if ((endingJobs - startingJobs).isNotEmpty()) {
+        val message = StringBuilder("Test finished with active jobs: ")
+        message.append(endingJobs)
+        if (waitConfig == SingleDispatcherWaitConfig) {
+            message.append("""
+
+            Note: runBlockingTest did not wait for other dispatchers due to argument waitConfig = $waitConfig
+            
+            Tip: If this runBlockingTest starts any code on another dispatcher (such as Dispatchers.Default, 
+            Dispatchers.IO, etc) in any of the functions it calls it will never pass when configured with 
+            SingleDispatcherWaitConfig. Please update your test to use the default value of MultiDispatcherWaitConfig
+            like:
+            
+                runBlockingTest { }
+            
+            """.trimIndent())
+        }
+        throw UncompletedCoroutinesError(message.toString())
     }
 }
 
-private fun Deferred<Unit>.getResultIfKnown(): Pair<Boolean, Throwable?> {
-    var testError: Throwable? = null
-    var wasExecuted = false
-    invokeOnCompletion { errorFromTestOrNull ->
-        testError = errorFromTestOrNull
-        wasExecuted = true
-    }.dispose()
-    return Pair(wasExecuted, testError)
+private fun Deferred<Unit>.waitForCompletion(waitConfig: WaitConfig, dispatcher: DelayController): Boolean {
+    var didTimeout = false
+    when (waitConfig) {
+        SingleDispatcherWaitConfig -> dispatcher.advanceUntilIdle()
+        else -> {
+            runBlocking {
+                val subscription = dispatcher.queueState.openSubscription()
+                dispatcher.advanceUntilIdle()
+
+                var finished = false
+                try {
+                    while (!finished) {
+                        finished = select {
+                            this@waitForCompletion.onAwait {
+                                true
+                            }
+                            onTimeout(waitConfig.wait) {
+                                didTimeout = true
+                                true
+                            }
+                            subscription.onReceive { queueState ->
+                                when (queueState) {
+                                    DelayController.QueueState.Idle -> Unit
+                                    else -> dispatcher.advanceUntilIdle()
+                                }
+                                false
+                            }
+                        }
+                    }
+                } finally {
+                    subscription.cancel()
+                }
+            }
+
+        }
+    }
+    return didTimeout
 }
 
 private fun CoroutineContext.activeJobs(): Set<Job> {
@@ -107,13 +227,13 @@ private fun CoroutineContext.activeJobs(): Set<Job> {
  */
 // todo: need documentation on how this extension is supposed to be used
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
-public fun TestCoroutineScope.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit) = runBlockingTest(coroutineContext, block)
+public fun TestCoroutineScope.runBlockingTest(configuration: WaitConfig = MultiDispatcherWaitConfig, block: suspend TestCoroutineScope.() -> Unit) = runBlockingTest(coroutineContext, configuration, block)
 
 /**
  * Convenience method for calling [runBlockingTest] on an existing [TestCoroutineDispatcher].
  */
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
-public fun TestCoroutineDispatcher.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit) = runBlockingTest(this, block)
+public fun TestCoroutineDispatcher.runBlockingTest(configuration: WaitConfig = MultiDispatcherWaitConfig, block: suspend TestCoroutineScope.() -> Unit) = runBlockingTest(this, configuration, block)
 
 private fun CoroutineContext.checkArguments(): Pair<CoroutineContext, DelayController> {
     // TODO optimize it

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -56,8 +56,8 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
     /** @suppress */
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         if (dispatchImmediately) {
-            unpark()
             block.run()
+            unpark()
         } else {
             post(block)
         }

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -25,6 +25,10 @@ import kotlin.math.max
  * not execute until a call to [DelayController.runCurrent] or the virtual clock-time has been advanced via one of the
  * methods on [DelayController].
  *
+ * While in immediate mode [TestCoroutineDispatcher] behaves similar to [Dispatchers.Unconfined]. When resuming from
+ * another thread it will *not* switch threads. When in lazy mode, [TestCoroutineDispatcher] will enqueue all
+ * dispatches and whatever thread calls an [advanceUntilIdle], [advanceTimeBy], or [runCurrent] will continue execution.
+ *
  * @see DelayController
  */
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0

--- a/kotlinx-coroutines-test/test/TestRunBlockingTest.kt
+++ b/kotlinx-coroutines-test/test/TestRunBlockingTest.kt
@@ -274,7 +274,7 @@ class TestRunBlockingTest {
     }
 
     @Test(expected = UncompletedCoroutinesError::class)
-    fun whenACoroutineLeaks_errorIsThrown() = runBlockingTest(waitConfig = SingleDispatcherWaitConfig) {
+    fun whenACoroutineLeaks_errorIsThrown() = runBlockingTest(waitForOtherDispatchers = 0L) {
         val uncompleted = CompletableDeferred<Unit>()
         launch {
             uncompleted.await()


### PR DESCRIPTION
Implement an eventLoop for runBlockingTest.
    
    As a result, runBlockingTest is now correct in the presence of repeated
    time-delayed dispatch from other dispatchers.
    
    Changes:
    - runBlockingTest will now allow a 30 second timeout for other
    dispatchers to complete coroutines
    - Introduced WaitConfig, SingleDispatcherWaitConfig, and
    MultiDispatcherWaitConfig to configure runBlockingTest timeout behavior
    - Added DelayController.queueState as a ConflatedBroadcastChannel to
    observe or poll the queue status of a TestCoroutineDispatcher
    - Added queue status of Idle, HasCurrentTask and HasDelayedTask as
    public APIs for quering the status of a TestCoroutineDispatcher
    - Added dependency on runBlocking from runBlockingTest
    - Improved documentation for threading concerns around resumeDispatche