### PR TITLE
Check for cancellation in concurrent flow merge on each element

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/BufferTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/BufferTest.kt
@@ -183,5 +183,19 @@ class BufferTest : TestBase() {
             }
         finish(n + 4)
     }
+
+    @Test
+    fun testCancellation() = runTest {
+        val result = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            expectUnreached()
+            emit(4)
+        }.buffer(0)
+            .take(2)
+            .toList()
+        assertEquals(listOf(1, 2), result)
+    }
 }
 

--- a/kotlinx-coroutines-core/common/test/flow/operators/FlatMapMergeTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/FlatMapMergeTest.kt
@@ -73,4 +73,19 @@ class FlatMapMergeTest : FlatMapMergeBaseTest() {
         assertFailsWith<CancellationException>(flow)
         finish(5)
     }
+
+    @Test
+    fun testCancellation() = runTest {
+        val result = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            emit(4)
+            expectUnreached() // Cancelled by take
+            emit(5)
+        }.flatMapMerge(2) { v -> flow { emit(v) } }
+            .take(2)
+            .toList()
+        assertEquals(listOf(1, 2), result)
+    }
 }

--- a/kotlinx-coroutines-core/common/test/flow/operators/FlowOnTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/FlowOnTest.kt
@@ -262,6 +262,21 @@ class FlowOnTest : TestBase() {
     }
 
     @Test
+    fun testCancellation() = runTest {
+        val result = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            expectUnreached()
+            emit(4)
+        }.flowOn(wrapperDispatcher())
+            .buffer(0)
+            .take(2)
+            .toList()
+        assertEquals(listOf(1, 2), result)
+    }
+
+    @Test
     fun testException() = runTest {
         val flow = flow {
             emit(314)


### PR DESCRIPTION
  * Implementation detail (launch on each value) is leaking into upstream behaviour
  * The overhead is negligible compared to launching a new coroutines and sending to channel, but it provides a much approachable mental model when no suspension in the upstream flow happens (note: upstream never sends elements to the channel)

Fixes #1392