### PR TITLE
Fix situation where thread.uncaughtExceptionHandler can be null.

### DIFF
--- a/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
+++ b/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
@@ -37,7 +37,7 @@ internal class AndroidExceptionPreHandler :
          */
         val thread = Thread.currentThread()
         if (Build.VERSION.SDK_INT >= 28) {
-            thread.uncaughtExceptionHandler.uncaughtException(thread, exception)
+            thread.uncaughtExceptionHandler?.uncaughtException(thread, exception)
         } else {
             (preHandler?.invoke(null) as? Thread.UncaughtExceptionHandler)
                 ?.uncaughtException(thread, exception)


### PR DESCRIPTION
Currently IDE gives warning as "Unsafe use of a nullable receiver of type Thread.UncaughtExceptionHandler?"