### PR TITLE
Add Flow.onStart, support emit in onCompletion

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -801,6 +801,9 @@ public abstract interface class kotlinx/coroutines/flow/FlowCollector {
 
 public final class kotlinx/coroutines/flow/FlowKt {
 	public static final field DEFAULT_CONCURRENCY_PROPERTY_NAME Ljava/lang/String;
+	public static final fun BehaviourSubject ()Ljava/lang/Object;
+	public static final fun PublishSubject ()Ljava/lang/Object;
+	public static final fun ReplaySubject ()Ljava/lang/Object;
 	public static final fun asFlow (Ljava/lang/Iterable;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun asFlow (Ljava/util/Iterator;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun asFlow (Lkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/flow/Flow;
@@ -827,6 +830,10 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function6;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun combineLatest (Lkotlinx/coroutines/flow/Flow;[Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final synthetic fun combineLatest (Lkotlinx/coroutines/flow/Flow;[Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun compose (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun concatMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun concatWith (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun concatWith (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun conflate (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun count (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun count (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -846,9 +853,11 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun filterNotNull (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun first (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun first (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun flatMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flatMapConcat (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flatMapMerge (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun flatMapMerge$default (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun flatten (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flattenConcat (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flattenMerge (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun flattenMerge$default (Lkotlinx/coroutines/flow/Flow;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
@@ -861,15 +870,26 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun flowWith (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun flowWith$default (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun fold (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun forEach (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)V
 	public static final fun getDEFAULT_CONCURRENCY ()I
 	public static final fun launchIn (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)Lkotlinx/coroutines/Job;
 	public static final fun map (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun mapNotNull (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun onCompletion (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun merge (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun observeOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
+	public static final synthetic fun onCompletion (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onCompletion (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun onEach (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun onErrorCollect (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun onErrorCollect$default (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onErrorResume (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onErrorResumeNext (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onErrorReturn (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onErrorReturn (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun onErrorReturn$default (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onStart (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun produceIn (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)Lkotlinx/coroutines/channels/ReceiveChannel;
+	public static final fun publishOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun reduce (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun retry (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun retry (Lkotlinx/coroutines/flow/Flow;JLkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
@@ -878,9 +898,17 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun retryWhen (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function4;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun sample (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun scan (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun scanFold (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun scanReduce (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun single (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun singleOrNull (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun skip (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
+	public static final fun startWith (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun startWith (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;)V
+	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)V
+	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+	public static final fun subscribeOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun switchMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun take (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static final fun takeWhile (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
@@ -891,33 +919,9 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static synthetic fun toSet$default (Lkotlinx/coroutines/flow/Flow;Ljava/util/Set;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun transform (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun unsafeFlow (Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun zip (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
-}
-
-public final class kotlinx/coroutines/flow/MigrationKt {
-	public static final fun BehaviourSubject ()Ljava/lang/Object;
-	public static final fun PublishSubject ()Ljava/lang/Object;
-	public static final fun ReplaySubject ()Ljava/lang/Object;
-	public static final fun compose (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun concatMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun flatMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun flatten (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun forEach (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)V
-	public static final fun merge (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun observeOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun onErrorResume (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun onErrorResumeNext (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun onErrorReturn (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun onErrorReturn (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun onErrorReturn$default (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun publishOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun scanFold (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun skip (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
-	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;)V
-	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)V
-	public static final fun subscribe (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
-	public static final fun subscribeOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun unsafeTransform (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun withContext (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static final fun zip (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class kotlinx/coroutines/flow/internal/ChannelFlow : kotlinx/coroutines/flow/Flow {

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -1,15 +1,26 @@
 /*
  * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+@file:JvmMultifileClass
+@file:JvmName("FlowKt")
 @file:Suppress("unused", "DeprecatedCallableAddReplaceWith", "UNUSED_PARAMETER")
+
 package kotlinx.coroutines.flow
 
 import kotlin.coroutines.*
+import kotlin.jvm.*
 
 /**
+ * **GENERAL NOTE**
+ *
  * These deprecations are added to improve user experience when they will start to
  * search for their favourite operators and/or patterns that are missing or renamed in Flow.
+ * Deprecated functions also are moved here when they renamed. The difference is that they have
+ * a body with their implementation while pure stubs have [noImpl].
  */
+private fun noImpl(): Nothing =
+    throw UnsupportedOperationException("Not implemented, should not be called")
 
 /**
  * `observeOn` has no direct match in [Flow] API because all terminal flow operators are suspending and
@@ -33,7 +44,7 @@ import kotlin.coroutines.*
  * @suppress
  */
 @Deprecated(message = "Collect flow in the desired context instead", level = DeprecationLevel.ERROR)
-public fun <T> Flow<T>.observeOn(context: CoroutineContext): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.observeOn(context: CoroutineContext): Flow<T> = noImpl()
 
 /**
  * `publishOn` has no direct match in [Flow] API because all terminal flow operators are suspending and
@@ -57,7 +68,7 @@ public fun <T> Flow<T>.observeOn(context: CoroutineContext): Flow<T> = error("Sh
  * @suppress
  */
 @Deprecated(message = "Collect flow in the desired context instead", level = DeprecationLevel.ERROR)
-public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = noImpl()
 
 /**
  * `subscribeOn` has no direct match in [Flow] API because [Flow] preserves its context and does not leak it.
@@ -86,36 +97,54 @@ public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = error("Sh
  * @suppress
  */
 @Deprecated(message = "Use flowOn instead", level = DeprecationLevel.ERROR)
-public fun <T> Flow<T>.subscribeOn(context: CoroutineContext): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.subscribeOn(context: CoroutineContext): Flow<T> = noImpl()
 
-/** @suppress **/
+/**
+ * Use [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].asFlow().
+ * @suppress
+ */
 @Deprecated(message = "Use BroadcastChannel.asFlow()", level = DeprecationLevel.ERROR)
-public fun BehaviourSubject(): Any = error("Should not be called")
+public fun BehaviourSubject(): Any = noImpl()
 
-/** @suppress **/
+/**
+ * `ReplaySubject` is not supported. The closest analogue is buffered [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].
+ * @suppress
+ */
 @Deprecated(
     message = "ReplaySubject is not supported. The closest analogue is buffered broadcast channel",
     level = DeprecationLevel.ERROR)
-public fun ReplaySubject(): Any = error("Should not be called")
+public fun ReplaySubject(): Any = noImpl()
 
-/** @suppress **/
+/**
+ * `PublishSubject` is not supported.
+ * @suppress
+ */
 @Deprecated(message = "PublishSubject is not supported", level = DeprecationLevel.ERROR)
-public fun PublishSubject(): Any = error("Should not be called")
+public fun PublishSubject(): Any = noImpl()
 
-/** @suppress **/
+/**
+ * Flow analogue of `onErrorXxx` is [catch].
+ * Use `catch { emitAll(fallback) }`.
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emitAll(fallback) }'",
     replaceWith = ReplaceWith("catch { emitAll(fallback) }")
 )
-public fun <T> Flow<T>.onErrorResume(fallback: Flow<T>): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.onErrorResume(fallback: Flow<T>): Flow<T> = noImpl()
 
+/**
+ * Flow analogue of `onErrorXxx` is [catch].
+ * Use `catch { emitAll(fallback) }`.
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emitAll(fallback) }'",
     replaceWith = ReplaceWith("catch { emitAll(fallback) }")
 )
-public fun <T> Flow<T>.onErrorResumeNext(fallback: Flow<T>): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.onErrorResumeNext(fallback: Flow<T>): Flow<T> = noImpl()
 
 /**
  * Self-explanatory, the reason of deprecation is "context preservation" property (you can read more in [Flow] documentation)
@@ -123,7 +152,7 @@ public fun <T> Flow<T>.onErrorResumeNext(fallback: Flow<T>): Flow<T> = error("Sh
  **/
 @Suppress("UNUSED_PARAMETER", "UNUSED", "DeprecatedCallableAddReplaceWith")
 @Deprecated(message = "withContext in flow body is deprecated, use flowOn instead", level = DeprecationLevel.ERROR)
-public fun <T, R> FlowCollector<T>.withContext(context: CoroutineContext, block: suspend () -> R): Unit = error("Should not be called")
+public fun <T, R> FlowCollector<T>.withContext(context: CoroutineContext, block: suspend () -> R): Unit = noImpl()
 
 /**
  * `subscribe` is Rx-specific API that has no direct match in flows.
@@ -153,19 +182,25 @@ public fun <T, R> FlowCollector<T>.withContext(context: CoroutineContext, block:
     message = "Use launchIn with onEach, onCompletion and catch operators instead",
     level = DeprecationLevel.ERROR
 )
-public fun <T> Flow<T>.subscribe(): Unit = error("Should not be called")
+public fun <T> Flow<T>.subscribe(): Unit = noImpl()
 
-/** @suppress **/
+/**
+ * Use [launchIn] with [onEach], [onCompletion] and [catch] operators instead.
+ * @suppress
+ */
 @Deprecated(
     message = "Use launchIn with onEach, onCompletion and catch operators instead",
     level = DeprecationLevel.ERROR
-)public fun <T> Flow<T>.subscribe(onEach: suspend (T) -> Unit): Unit = error("Should not be called")
+)public fun <T> Flow<T>.subscribe(onEach: suspend (T) -> Unit): Unit = noImpl()
 
-/** @suppress **/
+/**
+ * Use [launchIn] with [onEach], [onCompletion] and [catch] operators instead.
+ * @suppress
+ */
 @Deprecated(
     message = "Use launchIn with onEach, onCompletion and catch operators instead",
     level = DeprecationLevel.ERROR
-)public fun <T> Flow<T>.subscribe(onEach: suspend (T) -> Unit, onError: suspend (Throwable) -> Unit): Unit = error("Should not be called")
+)public fun <T> Flow<T>.subscribe(onEach: suspend (T) -> Unit, onError: suspend (Throwable) -> Unit): Unit = noImpl()
 
 /**
  * Note that this replacement is sequential (`concat`) by default.
@@ -177,15 +212,18 @@ public fun <T> Flow<T>.subscribe(): Unit = error("Should not be called")
     message = "Flow analogue is named flatMapConcat",
     replaceWith = ReplaceWith("flatMapConcat(mapper)")
 )
-public fun <T, R> Flow<T>.flatMap(mapper: suspend (T) -> Flow<R>): Flow<R> = error("Should not be called")
+public fun <T, R> Flow<T>.flatMap(mapper: suspend (T) -> Flow<R>): Flow<R> = noImpl()
 
-/** @suppress **/
+/**
+ * Flow analogue of `concatMap` is [flatMapConcat].
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Flow analogue is named flatMapConcat",
+    message = "Flow analogue of 'concatMap' is 'flatMapConcat'",
     replaceWith = ReplaceWith("flatMapConcat(mapper)")
 )
-public fun <T, R> Flow<T>.concatMap(mapper: (T) -> Flow<R>): Flow<R> = error("Should not be called")
+public fun <T, R> Flow<T>.concatMap(mapper: (T) -> Flow<R>): Flow<R> = noImpl()
 
 /**
  * Note that this replacement is sequential (`concat`) by default.
@@ -197,15 +235,18 @@ public fun <T, R> Flow<T>.concatMap(mapper: (T) -> Flow<R>): Flow<R> = error("Sh
     message = "Flow analogue of 'merge' is 'flattenConcat'",
     replaceWith = ReplaceWith("flattenConcat()")
 )
-public fun <T> Flow<Flow<T>>.merge(): Flow<T> = error("Should not be called")
+public fun <T> Flow<Flow<T>>.merge(): Flow<T> = noImpl()
 
-/** @suppress **/
+/**
+ * Flow analogue of `flatten` is [flattenConcat].
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'flatten' is 'flattenConcat'",
     replaceWith = ReplaceWith("flattenConcat()")
 )
-public fun <T> Flow<Flow<T>>.flatten(): Flow<T> = error("Should not be called")
+public fun <T> Flow<Flow<T>>.flatten(): Flow<T> = noImpl()
 
 /**
  * Kotlin has a built-in generic mechanism for making chained calls.
@@ -218,7 +259,6 @@ public fun <T> Flow<Flow<T>>.flatten(): Flow<T> = error("Should not be called")
  * ```
  * myFlow.let(MyFlowExtensions.ignoreErrors()).collect { ... }
  * ```
- *
  * @suppress
  */
 @Deprecated(
@@ -226,9 +266,10 @@ public fun <T> Flow<Flow<T>>.flatten(): Flow<T> = error("Should not be called")
     message = "Flow analogue of 'compose' is 'let'",
     replaceWith = ReplaceWith("let(transformer)")
 )
-public fun <T, R> Flow<T>.compose(transformer: Flow<T>.() -> Flow<R>): Flow<R> = error("Should not be called")
+public fun <T, R> Flow<T>.compose(transformer: Flow<T>.() -> Flow<R>): Flow<R> = noImpl()
 
 /**
+ * Flow analogue of `skip` is [drop].
  * @suppress
  */
 @Deprecated(
@@ -236,7 +277,7 @@ public fun <T, R> Flow<T>.compose(transformer: Flow<T>.() -> Flow<R>): Flow<R> =
     message = "Flow analogue of 'skip' is 'drop'",
     replaceWith = ReplaceWith("drop(count)")
 )
-public fun <T> Flow<T>.skip(count: Int): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.skip(count: Int): Flow<T> = noImpl()
 
 /**
  * Flow extension to iterate over elements is [collect].
@@ -251,23 +292,38 @@ public fun <T> Flow<T>.skip(count: Int): Flow<T> = error("Should not be called")
     message = "Flow analogue of 'forEach' is 'collect'",
     replaceWith = ReplaceWith("collect(block)")
 )
-public fun <T> Flow<T>.forEach(action: suspend (value: T) -> Unit): Unit = error("Should not be called")
+public fun <T> Flow<T>.forEach(action: suspend (value: T) -> Unit): Unit = noImpl()
 
+/**
+ * Flow has less verbose [scan] shortcut.
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow has less verbose 'scan' shortcut",
     replaceWith = ReplaceWith("scan(initial, operation)")
 )
-public fun <T, R> Flow<T>.scanFold(initial: R, @BuilderInference operation: suspend (accumulator: R, value: T) -> R): Flow<R> = error("Should not be called")
+public fun <T, R> Flow<T>.scanFold(initial: R, @BuilderInference operation: suspend (accumulator: R, value: T) -> R): Flow<R> =
+    noImpl()
 
+/**
+ * Flow analogue of `onErrorXxx` is [catch].
+ * Use `catch { emit(fallback) }`.
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emit(fallback) }'",
     replaceWith = ReplaceWith("catch { emit(fallback) }")
 )
 // Note: this version without predicate gives better "replaceWith" action
-public fun <T> Flow<T>.onErrorReturn(fallback: T): Flow<T> = error("Should not be called")
+public fun <T> Flow<T>.onErrorReturn(fallback: T): Flow<T> = noImpl()
 
+/**
+ * Flow analogue of `onErrorXxx` is [catch].
+ * Use `catch { e -> if (predicate(e)) emit(fallback) else throw e }`.
+ * @suppress
+ */
 @Deprecated(
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { e -> if (predicate(e)) emit(fallback) else throw e }'",
@@ -279,3 +335,52 @@ public fun <T> Flow<T>.onErrorReturn(fallback: T, predicate: (Throwable) -> Bool
         if (!predicate(e)) throw e
         emit(fallback)
     }
+
+/**
+ * Flow analogue of `startWith` is [onStart].
+ * Use `onStart { emit(value) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Flow analogue of 'startWith' is 'onStart'. Use 'onStart { emit(value) }'",
+    replaceWith = ReplaceWith("onStart { emit(value) }")
+)
+public fun <T> Flow<T>.startWith(value: T): Flow<T> = noImpl()
+
+/**
+ * Flow analogue of `startWith` is [onStart].
+ * Use `onStart { emitAll(other) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Flow analogue of 'startWith' is 'onStart'. Use 'onStart { emitAll(other) }'",
+    replaceWith = ReplaceWith("onStart { emitAll(other) }")
+)
+public fun <T> Flow<T>.startWith(other: Flow<T>): Flow<T> = noImpl()
+
+/**
+ * Flow analogue of `concatWith` is [onCompletion].
+ * Use `onCompletion { emit(value) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Flow analogue of 'concatWith' is 'onCompletion'. Use 'onCompletion { emit(value) }'",
+    replaceWith = ReplaceWith("onCompletion { emit(value) }")
+)
+public fun <T> Flow<T>.concatWith(value: T): Flow<T> = noImpl()
+
+/**
+ * Flow analogue of `concatWith` is [onCompletion].
+ * Use `onCompletion { emitAll(other) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Flow analogue of 'concatWith' is 'onCompletion'. Use 'onCompletion { emitAll(other) }'",
+    replaceWith = ReplaceWith("onCompletion { emitAkk(other) }")
+)
+public fun <T> Flow<T>.concatWith(other: Flow<T>): Flow<T> = noImpl()
+

--- a/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:JvmMultifileClass
+@file:JvmName("FlowKt")
+@file:Suppress("UNCHECKED_CAST")
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.internal.*
+import kotlin.coroutines.*
+import kotlin.jvm.*
+
+// ------------------ WARNING ------------------
+//   These emitting operators must use safe flow builder, because their allow
+//   user code to directly emit to the underlying FlowCollector.
+
+/**
+ * Applies [transform] function to each value of the given flow.
+ *
+ * The receiver of the [transform] is [FlowCollector] and thus `transform` is a
+ * generic function that may transform emitted element, skip it or emit it multiple times.
+ *
+ * This operator can be used as a building block for other operators, for example:
+ *
+ * ```
+ * fun Flow<Int>.skipOddAndDuplicateEven(): Flow<Int> = transform { value ->
+ *     if (value % 2 == 0) { // Emit only even values, but twice
+ *         emit(value)
+ *         emit(value)
+ *     } // Do nothing if odd
+ * }
+ * ```
+ */
+@ExperimentalCoroutinesApi
+public inline fun <T, R> Flow<T>.transform(
+    @BuilderInference crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
+): Flow<R> = flow { // Note: safe flow is used here, because collector is exposed to transform on each operation
+    collect { value ->
+        // kludge, without it Unit will be returned and TCE won't kick in, KT-28938
+        return@collect transform(value)
+    }
+}
+
+// For internal operator implementation
+@PublishedApi
+internal inline fun <T, R> Flow<T>.unsafeTransform(
+    @BuilderInference crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
+): Flow<R> = unsafeFlow { // Note: unsafe flow is used here, because unsafeTransform is only for internal use
+    collect { value ->
+        // kludge, without it Unit will be returned and TCE won't kick in, KT-28938
+        return@collect transform(value)
+    }
+}
+
+/**
+ * Invokes the given [action] when the this flow starts to be collected.
+ *
+ * The receiver of the [action] is [FlowCollector] and thus `onStart` can emit additional elements.
+ * For example:
+ *
+ * ```
+ * flowOf("a", "b", "c")
+ *     .onStart { emit("Begin") }
+ *     .collect { println(it) } // prints Begin, a, b, c
+ * ```
+ */
+@ExperimentalCoroutinesApi // tentatively stable in 1.3.0
+public fun <T> Flow<T>.onStart(
+    action: suspend FlowCollector<T>.() -> Unit
+): Flow<T> = unsafeFlow { // Note: unsafe flow is used here, but safe collector is used to invoke start action
+    SafeCollector<T>(this, coroutineContext).action()
+    collect(this) // directly delegate
+}
+
+/**
+ * Invokes the given [action] when the given flow is completed or cancelled, using
+ * the exception from the upstream (if any) as cause parameter of [action].
+ *
+ * Conceptually, `onCompletion` is similar to wrapping the flow collection into a `finally` block,
+ * for example the following imperative snippet:
+ *
+ * ```
+ * try {
+ *     myFlow.collect { value ->
+ *         println(value)
+ *     }
+ * } finally {
+ *     println("Done")
+ * }
+ * ```
+ *
+ * can be replaced with a declarative one using `onCompletion`:
+ *
+ * ```
+ * myFlow
+ *     .onEach { println(it) }
+ *     .onCompletion { println("Done") }
+ *     .collect()
+ * ```
+ *
+ * This operator is *transparent* to exceptions that occur in downstream flow
+ * and does not observe exceptions that are thrown to cancel the flow,
+ * while any exception from the [action] will be thrown downstream.
+ * This behaviour can be demonstrated by the following example:
+ *
+ * ```
+ * flow { emitData() }
+ *     .map { computeOne(it) }
+ *     .onCompletion { println(it) } // Can print exceptions from emitData and computeOne
+ *     .map { computeTwo(it) }
+ *     .onCompletion { println(it) } // Can print exceptions from emitData, computeOne, onCompletion and computeTwo
+ *     .collect()
+ * ```
+ *
+ * The receiver of the [action] is [FlowCollector] and this operator can be used to emit additional
+ * elements at the end of the collection. For example:
+ *
+ * ```
+ * flowOf("a", "b", "c")
+ *     .onCompletion { emit("Done") }
+ *     .collect { println(it) } // prints a, b, c, Done
+ * ```
+ */
+@ExperimentalCoroutinesApi // tentatively stable in 1.3.0
+public fun <T> Flow<T>.onCompletion(
+    action: suspend FlowCollector<T>.(cause: Throwable?) -> Unit
+): Flow<T> = unsafeFlow { // Note: unsafe flow is used here, but safe collector is used to invoke completion action
+    var exception: Throwable? = null
+    try {
+        exception = catchImpl(this)
+    } finally {
+        // Separate method because of KT-32220
+        SafeCollector<T>(this, coroutineContext).invokeSafely(action, exception)
+        exception?.let { throw it }
+    }
+}
+
+// It was only released in 1.3.0-M2, remove in 1.4.0
+/** @suppress */
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "binary compatibility with a version w/o FlowCollector receiver")
+public fun <T> Flow<T>.onCompletion(action: suspend (cause: Throwable?) -> Unit) =
+    onCompletion { action(it) }
+
+private suspend fun <T> FlowCollector<T>.invokeSafely(
+    action: suspend FlowCollector<T>.(cause: Throwable?) -> Unit,
+    cause: Throwable?
+) {
+    try {
+        action(cause)
+    } catch (e: Throwable) {
+        if (cause !== null) e.addSuppressedThrowable(cause)
+        throw e
+    }
+}
+
+

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -10,52 +10,24 @@ package kotlinx.coroutines.flow
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.internal.*
-import kotlin.coroutines.*
 import kotlin.jvm.*
 import kotlinx.coroutines.flow.unsafeFlow as flow
-
-/**
- * Applies [transform] function to each value of the given flow.
- * [transform] is a generic function that may transform emitted element, skip it or emit it multiple times.
- *
- * This operator is useless by itself, but can be used as a building block of user-specific operators:
- * ```
- * fun Flow<Int>.skipOddAndDuplicateEven(): Flow<Int> = transform { value ->
- *     if (value % 2 == 0) { // Emit only even values, but twice
- *         emit(value)
- *         emit(value)
- *     } // Do nothing if odd
- * }
- * ```
- */
-@ExperimentalCoroutinesApi
-public inline fun <T, R> Flow<T>.transform(@BuilderInference crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit): Flow<R> {
-    return flow {
-        collect { value ->
-            // kludge, without it Unit will be returned and TCE won't kick in, KT-28938
-            return@collect transform(value)
-        }
-    }
-}
+import kotlinx.coroutines.flow.unsafeTransform as transform
 
 /**
  * Returns a flow containing only values of the original flow that matches the given [predicate].
  */
 @ExperimentalCoroutinesApi
-public inline fun <T> Flow<T>.filter(crossinline predicate: suspend (T) -> Boolean): Flow<T> = flow {
-    collect { value ->
-        if (predicate(value)) return@collect emit(value)
-    }
+public inline fun <T> Flow<T>.filter(crossinline predicate: suspend (T) -> Boolean): Flow<T> = transform { value ->
+    if (predicate(value)) return@transform emit(value)
 }
 
 /**
  * Returns a flow containing only values of the original flow that do not match the given [predicate].
  */
 @ExperimentalCoroutinesApi
-public inline fun <T> Flow<T>.filterNot(crossinline predicate: suspend (T) -> Boolean): Flow<T> = flow {
-    collect { value ->
-        if (!predicate(value)) return@collect emit(value)
-    }
+public inline fun <T> Flow<T>.filterNot(crossinline predicate: suspend (T) -> Boolean): Flow<T> = transform { value ->
+    if (!predicate(value)) return@transform emit(value)
 }
 
 /**
@@ -69,8 +41,8 @@ public inline fun <reified R> Flow<*>.filterIsInstance(): Flow<R> = filter { it 
  * Returns a flow containing only values of the original flow that are not null.
  */
 @ExperimentalCoroutinesApi
-public fun <T: Any> Flow<T?>.filterNotNull(): Flow<T> = flow<T> {
-    collect { value -> if (value != null) return@collect  emit(value) }
+public fun <T: Any> Flow<T?>.filterNotNull(): Flow<T> = transform<T?, T> { value ->
+    if (value != null) return@transform emit(value)
 }
 
 /**
@@ -94,69 +66,9 @@ public inline fun <T, R: Any> Flow<T>.mapNotNull(crossinline transform: suspend 
  * Returns a flow which performs the given [action] on each value of the original flow.
  */
 @ExperimentalCoroutinesApi
-public fun <T> Flow<T>.onEach(action: suspend (T) -> Unit): Flow<T> = flow {
-    collect { value ->
-        action(value)
-        emit(value)
-    }
-}
-
-/**
- * Invokes the given [action] when the given flow is completed or cancelled, using
- * the exception from the upstream (if any) as cause parameter of [action].
- *
- * Conceptually, [onCompletion] is similar to wrapping the flow collection into a `finally` block,
- * for example the following imperative snippet:
- * ```
- * try {
- *     myFlow.collect { value ->
- *         println(value)
- *     }
- * } finally {
- *     println("Done")
- * }
- * ```
- *
- * can be replaced with a declarative one using [onCompletion]:
- * ```
- * myFlow
- *     .onEach { println(it) }
- *     .onCompletion { println("Done") }
- *     .collect()
- * ```
- *
- * This operator is *transparent* to exceptions that occur in downstream flow
- * and does not observe exceptions that are thrown to cancel the flow,
- * while any exception from the [action] will be thrown downstream.
- * This behaviour can be demonstrated by the following example:
- * ```
- * flow { emitData() }
- *     .map { computeOne(it) }
- *     .onCompletion { println(it) } // Can print exceptions from emitData and computeOne
- *     .map { computeTwo(it) }
- *     .onCompletion { println(it) } // Can print exceptions from emitData, computeOne, onCompletion and computeTwo
- *     .collect()
- * ```
- */
-@ExperimentalCoroutinesApi // tentatively stable in 1.3.0
-public fun <T> Flow<T>.onCompletion(action: suspend (cause: Throwable?) -> Unit): Flow<T> = flow {
-    var exception: Throwable? = null
-    try {
-        exception = catchImpl(this)
-    } finally {
-        // Separate method because of KT-32220
-        invokeSafely(action, exception)
-        exception?.let { throw it }
-    }
-}
-
-private suspend fun invokeSafely(action: suspend (cause: Throwable?) -> Unit, cause: Throwable?) {
-    try {
-        action(cause)
-    } catch (e: Throwable) {
-        if (cause !== null) e.addSuppressedThrowable(cause)
-        throw e
-    }
+public fun <T> Flow<T>.onEach(action: suspend (T) -> Unit): Flow<T> = transform { value ->
+    action(value)
+    return@transform emit(value)
 }
 
 /**

--- a/kotlinx-coroutines-core/common/test/flow/operators/OnStartTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/OnStartTest.kt
@@ -2,10 +2,9 @@
  * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package kotlinx.coroutines.flow.operators
+package kotlinx.coroutines.flow
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
 import kotlin.test.*
 
 class OnStartTest : TestBase() {

--- a/kotlinx-coroutines-core/common/test/flow/operators/OnStartTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/OnStartTest.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow.operators
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlin.test.*
+
+class OnStartTest : TestBase() {
+    @Test
+    fun testEmitExample() = runTest {
+        val flow = flowOf("a", "b", "c")
+            .onStart { emit("Begin") }
+        assertEquals(listOf("Begin", "a", "b", "c"), flow.toList())
+    }
+}

--- a/kotlinx-coroutines-core/common/test/flow/operators/TransformTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/TransformTest.kt
@@ -2,10 +2,9 @@
  * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package kotlinx.coroutines.flow.operators
+package kotlinx.coroutines.flow
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
 import kotlin.test.*
 
 class TransformTest : TestBase() {

--- a/kotlinx-coroutines-core/common/test/flow/operators/TransformTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/TransformTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow.operators
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlin.test.*
+
+class TransformTest : TestBase() {
+    @Test
+    fun testDoubleEmit() = runTest {
+         val flow = flowOf(1, 2, 3)
+             .transform {
+                 emit(it)
+                 emit(it)
+             }
+        assertEquals(listOf(1, 1, 2, 2, 3, 3), flow.toList())
+    }
+}


### PR DESCRIPTION
Add Flow.onStart, support emit in onCompletion

* All "emitting" operators (onStart, transform, onCompletion) are moved
  to Emitters.kt and are implemented in a safe way, making sure that
  user-specified block is called on a SafeCollector only.
* Unsafe internal version of transform (unsafeTransform) is introduced.  
* All transformations in Transform.kt are rewritten via unsafeTransform. 
* Added migration for startWith and concatWith.
* Consistent docs for all migration functions.
* JvmMultifileClass for Migration.kt so that renamed/deprecated 
  functions (when they moved there) continue to resolve.

Fixes #1168