### PR TITLE
Add distinctUntilChanged operator that uses a comparator function instead of a key extractor.

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -831,6 +831,7 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun delayEach (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun delayFlow (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun distinctUntilChanged (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun distinctUntilChanged (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun distinctUntilChangedBy (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun drop (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static final fun dropWhile (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;

--- a/kotlinx-coroutines-core/common/src/flow/operators/Distinct.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Distinct.kt
@@ -19,16 +19,35 @@ import kotlinx.coroutines.flow.unsafeFlow as flow
 public fun <T> Flow<T>.distinctUntilChanged(): Flow<T> = distinctUntilChangedBy { it }
 
 /**
+ * Returns flow where all subsequent repetitions of the same value are filtered out, when compared
+ * with each other via the provided [areEquivalent] function.
+ */
+@FlowPreview
+public fun <T> Flow<T>.distinctUntilChanged(areEquivalent: (old: T, new: T) -> Boolean): Flow<T> =
+    distinctUntilChangedBy(keySelector = { it }, areEquivalent = areEquivalent)
+
+/**
  * Returns flow where all subsequent repetitions of the same key are filtered out, where
  * key is extracted with [keySelector] function.
  */
 @FlowPreview
 public fun <T, K> Flow<T>.distinctUntilChangedBy(keySelector: (T) -> K): Flow<T> =
+    distinctUntilChangedBy(keySelector = keySelector, areEquivalent = { old, new -> old == new })
+
+/**
+ * Returns flow where all subsequent repetitions of the same key are filtered out, where
+ * keys are extracted with [keySelector] function and compared with each other via the
+ * provided [areEquivalent] function.
+ */
+private inline fun <T, K> Flow<T>.distinctUntilChangedBy(
+    crossinline keySelector: (T) -> K,
+    crossinline areEquivalent: (old: K, new: K) -> Boolean
+): Flow<T> =
     flow {
         var previousKey: Any? = NULL
         collect { value ->
             val key = keySelector(value)
-            if (previousKey != key) {
+            if (previousKey === NULL || !areEquivalent(NULL.unbox(previousKey), key)) {
                 previousKey = key
                 emit(value)
             }

--- a/kotlinx-coroutines-core/common/test/flow/operators/DistinctUntilChangedTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/DistinctUntilChangedTest.kt
@@ -33,6 +33,29 @@ class DistinctUntilChangedTest : TestBase() {
     }
 
     @Test
+    fun testDistinctUntilChangedAreEquivalent() = runTest {
+        val flow = flow {
+            emit(Box(1))
+            emit(Box(1))
+            emit(Box(2))
+            emit(Box(1))
+        }
+
+        val sum1 = flow.distinctUntilChanged().map { it.i }.sum()
+        val sum2 = flow.distinctUntilChanged { old, new -> old.i == new.i }.map { it.i }.sum()
+        assertEquals(5, sum1)
+        assertEquals(4, sum2)
+    }
+
+    @Test
+    fun testDistinctUntilChangedAreEquivalentSingleValue() = runTest {
+        val flow = flowOf(1)
+
+        val values = flow.distinctUntilChanged { _, _ -> fail("Expected not to compare single value.") }.toList()
+        assertEquals(listOf(1), values)
+    }
+
+    @Test
     fun testThrowingKeySelector() = runTest {
         val flow = flow {
             coroutineScope {
@@ -50,7 +73,25 @@ class DistinctUntilChangedTest : TestBase() {
     }
 
     @Test
-    fun testDistinctUntilChangedNull() = runTest{
+    fun testThrowingAreEquivalent() = runTest {
+        val flow = flow {
+            coroutineScope {
+                launch(start = CoroutineStart.ATOMIC) {
+                    hang { expect(3) }
+                }
+                expect(2)
+                emit(1)
+                emit(2)
+            }
+        }.distinctUntilChanged { _, _ -> throw TestException() }
+
+        expect(1)
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testDistinctUntilChangedNull() = runTest {
         val flow = flowOf(null, 1, null).distinctUntilChanged()
         assertEquals(listOf(null, 1, null), flow.toList())
     }


### PR DESCRIPTION
**Use case:** Deduping values that have some custom definition of equality that can't be expressed easily via a single key (e.g. compares multiple properties, or via a custom comparator interface).

This is implemented as a two-step comparison, first extracting the keys (which is the identity function by default) and then comparing keys using the comparator function (which is just `==` by default).

The `By` suffix doesn't really make sense without a key selector, so I called the comparator-only version simply `distinctUntilChanged`. This also disambiguates the operator when a parameter-less lambda is passed in, without having to use placeholders (e.g. `distinctUntilChanged{ _ -> ... }`).

| operator | equality defined as |
|---------|---------------------|
| `distinctUntilChanged()` | `old == new` |
| `distinctUntilChanged(areEquivalent)` | `areEquivalent(old, new)` |
| `distinctUntilChangedBy(keySelector)` | `keySelector(old) == keySelector(new)` |
| `distinctUntilChangedBy(keySelector, areEquivalent)` | `areEquivalent(keySelector(old), keySelector(new))` |