### PR TITLE
Fixed sample to use `awaitClose` instead of `await`

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -305,7 +305,7 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  *     }
  *     api.register(callback)
  *     // Suspend until either onCompleted or external cancellation are invoked
- *     await { api.unregister(callback) }
+ *     awaitClose { api.unregister(callback) }
  * }
  * ```
  */


### PR DESCRIPTION
Because there is no `await`