### PR TITLE
Adds R8 optimization rule for FastServiceLoader

### DIFF
--- a/ui/kotlinx-coroutines-android/build.gradle
+++ b/ui/kotlinx-coroutines-android/build.gradle
@@ -4,7 +4,7 @@
 
 repositories {
     google()
-    // TODO Remove once R8 is updated to a 1.5.x version.
+    // TODO Remove once R8 is updated to a 1.6.x version.
     maven {
         url "http://storage.googleapis.com/r8-releases/raw/master"
         metadataSources {
@@ -25,38 +25,64 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.0-alpha-3'
     testImplementation 'org.smali:baksmali:2.2.7'
 
-    // TODO Replace with a 1.5.x version once released to maven.google.com.
-    r8 'com.android.tools:r8:878ec25559ca91497517345ec3a6c16102b7025c'
+    // TODO Replace with a 1.6.x version once released to maven.google.com.
+    r8 'com.android.tools:r8:a7ce65837bec81c62261bf0adac73d9c09d32af2'
 }
 
-def optimizedDex = new File(buildDir, "dex/")
-task runR8(type: JavaExec, dependsOn: 'jar') {
-    classpath = configurations.r8
-    main = 'com.android.tools.r8.R8'
+class RunR8Task extends JavaExec {
 
-    doFirst {
-        if (optimizedDex.exists()) {
-            optimizedDex.deleteDir()
-        }
-        optimizedDex.mkdirs()
+    File outputDex
+    File inputConfig
+
+    @Override
+    Task configure(Closure closure) {
+        super.configure(closure)
+        classpath = project.configurations.r8
+        main = 'com.android.tools.r8.R8'
 
         def arguments = [
-            '--release',
-            '--no-desugaring',
-            '--output', optimizedDex.absolutePath,
-            '--pg-conf', file('r8-test-rules.pro').absolutePath
+                '--release',
+                '--no-desugaring',
+                '--output', outputDex.absolutePath,
+                '--pg-conf', inputConfig.absolutePath
         ]
-        arguments.addAll(configurations.runtimeClasspath.files.collect { it.absolutePath })
-        arguments.addAll(jar.archivePath.absolutePath)
+        arguments.addAll(project.configurations.runtimeClasspath.files.collect { it.absolutePath })
+        arguments.addAll(project.jar.archivePath.absolutePath)
 
         args = arguments
+        return this
     }
+
+    @Override
+    void exec() {
+        if (outputDex.exists()) {
+            outputDex.deleteDir()
+        }
+        outputDex.mkdirs()
+
+        super.exec()
+    }
+}
+
+def optimizedDex = new File(buildDir, "dex-optim/")
+def unOptimizedDex = new File(buildDir, "dex-unoptim/")
+
+task runR8(type: RunR8Task, dependsOn: 'jar'){
+    outputDex = optimizedDex
+    inputConfig = file('r8-test-rules.pro')
+}
+
+task runR8NoOptim(type: RunR8Task, dependsOn: 'jar'){
+    outputDex = unOptimizedDex
+    inputConfig = file('r8-test-rules-no-optim.pro')
 }
 
 test {
     // Ensure the R8-processed dex is built and supply its path as a property to the test.
     dependsOn(runR8)
+    dependsOn(runR8NoOptim)
     systemProperty 'dexPath', new File(optimizedDex, "classes.dex").absolutePath
+    systemProperty 'noOptimDexPath', new File(unOptimizedDex, "classes.dex").absolutePath
 }
 
 tasks.withType(dokka.getClass()) {

--- a/ui/kotlinx-coroutines-android/build.gradle
+++ b/ui/kotlinx-coroutines-android/build.gradle
@@ -31,8 +31,17 @@ dependencies {
 
 class RunR8Task extends JavaExec {
 
+    @OutputDirectory
     File outputDex
+
+    @InputFile
     File inputConfig
+
+    @InputFile
+    final File inputConfigCommon = new File('r8-test-common.pro')
+
+    @InputFiles
+    final File jarFile = project.jar.archivePath
 
     @Override
     Task configure(Closure closure) {
@@ -47,7 +56,7 @@ class RunR8Task extends JavaExec {
                 '--pg-conf', inputConfig.absolutePath
         ]
         arguments.addAll(project.configurations.runtimeClasspath.files.collect { it.absolutePath })
-        arguments.addAll(project.jar.archivePath.absolutePath)
+        arguments.addAll(jarFile.absolutePath)
 
         args = arguments
         return this
@@ -81,8 +90,13 @@ test {
     // Ensure the R8-processed dex is built and supply its path as a property to the test.
     dependsOn(runR8)
     dependsOn(runR8NoOptim)
-    systemProperty 'dexPath', new File(optimizedDex, "classes.dex").absolutePath
-    systemProperty 'noOptimDexPath', new File(unOptimizedDex, "classes.dex").absolutePath
+    def dex1 = new File(optimizedDex, "classes.dex")
+    def dex2 = new File(unOptimizedDex, "classes.dex")
+
+    inputs.files(dex1, dex2)
+
+    systemProperty 'dexPath', dex1.absolutePath
+    systemProperty 'noOptimDexPath', dex2.absolutePath
 }
 
 tasks.withType(dokka.getClass()) {

--- a/ui/kotlinx-coroutines-android/build.gradle
+++ b/ui/kotlinx-coroutines-android/build.gradle
@@ -4,6 +4,17 @@
 
 repositories {
     google()
+    // TODO Remove once R8 is updated to a 1.5.x version.
+    maven {
+        url "http://storage.googleapis.com/r8-releases/raw/master"
+        metadataSources {
+            artifact()
+        }
+    }
+}
+
+configurations {
+    r8
 }
 
 dependencies {
@@ -12,6 +23,40 @@ dependencies {
 
     testImplementation 'com.google.android:android:4.1.1.4'
     testImplementation 'org.robolectric:robolectric:4.0-alpha-3'
+    testImplementation 'org.smali:baksmali:2.2.7'
+
+    // TODO Replace with a 1.5.x version once released to maven.google.com.
+    r8 'com.android.tools:r8:878ec25559ca91497517345ec3a6c16102b7025c'
+}
+
+def optimizedDex = new File(buildDir, "dex/")
+task runR8(type: JavaExec, dependsOn: 'jar') {
+    classpath = configurations.r8
+    main = 'com.android.tools.r8.R8'
+
+    doFirst {
+        if (optimizedDex.exists()) {
+            optimizedDex.deleteDir()
+        }
+        optimizedDex.mkdirs()
+
+        def arguments = [
+            '--release',
+            '--no-desugaring',
+            '--output', optimizedDex.absolutePath,
+            '--pg-conf', file('r8-test-rules.pro').absolutePath
+        ]
+        arguments.addAll(configurations.runtimeClasspath.files.collect { it.absolutePath })
+        arguments.addAll(jar.archivePath.absolutePath)
+
+        args = arguments
+    }
+}
+
+test {
+    // Ensure the R8-processed dex is built and supply its path as a property to the test.
+    dependsOn(runR8)
+    systemProperty 'dexPath', new File(optimizedDex, "classes.dex").absolutePath
 }
 
 tasks.withType(dokka.getClass()) {

--- a/ui/kotlinx-coroutines-android/r8-test-common.pro
+++ b/ui/kotlinx-coroutines-android/r8-test-common.pro
@@ -1,0 +1,12 @@
+# Entry point for retaining MainDispatcherLoader which uses a ServiceLoader.
+-keep class kotlinx.coroutines.Dispatchers {
+  ** getMain();
+}
+
+# Entry point for retaining CoroutineExceptionHandlerImpl.handlers which uses a ServiceLoader.
+-keep class kotlinx.coroutines.CoroutineExceptionHandlerKt {
+  void handleCoroutineException(...);
+}
+
+# We are cheating a bit by not having android.jar on R8's library classpath. Ignore those warnings.
+-ignorewarnings

--- a/ui/kotlinx-coroutines-android/r8-test-rules-no-optim.pro
+++ b/ui/kotlinx-coroutines-android/r8-test-rules-no-optim.pro
@@ -8,12 +8,7 @@
   void handleCoroutineException(...);
 }
 
-# Ensure the custom, fast service loader implementation is removed. In the case of fast service
-# loader encountering an exception it falls back to regular ServiceLoader in a way that cannot be
-# optimized out by R8.
--include resources/META-INF/com.android.tools/r8-min-1.6.0/coroutines.pro
--checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
+-include resources/META-INF/com.android.tools/proguard/coroutines.pro
 
 # We are cheating a bit by not having android.jar on R8's library classpath. Ignore those warnings.
 -ignorewarnings
--dontobfuscate

--- a/ui/kotlinx-coroutines-android/r8-test-rules-no-optim.pro
+++ b/ui/kotlinx-coroutines-android/r8-test-rules-no-optim.pro
@@ -1,14 +1,4 @@
-# Entry point for retaining MainDispatcherLoader which uses a ServiceLoader.
--keep class kotlinx.coroutines.Dispatchers {
-  ** getMain();
-}
+-include r8-test-common.pro
 
-# Entry point for retaining CoroutineExceptionHandlerImpl.handlers which uses a ServiceLoader.
--keep class kotlinx.coroutines.CoroutineExceptionHandlerKt {
-  void handleCoroutineException(...);
-}
-
+# Include the shrinker config used by legacy versions of AGP and ProGuard
 -include resources/META-INF/com.android.tools/proguard/coroutines.pro
-
-# We are cheating a bit by not having android.jar on R8's library classpath. Ignore those warnings.
--ignorewarnings

--- a/ui/kotlinx-coroutines-android/r8-test-rules.pro
+++ b/ui/kotlinx-coroutines-android/r8-test-rules.pro
@@ -1,0 +1,20 @@
+# Entry point for retaining MainDispatcherLoader which uses a ServiceLoader.
+-keep class kotlinx.coroutines.Dispatchers {
+  ** getMain();
+}
+
+# Entry point for retaining CoroutineExceptionHandlerImpl.handlers which uses a ServiceLoader.
+-keep class kotlinx.coroutines.CoroutineExceptionHandlerKt {
+  void handleCoroutineException(...);
+}
+
+# Ensure the custom, fast service loader implementation is removed. In the case of fast service
+# loader encountering an exception it falls back to regular ServiceLoader in a way that cannot be
+# optimized out by R8.
+-assumevalues class kotlinx.coroutines.internal.MainDispatcherLoader {
+  boolean FAST_SERVICE_LOADER_ENABLED return false;
+}
+-checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
+
+# We are cheating a bit by not having android.jar on R8's library classpath. Ignore those warnings.
+-ignorewarnings

--- a/ui/kotlinx-coroutines-android/r8-test-rules.pro
+++ b/ui/kotlinx-coroutines-android/r8-test-rules.pro
@@ -1,19 +1,7 @@
-# Entry point for retaining MainDispatcherLoader which uses a ServiceLoader.
--keep class kotlinx.coroutines.Dispatchers {
-  ** getMain();
-}
-
-# Entry point for retaining CoroutineExceptionHandlerImpl.handlers which uses a ServiceLoader.
--keep class kotlinx.coroutines.CoroutineExceptionHandlerKt {
-  void handleCoroutineException(...);
-}
+-include r8-test-common.pro
 
 # Ensure the custom, fast service loader implementation is removed. In the case of fast service
 # loader encountering an exception it falls back to regular ServiceLoader in a way that cannot be
 # optimized out by R8.
 -include resources/META-INF/com.android.tools/r8-min-1.6.0/coroutines.pro
 -checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
-
-# We are cheating a bit by not having android.jar on R8's library classpath. Ignore those warnings.
--ignorewarnings
--dontobfuscate

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
@@ -1,0 +1,1 @@
+-keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
@@ -1,1 +1,5 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
+# - META-INF/proguard/coroutines.pro
+
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
@@ -1,0 +1,1 @@
+-keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
@@ -1,1 +1,5 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/proguard/coroutines.pro
+# - META-INF/proguard/coroutines.pro
+
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-min-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-min-1.6.0/coroutines.pro
@@ -1,0 +1,6 @@
+# Allow R8 to optimize away the FastServiceLoader.
+# Together with ServiceLoader optimization in R8
+# this results in direct instantiation when loading Dispatchers.Main
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatcherLoader {
+    boolean FAST_SERVICE_LOADER_ENABLED return false;
+}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
@@ -1,0 +1,6 @@
+# Files in this directory will be ignored starting with Android Gradle Plugin 3.6.0+
+# For rules that should work on AGP < 3.6.0, put them here.
+# For rules that should also work on AGP >= 3.6.0,
+# put them in META-INF/com.android.tools/(r8|proguard)/
+
+-keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
@@ -1,6 +1,7 @@
 # Files in this directory will be ignored starting with Android Gradle Plugin 3.6.0+
-# For rules that should work on AGP < 3.6.0, put them here.
-# For rules that should also work on AGP >= 3.6.0,
-# put them in META-INF/com.android.tools/(r8|proguard)/
+
+# When editing this file, update the following files as well for AGP 3.6.0+:
+# - META-INF/com.android.tools/proguard/coroutines.pro
+# - META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro
 
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -49,7 +49,6 @@ public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
     public abstract override val immediate: HandlerDispatcher
 }
 
-@Keep
 internal class AndroidDispatcherFactory : MainDispatcherFactory {
 
     override fun createDispatcher(allFactories: List<MainDispatcherFactory>) =

--- a/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
+++ b/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
@@ -4,66 +4,68 @@
 
 package kotlinx.coroutines.android
 
-import org.jf.baksmali.Adaptors.ClassDefinition
-import org.jf.baksmali.BaksmaliOptions
-import org.jf.dexlib2.DexFileFactory
-import org.jf.dexlib2.iface.ClassDef
-import org.jf.dexlib2.iface.DexFile
-import org.jf.util.IndentingWriter
+import org.jf.baksmali.Adaptors.*
+import org.jf.baksmali.*
+import org.jf.dexlib2.*
+import org.jf.dexlib2.iface.*
+import org.jf.util.*
 import org.junit.Test
-import java.io.File
-import java.io.StringWriter
-import java.util.stream.Collectors
-import kotlin.test.assertEquals
+import java.io.*
+import java.util.stream.*
+import kotlin.test.*
 
 class R8ServiceLoaderOptimizationTest {
-  private val r8Dex = File(System.getProperty("dexPath")!!).asDexFile()
-  private val r8DexNoOptim = File(System.getProperty("noOptimDexPath")!!).asDexFile()
+    private val r8Dex = File(System.getProperty("dexPath")!!).asDexFile()
+    private val r8DexNoOptim = File(System.getProperty("noOptimDexPath")!!).asDexFile()
 
-  @Test fun noServiceLoaderCalls() {
-    val serviceLoaderInvocations = r8Dex.classes
-        // Create a map of type names to a list of their ServiceLoader invocations.
-        .associate { clz ->
-          clz.type to clz.toSmali().lines().filter { "Ljava/util/ServiceLoader;->" in it }
+    @Test
+    fun noServiceLoaderCalls() {
+        val serviceLoaderInvocations = r8Dex.types.any {
+            it.type == "Ljava/util/ServiceLoader;"
         }
-        .filterValues { it.isNotEmpty() }
-    assertEquals(emptyMap(), serviceLoaderInvocations)
-  }
-
-  @Test fun androidDispatcherIsKept() {
-    val hasAndroidDispatcher = r8DexNoOptim.classes.any {
-        it.type == "Lkotlinx/coroutines/android/AndroidDispatcherFactory;"
+        assertEquals(
+                false,
+                serviceLoaderInvocations,
+                "References to the ServiceLoader class were found in the resulting DEX."
+        )
     }
 
-    assertEquals(true, hasAndroidDispatcher)
-  }
+    @Test
+    fun androidDispatcherIsKept() {
+        val hasAndroidDispatcher = r8DexNoOptim.classes.any {
+            it.type == "Lkotlinx/coroutines/android/AndroidDispatcherFactory;"
+        }
 
-  @Test fun noOptimRulesMatch() {
-    val paths = listOf(
-            "META-INF/com.android.tools/proguard/coroutines.pro",
-            "META-INF/proguard/coroutines.pro",
-            "META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro"
-    )
-    paths.associate { path ->
-      val ruleSet = javaClass.classLoader.getResourceAsStream(path)!!.bufferedReader().lines().filter { line ->
-        line.isNotBlank() && !line.startsWith("#")
-      }.collect(Collectors.toSet())
-      path to ruleSet
-    }.asSequence().reduce { acc: Map.Entry<String, MutableSet<String>>, entry: Map.Entry<String, MutableSet<String>> ->
-      assertEquals(
-              acc.value,
-              entry.value,
-              "Rule sets between ${acc.key} and ${entry.key} don't match."
-              )
-      entry
+        assertEquals(true, hasAndroidDispatcher)
     }
-  }
+
+    @Test
+    fun noOptimRulesMatch() {
+        val paths = listOf(
+                "META-INF/com.android.tools/proguard/coroutines.pro",
+                "META-INF/proguard/coroutines.pro",
+                "META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro"
+        )
+        paths.associate { path ->
+            val ruleSet = javaClass.classLoader.getResourceAsStream(path)!!.bufferedReader().lines().filter { line ->
+                line.isNotBlank() && !line.startsWith("#")
+            }.collect(Collectors.toSet())
+            path to ruleSet
+        }.asSequence().reduce { acc: Map.Entry<String, MutableSet<String>>, entry: Map.Entry<String, MutableSet<String>> ->
+            assertEquals(
+                    acc.value,
+                    entry.value,
+                    "Rule sets between ${acc.key} and ${entry.key} don't match."
+            )
+            entry
+        }
+    }
 }
 
-private fun File.asDexFile(): DexFile = DexFileFactory.loadDexFile(this, null)
+private fun File.asDexFile() = DexFileFactory.loadDexFile(this, null)
 
 private fun ClassDef.toSmali(): String {
-  val stringWriter = StringWriter()
-  ClassDefinition(BaksmaliOptions(), this).writeTo(IndentingWriter(stringWriter))
-  return stringWriter.toString()
+    val stringWriter = StringWriter()
+    ClassDefinition(BaksmaliOptions(), this).writeTo(IndentingWriter(stringWriter))
+    return stringWriter.toString()
 }

--- a/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
+++ b/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
@@ -4,11 +4,7 @@
 
 package kotlinx.coroutines.android
 
-import org.jf.baksmali.Adaptors.*
-import org.jf.baksmali.*
 import org.jf.dexlib2.*
-import org.jf.dexlib2.iface.*
-import org.jf.util.*
 import org.junit.Test
 import java.io.*
 import java.util.stream.*
@@ -46,12 +42,12 @@ class R8ServiceLoaderOptimizationTest {
                 "META-INF/proguard/coroutines.pro",
                 "META-INF/com.android.tools/r8-max-1.5.999/coroutines.pro"
         )
-        paths.associate { path ->
+        paths.associateWith { path ->
             val ruleSet = javaClass.classLoader.getResourceAsStream(path)!!.bufferedReader().lines().filter { line ->
                 line.isNotBlank() && !line.startsWith("#")
             }.collect(Collectors.toSet())
-            path to ruleSet
-        }.asSequence().reduce { acc: Map.Entry<String, MutableSet<String>>, entry: Map.Entry<String, MutableSet<String>> ->
+            ruleSet
+        }.asSequence().reduce { acc, entry ->
             assertEquals(
                     acc.value,
                     entry.value,
@@ -63,9 +59,3 @@ class R8ServiceLoaderOptimizationTest {
 }
 
 private fun File.asDexFile() = DexFileFactory.loadDexFile(this, null)
-
-private fun ClassDef.toSmali(): String {
-    val stringWriter = StringWriter()
-    ClassDefinition(BaksmaliOptions(), this).writeTo(IndentingWriter(stringWriter))
-    return stringWriter.toString()
-}

--- a/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
+++ b/ui/kotlinx-coroutines-android/test/R8ServiceLoaderOptimizationTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.android
+
+import org.jf.baksmali.Adaptors.ClassDefinition
+import org.jf.baksmali.BaksmaliOptions
+import org.jf.dexlib2.DexFileFactory
+import org.jf.dexlib2.iface.ClassDef
+import org.jf.dexlib2.iface.DexFile
+import org.jf.util.IndentingWriter
+import org.junit.Test
+import java.io.File
+import java.io.StringWriter
+import kotlin.test.assertEquals
+
+class R8ServiceLoaderOptimizationTest {
+  private val r8Dex = File(System.getProperty("dexPath")!!).asDexFile()
+
+  @Test fun noServiceLoaderCalls() {
+    val serviceLoaderInvocations = r8Dex.classes
+        // Create a map of type names to a list of their ServiceLoader invocations.
+        .associate { clz ->
+          clz.type to clz.toSmali().lines().filter { "Ljava/util/ServiceLoader;->" in it }
+        }
+        .filterValues { it.isNotEmpty() }
+    assertEquals(emptyMap(), serviceLoaderInvocations)
+  }
+}
+
+private fun File.asDexFile(): DexFile = DexFileFactory.loadDexFile(this, null)
+
+private fun ClassDef.toSmali(): String {
+  val stringWriter = StringWriter()
+  ClassDefinition(BaksmaliOptions(), this).writeTo(IndentingWriter(stringWriter))
+  return stringWriter.toString()
+}


### PR DESCRIPTION
This anticipates a new mechanism in a future
Android Gradle Plugin (3.6.0+) that enables
version targeting of ProGuard/R8 rules.

It does not change any behavior for current users
of the library.

Once the new plugin is used, the R8 optimization
will be read automatically.