### PR TITLE
Add experimental contracts for withContext and coroutineScope

### DIFF
--- a/gradle/experimental.gradle
+++ b/gradle/experimental.gradle
@@ -5,6 +5,7 @@
 // For new mpp
 ext.experimentalAnnotations = [
         "kotlin.Experimental",
+        "kotlin.contracts.ExperimentalContracts",
         "kotlin.experimental.ExperimentalTypeInference",
         "kotlin.ExperimentalMultiplatform",
         "kotlinx.coroutines.ExperimentalCoroutinesApi",

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -11,6 +11,8 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.intrinsics.*
 import kotlinx.coroutines.selects.*
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 import kotlin.jvm.*
@@ -136,6 +138,14 @@ private class LazyDeferredCoroutine<T>(
 public suspend fun <T> withContext(
     context: CoroutineContext,
     block: suspend CoroutineScope.() -> T
+): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return withContextImpl(context, block)
+}
+
+private suspend inline fun <T> withContextImpl(
+    context: CoroutineContext,
+    noinline block: suspend CoroutineScope.() -> T
 ): T = suspendCoroutineUninterceptedOrReturn sc@ { uCont ->
     // compute new context
     val oldContext = uCont.context

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -6,6 +6,8 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.intrinsics.*
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 
@@ -174,11 +176,13 @@ public object GlobalScope : CoroutineScope {
  * or may throw a corresponding unhandled [Throwable] if there is any unhandled exception in this scope
  * (for example, from a crashed coroutine that was started with [launch][CoroutineScope.launch] in this scope).
  */
-public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R =
-    suspendCoroutineUninterceptedOrReturn { uCont ->
+public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return suspendCoroutineUninterceptedOrReturn { uCont ->
         val coroutine = ScopeCoroutine(uCont.context, uCont)
         coroutine.startUndispatchedOrReturn(coroutine, block)
     }
+}
 
 /**
  * Creates a [CoroutineScope] that wraps the given coroutine [context].


### PR DESCRIPTION
Resolves #1257

Note that I couldn't implement a contract for the operator function `invoke` for `CoroutineDispatcher` because these are not currently allowed for operator functions.
I requested the feature and asked why in [KT-32313](https://youtrack.jetbrains.com/issue/KT-32313).