### PR TITLE
 Consistently handle fatal exceptions in reactive integrations

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/terminal/SingleTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/terminal/SingleTest.kt
@@ -7,7 +7,7 @@ package kotlinx.coroutines.flow
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-class SingleTest : TestBase() {
+class SingleTest : TestBase() { 
 
     @Test
     fun testSingle() = runTest {

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -160,11 +160,11 @@ private class PublisherCoroutine<in T>(
         }
         // now update nRequested
         while (true) { // lock-free loop on nRequested
-            val cur = _nRequested.value
-            if (cur < 0) break // closed from inside onNext => unlock
-            if (cur == Long.MAX_VALUE) break // no back-pressure => unlock
-            val upd = cur - 1
-            if (_nRequested.compareAndSet(cur, upd)) {
+            val current = _nRequested.value
+            if (current < 0) break // closed from inside onNext => unlock
+            if (current == Long.MAX_VALUE) break // no back-pressure => unlock
+            val upd = current - 1
+            if (_nRequested.compareAndSet(current, upd)) {
                 if (upd == 0L) {
                     // return to keep locked due to back-pressure
                     return

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -198,17 +198,32 @@ private class PublisherCoroutine<in T>(
                 if (cancelled) {
                     // If the parent had failed to handle our exception, then we must not lose this exception
                     if (cause != null && !handled) handleCoroutineException(context, cause)
-                } else {
-                    try {
-                        if (cause != null && cause !is CancellationException) {
+                    return
+                }
+
+                try {
+                    if (cause != null && cause !is CancellationException) {
+                        /*
+                         * Reactive frameworks have two types of exceptions: regular and fatal.
+                         * Regular are passed to onError.
+                         * Fatal can be passed to onError, but implementation **is free to swallow it** (e.g. see #1297).
+                         * Such behaviour is inconsistent, leads to silent failures and we can't possibly know whether
+                         * the cause will be handled by onError (and moreover, it depends on whether a fatal exception was
+                         * thrown by subscriber or upstream).
+                         * To make behaviour consistent and least surprising, we always handle fatal exceptions
+                         * by coroutines machinery, anyway, they should not be present in regular program flow,
+                         * thus our goal here is just to expose it as soon as possible.
+                         */
+                        if (cause.isFatal()) {
+                            if (!handled) handleCoroutineException(context, cause)
+                        } else {
                             subscriber.onError(cause)
                         }
-                        else {
-                            subscriber.onComplete()
-                        }
-                    } catch (e: Throwable) {
-                        handleCoroutineException(context, e)
+                    } else {
+                        subscriber.onComplete()
                     }
+                } catch (e: Throwable) {
+                    handleCoroutineException(context, e)
                 }
             }
         } finally {
@@ -242,12 +257,12 @@ private class PublisherCoroutine<in T>(
     // assert: isCompleted
     private fun signalCompleted(cause: Throwable?, handled: Boolean) {
         while (true) { // lock-free loop for nRequested
-            val cur = _nRequested.value
-            if (cur == SIGNALLED) return // some other thread holding lock already signalled cancellation/completion
-            check(cur >= 0) // no other thread could have marked it as CLOSED, because onCompleted[Exceptionally] is invoked once
-            if (!_nRequested.compareAndSet(cur, CLOSED)) continue // retry on failed CAS
+            val current = _nRequested.value
+            if (current == SIGNALLED) return // some other thread holding lock already signalled cancellation/completion
+            check(current >= 0) // no other thread could have marked it as CLOSED, because onCompleted[Exceptionally] is invoked once
+            if (!_nRequested.compareAndSet(current, CLOSED)) continue // retry on failed CAS
             // Ok -- marked as CLOSED, now can unlock the mutex if it was locked due to backpressure
-            if (cur == 0L) {
+            if (current == 0L) {
                 doLockedSignalCompleted(cause, handled)
             } else {
                 // otherwise mutex was either not locked or locked in concurrent onNext... try lock it to signal completion
@@ -272,4 +287,6 @@ private class PublisherCoroutine<in T>(
         cancelled = true
         super.cancel(null)
     }
+
+    private fun Throwable.isFatal() = this is VirtualMachineError || this is ThreadDeath || this is LinkageError
 }

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -163,13 +163,13 @@ private class PublisherCoroutine<in T>(
             val current = _nRequested.value
             if (current < 0) break // closed from inside onNext => unlock
             if (current == Long.MAX_VALUE) break // no back-pressure => unlock
-            val upd = current - 1
-            if (_nRequested.compareAndSet(current, upd)) {
-                if (upd == 0L) {
+            val updated = current - 1
+            if (_nRequested.compareAndSet(current, updated)) {
+                if (updated == 0L) {
                     // return to keep locked due to back-pressure
                     return
                 }
-                break // unlock if upd > 0
+                break // unlock if updated > 0
             }
         }
         unlockAndCheckCompleted()
@@ -206,7 +206,7 @@ private class PublisherCoroutine<in T>(
                         /*
                          * Reactive frameworks have two types of exceptions: regular and fatal.
                          * Regular are passed to onError.
-                         * Fatal can be passed to onError, but implementation **is free to swallow it** (e.g. see #1297).
+                         * Fatal can be passed to onError, but even the standard implementations **can just swallow it** (e.g. see #1297).
                          * Such behaviour is inconsistent, leads to silent failures and we can't possibly know whether
                          * the cause will be handled by onError (and moreover, it depends on whether a fatal exception was
                          * thrown by subscriber or upstream).
@@ -214,10 +214,9 @@ private class PublisherCoroutine<in T>(
                          * by coroutines machinery, anyway, they should not be present in regular program flow,
                          * thus our goal here is just to expose it as soon as possible.
                          */
-                        if (cause.isFatal()) {
-                            if (!handled) handleCoroutineException(context, cause)
-                        } else {
-                            subscriber.onError(cause)
+                        subscriber.onError(cause)
+                        if (!handled && cause.isFatal()) {
+                            handleCoroutineException(context, cause)
                         }
                     } else {
                         subscriber.onComplete()

--- a/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
@@ -61,12 +61,20 @@ private class RxCompletableCoroutine(
     private val subscriber: CompletableEmitter
 ) : AbstractCoroutine<Unit>(parentContext, true) {
     override fun onCompleted(value: Unit) {
-        if (!subscriber.isDisposed) subscriber.onComplete()
+        try {
+            if (!subscriber.isDisposed) subscriber.onComplete()
+        } catch (e: Throwable) {
+            handleCoroutineException(context, e)
+        }
     }
 
     override fun onCancelled(cause: Throwable, handled: Boolean) {
         if (!subscriber.isDisposed) {
-            subscriber.onError(cause)
+            try {
+                subscriber.onError(cause)
+            } catch (e: Throwable) {
+                handleCoroutineException(context, e)
+            }
         } else if (!handled) {
             handleCoroutineException(context, cause)
         }

--- a/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
@@ -63,13 +63,21 @@ private class RxMaybeCoroutine<T>(
 ) : AbstractCoroutine<T>(parentContext, true) {
     override fun onCompleted(value: T) {
         if (!subscriber.isDisposed) {
-            if (value == null) subscriber.onComplete() else subscriber.onSuccess(value)
+            try {
+                if (value == null) subscriber.onComplete() else subscriber.onSuccess(value)
+            } catch(e: Throwable) {
+                handleCoroutineException(context, e)
+            }
         }
     }
 
     override fun onCancelled(cause: Throwable, handled: Boolean) {
         if (!subscriber.isDisposed) {
-            subscriber.onError(cause)
+            try {
+                subscriber.onError(cause)
+            } catch (e: Throwable) {
+                handleCoroutineException(context, e)
+            }
         } else if (!handled) {
             handleCoroutineException(context, cause)
         }

--- a/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
@@ -61,12 +61,20 @@ private class RxSingleCoroutine<T: Any>(
     private val subscriber: SingleEmitter<T>
 ) : AbstractCoroutine<T>(parentContext, true) {
     override fun onCompleted(value: T) {
-        if (!subscriber.isDisposed) subscriber.onSuccess(value)
+        try {
+            if (!subscriber.isDisposed) subscriber.onSuccess(value)
+        } catch (e: Throwable) {
+            handleCoroutineException(context, e)
+        }
     }
 
     override fun onCancelled(cause: Throwable, handled: Boolean) {
         if (!subscriber.isDisposed) {
-            subscriber.onError(cause)
+            try {
+                subscriber.onError(cause)
+            } catch (e: Throwable) {
+                handleCoroutineException(context, e)
+            }
         } else if (!handled) {
             handleCoroutineException(context, cause)
         }

--- a/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
@@ -147,4 +147,21 @@ class CompletableTest : TestBase() {
         yield() // run coroutine
         finish(6)
     }
+
+    @Test
+    fun testFatalExceptionInSubscribe() = runTest {
+        GlobalScope.rxCompletable(Dispatchers.Unconfined + CoroutineExceptionHandler{ _, e -> assertTrue(e is LinkageError); expect(2)}) {
+            expect(1)
+            42
+        }.subscribe({ throw LinkageError() })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionInSingle() = runTest {
+        GlobalScope.rxCompletable(Dispatchers.Unconfined) {
+            throw LinkageError()
+        }.subscribe({ expectUnreached()  }, { expect(1); assertTrue(it is LinkageError) })
+        finish(2)
+    }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
@@ -143,7 +143,7 @@ class ConvertTest : TestBase() {
         val single = rxSingle(Dispatchers.Unconfined) {
             var result = ""
             try {
-                observable.consumeEach { result += it }
+                observable.collect { result += it }
             } catch(e: Throwable) {
                 check(e is TestException)
                 result += e.message

--- a/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.rx2

--- a/reactive/kotlinx-coroutines-rx2/test/FlowableExceptionHandlingTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowableExceptionHandlingTest.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.rx2
+
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import kotlin.test.*
+
+class FlowableExceptionHandlingTest : TestBase() {
+
+    @Before
+    fun setup() {
+        ignoreLostThreads("RxComputationThreadPool-", "RxCachedWorkerPoolEvictor-", "RxSchedulerPurge-")
+    }
+
+    @Test
+    fun testException() = runTest(expected = { it is TestException }) {
+        rxFlowable<Int>(Dispatchers.Unconfined) {
+            expect(1)
+            throw TestException()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expect(2) // Reported to onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalException() = runTest(expected = { it is LinkageError }) {
+        rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw LinkageError()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expectUnreached() // Fatal exception is not reported in onError
+        })
+        finish(2)
+    }
+
+    @Test
+    fun testExceptionWithoutParent() = runTest {
+        GlobalScope.rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw TestException()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            assertTrue(it is TestException)
+            expect(2) // Reported to onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionWithoutParent() = runTest {
+        GlobalScope.rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+            assertTrue(e is LinkageError); expect(
+            2
+        )
+        }) {
+            expect(1)
+            throw LinkageError()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expectUnreached() // Fatal exception is not reported in onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testExceptionAsynchronous() = runTest(expected = { it is TestException }) {
+        rxFlowable<Int>(Dispatchers.Unconfined) {
+            expect(1)
+            throw TestException()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expect(2) // Reported to onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionAsynchronous() = runTest(expected = { it is LinkageError }) {
+        rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw LinkageError()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expectUnreached() // Fatal exception is not reported in onError
+            })
+        finish(2)
+    }
+
+    @Test
+    fun testExceptionAsynchronousWithoutParent() = runTest {
+        GlobalScope.rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw TestException()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expect(2) // Reported to onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionAsynchronousWithoutParent() = runTest {
+        GlobalScope.rxFlowable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+            assertTrue(e is LinkageError); expect(2)
+        }) {
+            expect(1)
+            throw LinkageError()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expectUnreached() // Fatal exception is not reported in onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionFromSubscribe() = runTest(expected = { it is LinkageError }) {
+        rxFlowable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.subscribe({
+            expect(2)
+            throw LinkageError()
+        }, { expectUnreached() }) // Unreached because fatal errors are rethrown
+        finish(3)
+    }
+
+    @Test
+    fun testExceptionFromSubscribe() = runTest {
+        rxFlowable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.subscribe({
+            expect(2)
+            throw TestException()
+        }, { expect(3) }) // not reported to onError because came from the subscribe itself
+        finish(4)
+    }
+
+    @Test
+    fun testAsynchronousExceptionFromSubscribe() = runTest {
+        rxFlowable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.publish()
+            .refCount()
+            .subscribe({
+                expect(2)
+                throw RuntimeException()
+            }, { expect(3) })
+        finish(4)
+    }
+
+    @Test
+    fun testAsynchronousFatalExceptionFromSubscribe() = runTest(expected = { it is LinkageError }) {
+        rxFlowable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.publish()
+            .refCount()
+            .subscribe({
+                expect(2)
+                throw LinkageError()
+            }, { expectUnreached() })
+        finish(3)
+    }
+
+    @Test
+    fun testAsynchronousExceptionFromSubscribeWithoutParent() =
+        runTest {
+            GlobalScope.rxFlowable(Dispatchers.Unconfined) {
+                expect(1)
+                send(Unit)
+            }.publish()
+                .refCount()
+                .subscribe({
+                    expect(2)
+                    throw RuntimeException()
+                }, { expect(3) })
+            finish(4)
+        }
+
+    @Test
+    fun testAsynchronousFatalExceptionFromSubscribeWithoutParent() =
+        runTest {
+            GlobalScope.rxFlowable(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+                assertTrue(e is LinkageError); expect(3)
+            }) {
+                expect(1)
+                send(Unit)
+            }.publish()
+                .refCount()
+                .subscribe({
+                    expect(2)
+                    throw LinkageError()
+                }, { expectUnreached() })
+            finish(4)
+        }
+}

--- a/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
@@ -277,4 +277,21 @@ class MaybeTest : TestBase() {
         yield() // run coroutine
         finish(6)
     }
+
+    @Test
+    fun testFatalExceptionInSubscribe() = runTest {
+        GlobalScope.rxMaybe(Dispatchers.Unconfined + CoroutineExceptionHandler{ _, e -> assertTrue(e is LinkageError); expect(2)}) {
+            expect(1)
+            42
+        }.subscribe({ throw LinkageError() })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionInSingle() = runTest {
+        GlobalScope.rxMaybe(Dispatchers.Unconfined) {
+            throw LinkageError()
+        }.subscribe({ expectUnreached()  }, { expect(1); assertTrue(it is LinkageError) })
+        finish(2)
+    }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
@@ -31,7 +31,7 @@ class MaybeTest : TestBase() {
         expect(2)
         maybe.subscribe { value ->
             expect(5)
-            Assert.assertThat(value, IsEqual("OK"))
+            assertThat(value, IsEqual("OK"))
         }
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableExceptionHandlingTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableExceptionHandlingTest.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.rx2
+
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import kotlin.test.*
+
+class ObservableExceptionHandlingTest : TestBase() {
+
+    @Before
+    fun setup() {
+        ignoreLostThreads("RxComputationThreadPool-", "RxCachedWorkerPoolEvictor-", "RxSchedulerPurge-")
+    }
+
+    @Test
+    fun testException() = runTest(expected = { it is TestException }) {
+        rxObservable<Int>(Dispatchers.Unconfined) {
+            expect(1)
+            throw TestException()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expect(2) // Reported to onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalException() = runTest(expected = { it is LinkageError }) {
+        rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw LinkageError()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expectUnreached() // Fatal exception is not reported in onError
+        })
+        finish(2)
+    }
+
+    @Test
+    fun testExceptionWithoutParent() = runTest {
+        GlobalScope.rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw TestException()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            assertTrue(it is TestException)
+            expect(2) // Reported to onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionWithoutParent() = runTest {
+        GlobalScope.rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+            assertTrue(e is LinkageError); expect(
+            2
+        )
+        }) {
+            expect(1)
+            throw LinkageError()
+        }.subscribe({
+            expectUnreached()
+        }, {
+            expectUnreached() // Fatal exception is not reported in onError
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testExceptionAsynchronous() = runTest(expected = { it is TestException }) {
+        rxObservable<Int>(Dispatchers.Unconfined) {
+            expect(1)
+            throw TestException()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expect(2) // Reported to onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionAsynchronous() = runTest(expected = { it is LinkageError }) {
+        rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw LinkageError()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expectUnreached() // Fatal exception is not reported in onError
+            })
+        finish(2)
+    }
+
+    @Test
+    fun testExceptionAsynchronousWithoutParent() = runTest {
+        GlobalScope.rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> expectUnreached() }) {
+            expect(1)
+            throw TestException()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expect(2) // Reported to onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionAsynchronousWithoutParent() = runTest {
+        GlobalScope.rxObservable<Int>(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+            assertTrue(e is LinkageError); expect(2)
+        }) {
+            expect(1)
+            throw LinkageError()
+        }.publish()
+            .refCount()
+            .subscribe({
+                expectUnreached()
+            }, {
+                expectUnreached() // Fatal exception is not reported in onError
+            })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionFromSubscribe() = runTest(expected = { it is LinkageError }) {
+        rxObservable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.subscribe({
+            expect(2)
+            throw LinkageError()
+        }, { expectUnreached() }) // Unreached because fatal errors are rethrown
+        finish(3)
+    }
+
+    @Test
+    fun testExceptionFromSubscribe() = runTest {
+        rxObservable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.subscribe({
+            expect(2)
+            throw TestException()
+        }, { expect(3) }) // not reported to onError because came from the subscribe itself
+        finish(4)
+    }
+
+    @Test
+    fun testAsynchronousExceptionFromSubscribe() = runTest {
+        rxObservable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.publish()
+            .refCount()
+            .subscribe({
+                expect(2)
+                throw RuntimeException()
+            }, { expect(3) })
+        finish(4)
+    }
+
+    @Test
+    fun testAsynchronousFatalExceptionFromSubscribe() = runTest(expected = { it is LinkageError }) {
+        rxObservable(Dispatchers.Unconfined) {
+            expect(1)
+            send(Unit)
+        }.publish()
+            .refCount()
+            .subscribe({
+                expect(2)
+                throw LinkageError()
+            }, { expectUnreached() })
+        finish(3)
+    }
+
+    @Test
+    fun testAsynchronousExceptionFromSubscribeWithoutParent() =
+        runTest {
+            GlobalScope.rxObservable(Dispatchers.Unconfined) {
+                expect(1)
+                send(Unit)
+            }.publish()
+                .refCount()
+                .subscribe({
+                    expect(2)
+                    throw RuntimeException()
+                }, { expect(3) })
+            finish(4)
+        }
+
+    @Test
+    fun testAsynchronousFatalExceptionFromSubscribeWithoutParent() =
+        runTest {
+            GlobalScope.rxObservable(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+                assertTrue(e is LinkageError); expect(3)
+            }) {
+                expect(1)
+                send(Unit)
+            }.publish()
+                .refCount()
+                .subscribe({
+                    expect(2)
+                    throw LinkageError()
+                }, { expectUnreached() })
+            finish(4)
+        }
+}

--- a/reactive/kotlinx-coroutines-rx2/test/SingleTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/SingleTest.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.rx2
 
 import io.reactivex.*
 import io.reactivex.disposables.*
+import io.reactivex.functions.*
 import kotlinx.coroutines.*
 import org.hamcrest.core.*
 import org.junit.*
@@ -196,6 +197,26 @@ class SingleTest : TestBase() {
         } catch (e: TestException) {
             assertTrue(e.suppressed[0] is TestException2)
         }
+    }
+
+    @Test
+    fun testFatalExceptionInSubscribe() = runTest {
+        GlobalScope.rxSingle(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e -> assertTrue(e is LinkageError); expect(2) }) {
+            expect(1)
+            42
+        }.subscribe(Consumer {
+            throw LinkageError()
+        })
+        finish(3)
+    }
+
+    @Test
+    fun testFatalExceptionInSingle() = runTest {
+        GlobalScope.rxSingle(Dispatchers.Unconfined) {
+            throw LinkageError()
+        }.subscribe({ _, e ->  assertTrue(e is LinkageError); expect(1) })
+
+        finish(2)
     }
 
     @Test


### PR DESCRIPTION
Fixes #1297
