### PR TITLE
Update Guava to the latest version 28.0

### DIFF
--- a/integration/kotlinx-coroutines-guava/build.gradle
+++ b/integration/kotlinx-coroutines-guava/build.gradle
@@ -2,7 +2,7 @@
  * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-ext.guava_version = '24.0-jre'
+ext.guava_version = '28.0-jre'
 
 dependencies {
     compile "com.google.guava:guava:$guava_version"


### PR DESCRIPTION
This fixes vulnerability CVE-2018-10237
See https://ossindex.sonatype.org/vuln/24585a7f-eb6b-4d8d-a2a9-a6f16cc7c1d0