### PR TITLE
Fix documentation of (suspend () -> T).asFlow()

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -67,7 +67,7 @@ public fun <T> (() -> T).asFlow(): Flow<T> = flow {
  * Example of usage:
  * ```
  * suspend fun remoteCall(): R = ...
- * suspend fun remoteCallFlow(): Flow<R> = ::remoteCall.asFlow()
+ * fun remoteCallFlow(): Flow<R> = ::remoteCall.asFlow()
  * ```
  */
 @FlowPreview


### PR DESCRIPTION
The function calling asFlow() doesn't need to be suspending, and the
doc seems to suggest otherwise.