### PR TITLE
Fix naming for Flow BehaviorSubject migration

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -104,7 +104,7 @@ public fun <T> Flow<T>.subscribeOn(context: CoroutineContext): Flow<T> = noImpl(
  * @suppress
  */
 @Deprecated(message = "Use BroadcastChannel.asFlow()", level = DeprecationLevel.ERROR)
-public fun BehaviourSubject(): Any = noImpl()
+public fun BehaviorSubject(): Any = noImpl()
 
 /**
  * `ReplaySubject` is not supported. The closest analogue is buffered [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].


### PR DESCRIPTION
It is `BehaviorSubject` in [RxJava](https://github.com/ReactiveX/RxJava/blob/v2.2.10/src/main/java/io/reactivex/subjects/BehaviorSubject.java) and [ReactiveX](http://reactivex.io/documentation/subject.html).