### PR TITLE
Replace unneeded type parameter with projection

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -42,7 +42,7 @@ public interface ProducerScope<in E> : CoroutineScope, SendChannel<E> {
  * ```
  */
 @ExperimentalCoroutinesApi
-public suspend fun <T> ProducerScope<T>.awaitClose(block: () -> Unit = {}) {
+public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
     check(kotlin.coroutines.coroutineContext[Job] === this) { "awaitClose() can be invoke only from the producer context" }
     try {
         suspendCancellableCoroutine<Unit> { cont ->


### PR DESCRIPTION
Type parameter of awaitClose is not used but produces a warning in
new type inference when used with builder inference as in callbackFlow
as seen in this issue: https://youtrack.jetbrains.com/issue/KT-32097

Using star projection removes the warning and is binary compatible
thanks to generics type erasure.