### PR TITLE
Treat Duration.ZERO as 0L in jdk8 extensions

### DIFF
--- a/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
@@ -46,7 +46,7 @@ public suspend fun <T> withTimeoutOrNull(duration: Duration, block: suspend Coro
  *    - Non-suspending fast-paths (e.g. `withTimeout(1 nanosecond) { 42 }` should not throw)
  */
 private fun Duration.coerceToMillis(): Long {
-    if (isNegative) return 0
+    if (this <= Duration.ZERO) return 0
     if (this <= ChronoUnit.MILLIS.duration) return 1
 
     // Maximum scalar values of Duration.ofMillis(Long.MAX_VALUE)

--- a/integration/kotlinx-coroutines-jdk8/test/time/DurationOverflowTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/DurationOverflowTest.kt
@@ -65,4 +65,15 @@ class DurationOverflowTest : TestBase() {
         assertNull(result)
     }
 
+    @Test
+    fun testZeroDurationWithTimeout() = runTest {
+        assertFailsWith<TimeoutCancellationException> { withTimeout(0L) {} }
+        assertFailsWith<TimeoutCancellationException> { withTimeout(Duration.ZERO) {} }
+    }
+
+    @Test
+    fun testZeroDurationWithTimeoutOrNull() = runTest {
+        assertNull(withTimeoutOrNull(0L) {})
+        assertNull(withTimeoutOrNull(Duration.ZERO) {})
+    }
 }


### PR DESCRIPTION
Fixes #1349