### PR TITLE
Get rid of top-level functions in Migration.kt to improve experience …

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -826,9 +826,6 @@ public abstract interface class kotlinx/coroutines/flow/FlowCollector {
 
 public final class kotlinx/coroutines/flow/FlowKt {
 	public static final field DEFAULT_CONCURRENCY_PROPERTY_NAME Ljava/lang/String;
-	public static final fun BehaviorSubject ()Ljava/lang/Object;
-	public static final fun PublishSubject ()Ljava/lang/Object;
-	public static final fun ReplaySubject ()Ljava/lang/Object;
 	public static final fun asFlow (Ljava/lang/Iterable;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun asFlow (Ljava/util/Iterator;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun asFlow (Lkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/flow/Flow;

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -100,29 +100,6 @@ public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = noImpl()
 public fun <T> Flow<T>.subscribeOn(context: CoroutineContext): Flow<T> = noImpl()
 
 /**
- * Use [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].asFlow().
- * @suppress
- */
-@Deprecated(message = "Use BroadcastChannel.asFlow()", level = DeprecationLevel.ERROR)
-public fun BehaviorSubject(): Any = noImpl()
-
-/**
- * `ReplaySubject` is not supported. The closest analogue is buffered [BroadcastChannel][kotlinx.coroutines.channels.BroadcastChannel].
- * @suppress
- */
-@Deprecated(
-    message = "ReplaySubject is not supported. The closest analogue is buffered broadcast channel",
-    level = DeprecationLevel.ERROR)
-public fun ReplaySubject(): Any = noImpl()
-
-/**
- * `PublishSubject` is not supported.
- * @suppress
- */
-@Deprecated(message = "PublishSubject is not supported", level = DeprecationLevel.ERROR)
-public fun PublishSubject(): Any = noImpl()
-
-/**
  * Flow analogue of `onErrorXxx` is [catch].
  * Use `catch { emitAll(fallback) }`.
  * @suppress


### PR DESCRIPTION
…of users who depend on any reactive library and kotlinx.coroutines