### PR TITLE
Add more Flow migrations for Rx types

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -100,6 +100,61 @@ public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = noImpl()
 public fun <T> Flow<T>.subscribeOn(context: CoroutineContext): Flow<T> = noImpl()
 
 /**
+ * Flow analogue of 'Flowable' is [Flow].
+ * @suppress
+ */
+@Deprecated(
+        message = "Flow analogue of 'Flowable' is Flow",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("kotlinx.coroutines.flow.Flow")
+)
+public class Flowable private constructor()
+
+/**
+ * Flow analogue of 'Observable' is [Flow].
+ * @suppress
+ */
+@Deprecated(
+        message = "Flow analogue of 'Observable' is Flow",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("kotlinx.coroutines.flow.Flow")
+)
+public class Observable private constructor()
+
+/**
+ * Flow analogue of 'Single' is [Flow].
+ * @suppress
+ */
+@Deprecated(
+        message = "Flow analogue of 'Single' is Flow",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("kotlinx.coroutines.flow.Flow")
+)
+public class Single private constructor()
+
+/**
+ * Flow analogue of 'Maybe' is [Flow].
+ * @suppress
+ */
+@Deprecated(
+        message = "Flow analogue of 'Maybe' is Flow",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("kotlinx.coroutines.flow.Flow")
+)
+public class Maybe private constructor()
+
+/**
+ * Flow analogue of 'Completable' is [Flow].
+ * @suppress
+ */
+@Deprecated(
+        message = "Flow analogue of 'Completable' is Flow",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("kotlinx.coroutines.flow.Flow")
+)
+public class Completable private constructor()
+
+/**
  * Use [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].asFlow().
  * @suppress
  */


### PR DESCRIPTION
Migrations already included:

- BehaviourSubject
- ReplaySubject
- PublishSubject

This PR adds more types to ease migration to Flow with potential to migrations for static and non-static functions (that's why they're classes with private constructor).