### PR TITLE
Cross platform support for scheduled coroutines

### DIFF
--- a/kotlinx-coroutines-core/common/src/Schedule.kt
+++ b/kotlinx-coroutines-core/common/src/Schedule.kt
@@ -1,0 +1,47 @@
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+suspend fun <T> scheduleAsync(
+    initialDelay: Long,
+    context: CoroutineContext = EmptyCoroutineContext,
+    block: suspend () -> T
+): Deferred<T> = coroutineScope {
+    async(Dispatchers.Default + Job()) {
+        delay(initialDelay)
+        withContext(context) { block() }
+    }
+}
+
+suspend fun scheduleWithFixedDelay(
+    initialDelay: Long,
+    successiveDelay: Long,
+    context: CoroutineContext = EmptyCoroutineContext,
+    block: suspend () -> Unit
+): Job = coroutineScope {
+    launch(Dispatchers.Default + Job()) {
+        delay(initialDelay)
+        while (isActive) {
+            withContext(context) { block() }
+            delay(successiveDelay)
+        }
+    }
+}
+
+suspend fun scheduleAtFixedRate(
+    initialDelay: Long,
+    period: Long,
+    context: CoroutineContext = EmptyCoroutineContext,
+    block: suspend () -> Unit
+): Job = coroutineScope {
+    launch(Dispatchers.Default + Job()) {
+        delay(initialDelay)
+        val start = nanoTime()
+        var periodMultiplier = 1L
+        while (isActive) {
+            launch(context) { block() }
+            delay(delayNanosToMillis(start - nanoTime()) + periodMultiplier++ * period)
+        }
+    }
+}

--- a/kotlinx-coroutines-core/common/test/ScheduleTest.kt
+++ b/kotlinx-coroutines-core/common/test/ScheduleTest.kt
@@ -1,0 +1,72 @@
+package kotlinx.coroutines
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScheduleTest : TestBase() {
+
+    @Test
+    fun testScheduleExecutesBlockAfterGivenDelay() = runTest {
+        expect(1)
+        val result = scheduleAsync(50) {
+            expect(3)
+            "OK"
+        }
+        expect(2)
+        delay(100)
+        finish(4)
+        assertEquals("OK", result.await())
+    }
+
+    @Test
+    fun testScheduleNotExecutingBlockIfCanceled() = runTest {
+        expect(1)
+        val job = scheduleAsync(1000) {
+            expectUnreached()
+        }
+        expect(2)
+        job.cancelAndJoin()
+        finish(3)
+    }
+
+    @Test
+    fun testRunningBlockNotCanceledIfScheduledWithNonCancelableContext() = runTest {
+        expect(1)
+        val job = scheduleAsync(50, NonCancellable) {
+            delay(100)
+            expect(4)
+        }
+        expect(2)
+        delay(75)
+        expect(3)
+        job.cancelAndJoin()
+        finish(5)
+    }
+
+    @Test
+    fun testScheduleWithFixedDelay() = runTest {
+        expect(1)
+        val job = scheduleWithFixedDelay(0, 100) {
+            expect(3)
+            delay(100)
+        }
+        expect(2)
+        delay(150)
+        job.cancelAndJoin()
+        finish(4)
+    }
+
+    @Test
+    fun testScheduleAtFixedRate() = runTest {
+        expect(1)
+        var n = 3
+        val job = scheduleAtFixedRate(0, 100) {
+            expect(n++)
+            delay(100)
+        }
+        expect(2)
+        delay(250)
+        job.cancelAndJoin()
+        finish(6)
+    }
+}


### PR DESCRIPTION
I've tried to mimic the behavior of `ScheduledExecutor` on the jvm, but with suspending functions instead of `Runnable` (and without `TimeUnit`).