### PR TITLE
Enable R8 optimization of Dispatchers.Main loading

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/CoroutineExceptionHandlerImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineExceptionHandlerImpl.kt
@@ -13,10 +13,15 @@ import kotlin.coroutines.*
  * Note that Android may have dummy [Thread.contextClassLoader] which is used by one-argument [ServiceLoader.load] function,
  * see (https://stackoverflow.com/questions/13407006/android-class-loader-may-fail-for-processes-that-host-multiple-applications).
  * So here we explicitly use two-argument `load` with a class-loader of [CoroutineExceptionHandler] class.
+ *
+ * We are explicitly using the `ServiceLoader.load(MyClass::class.java, MyClass::class.java.classLoader).iterator()`
+ * form of the ServiceLoader call to enable R8 optimization when compiled on Android.
  */
-private val handlers: List<CoroutineExceptionHandler> = CoroutineExceptionHandler::class.java.let { serviceClass ->
-    ServiceLoader.load(serviceClass, serviceClass.classLoader).toList()
-}
+private val handlers: List<CoroutineExceptionHandler> = ServiceLoader.load(
+        CoroutineExceptionHandler::class.java,
+        CoroutineExceptionHandler::class.java.classLoader
+).iterator().asSequence().toList()
+
 
 internal actual fun handleCoroutineExceptionImpl(context: CoroutineContext, exception: Throwable) {
     // use additional extension handlers

--- a/kotlinx-coroutines-core/jvm/src/internal/FastServiceLoader.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/FastServiceLoader.kt
@@ -7,11 +7,6 @@ import java.util.jar.*
 import java.util.zip.*
 
 /**
- * Name of the boolean property that enables using of [FastServiceLoader].
- */
-private const val FAST_SERVICE_LOADER_PROPERTY_NAME = "kotlinx.coroutines.fast.service.loader"
-
-/**
  * A simplified version of [ServiceLoader].
  * FastServiceLoader locates and instantiates all service providers named in configuration
  * files placed in the resource directory <tt>META-INF/services</tt>.
@@ -25,12 +20,7 @@ private const val FAST_SERVICE_LOADER_PROPERTY_NAME = "kotlinx.coroutines.fast.s
 internal object FastServiceLoader {
     private const val PREFIX: String = "META-INF/services/"
 
-    private val FAST_SERVICE_LOADER_ENABLED = systemProp(FAST_SERVICE_LOADER_PROPERTY_NAME, true)
-
     internal fun <S> load(service: Class<S>, loader: ClassLoader): List<S> {
-        if (!FAST_SERVICE_LOADER_ENABLED) {
-            return ServiceLoader.load(service, loader).toList()
-        }
         return try {
             loadProviders(service, loader)
         } catch (e: Throwable) {


### PR DESCRIPTION
The developer still has to disable the FastServiceLoader manually
if they're using R8.

R8 is then able to optimize away the ServiceLoader and reflection
entirely, resulting in direct class instantiation and no extra I/O
on calling thread.

Fixes #1231