### PR TITLE
Fix SOE with select onSend/onReceive clauses on the same channel

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -1025,7 +1025,9 @@ public final class kotlinx/coroutines/selects/SelectBuilderImpl : kotlinx/corout
 	public fun performAtomicTrySelect (Lkotlinx/coroutines/internal/AtomicDesc;)Ljava/lang/Object;
 	public fun resumeSelectCancellableWithException (Ljava/lang/Throwable;)V
 	public fun resumeWith (Ljava/lang/Object;)V
-	public fun trySelect (Ljava/lang/Object;)Z
+	public fun toString ()Ljava/lang/String;
+	public fun trySelect ()Z
+	public fun trySelectIdempotent (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class kotlinx/coroutines/selects/SelectClause0 {
@@ -1047,11 +1049,16 @@ public abstract interface class kotlinx/coroutines/selects/SelectInstance {
 	public abstract fun performAtomicIfNotSelected (Lkotlinx/coroutines/internal/AtomicDesc;)Ljava/lang/Object;
 	public abstract fun performAtomicTrySelect (Lkotlinx/coroutines/internal/AtomicDesc;)Ljava/lang/Object;
 	public abstract fun resumeSelectCancellableWithException (Ljava/lang/Throwable;)V
-	public abstract fun trySelect (Ljava/lang/Object;)Z
+	public abstract fun trySelect ()Z
+	public abstract fun trySelectIdempotent (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class kotlinx/coroutines/selects/SelectKt {
 	public static final fun select (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public synthetic class kotlinx/coroutines/selects/SelectKtSelectOpSequenceNumberRefVolatile {
+	public fun <init> (J)V
 }
 
 public final class kotlinx/coroutines/selects/SelectUnbiasedKt {

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -553,7 +553,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
             if (select.isSelected) return
             if (state !is Incomplete) {
                 // already complete -- select result
-                if (select.trySelect(null)) {
+                if (select.trySelect()) {
                     block.startCoroutineUnintercepted(select.completion)
                 }
                 return
@@ -1181,7 +1181,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
             if (select.isSelected) return
             if (state !is Incomplete) {
                 // already complete -- select result
-                if (select.trySelect(null)) {
+                if (select.trySelect()) {
                     if (state is CompletedExceptionally) {
                         select.resumeSelectCancellableWithException(state.cause)
                     }
@@ -1362,7 +1362,7 @@ private class SelectJoinOnCompletion<R>(
     private val block: suspend () -> R
 ) : JobNode<JobSupport>(job) {
     override fun invoke(cause: Throwable?) {
-        if (select.trySelect(null))
+        if (select.trySelect())
             block.startCoroutineCancellable(select.completion)
     }
     override fun toString(): String = "SelectJoinOnCompletion[$select]"
@@ -1374,7 +1374,7 @@ private class SelectAwaitOnCompletion<T, R>(
     private val block: suspend (T) -> R
 ) : JobNode<JobSupport>(job) {
     override fun invoke(cause: Throwable?) {
-        if (select.trySelect(null))
+        if (select.trySelect())
             job.selectAwaitCompletion(select, block)
     }
     override fun toString(): String = "SelectAwaitOnCompletion[$select]"

--- a/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayBroadcastChannel.kt
@@ -105,7 +105,7 @@ internal class ArrayBroadcastChannel<E>(
             val size = this.size
             if (size >= capacity) return OFFER_FAILED
             // let's try to select sending this element to buffer
-            if (!select.trySelect(null)) { // :todo: move trySelect completion outside of lock
+            if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
                 return ALREADY_SELECTED
             }
             val tail = this.tail
@@ -299,7 +299,7 @@ internal class ArrayBroadcastChannel<E>(
                     result === POLL_FAILED -> { /* just bail out of lock */ }
                     else -> {
                         // let's try to select receiving this element from buffer
-                        if (!select.trySelect(null)) { // :todo: move trySelect completion outside of lock
+                        if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
                             result = ALREADY_SELECTED
                         } else {
                             // update subHead after retrieiving element from buffer

--- a/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
@@ -88,7 +88,7 @@ internal open class ArrayChannel<E>(
                 // check for receivers that were waiting on empty queue
                 if (size == 0) {
                     loop@ while (true) {
-                        val offerOp = describeTryOffer(element)
+                        val offerOp = describeTryOffer(element, select)
                         val failure = select.performAtomicTrySelect(offerOp)
                         when {
                             failure == null -> { // offered successfully
@@ -175,7 +175,7 @@ internal open class ArrayChannel<E>(
             var replacement: Any? = POLL_FAILED
             if (size == capacity) {
                 loop@ while (true) {
-                    val pollOp = describeTryPoll()
+                    val pollOp = describeTryPoll(select)
                     val failure = select.performAtomicTrySelect(pollOp)
                     when {
                         failure == null -> { // polled successfully

--- a/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
@@ -88,7 +88,7 @@ internal open class ArrayChannel<E>(
                 // check for receivers that were waiting on empty queue
                 if (size == 0) {
                     loop@ while (true) {
-                        val offerOp = describeTryOffer(element, select)
+                        val offerOp = describeTryOffer(element)
                         val failure = select.performAtomicTrySelect(offerOp)
                         when {
                             failure == null -> { // offered successfully
@@ -108,7 +108,7 @@ internal open class ArrayChannel<E>(
                     }
                 }
                 // let's try to select sending this element to buffer
-                if (!select.trySelect(null)) { // :todo: move trySelect completion outside of lock
+                if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
                     this.size = size // restore size
                     return ALREADY_SELECTED
                 }
@@ -175,7 +175,7 @@ internal open class ArrayChannel<E>(
             var replacement: Any? = POLL_FAILED
             if (size == capacity) {
                 loop@ while (true) {
-                    val pollOp = describeTryPoll(select)
+                    val pollOp = describeTryPoll()
                     val failure = select.performAtomicTrySelect(pollOp)
                     when {
                         failure == null -> { // polled successfully
@@ -206,7 +206,7 @@ internal open class ArrayChannel<E>(
                 buffer[(head + size) % capacity] = replacement
             } else {
                 // failed to poll or is already closed --> let's try to select receiving this element from buffer
-                if (!select.trySelect(null)) { // :todo: move trySelect completion outside of lock
+                if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
                     this.size = size // restore size
                     buffer[head] = result // restore head
                     return ALREADY_SELECTED

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
@@ -273,7 +273,7 @@ public class ConflatedBroadcastChannel<E>() : BroadcastChannel<E> {
         }
 
     private fun <R> registerSelectSend(select: SelectInstance<R>, element: E, block: suspend (SendChannel<E>) -> R) {
-        if (!select.trySelect(null)) return
+        if (!select.trySelect()) return
         offerInternal(element)?.let {
             select.resumeSelectCancellableWithException(it.sendException)
             return

--- a/kotlinx-coroutines-core/common/src/internal/LockFreeLinkedList.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/LockFreeLinkedList.common.kt
@@ -4,6 +4,8 @@
 
 package kotlinx.coroutines.internal
 
+import kotlin.jvm.*
+
 /** @suppress **This is unstable API and it is subject to change.** */
 public expect open class LockFreeLinkedListNode() {
     public val isRemoved: Boolean
@@ -57,7 +59,7 @@ public expect open class AddLastDesc<T : LockFreeLinkedListNode>(
 public expect open class RemoveFirstDesc<T>(queue: LockFreeLinkedListNode): AbstractAtomicDesc {
     val queue: LockFreeLinkedListNode
     public val result: T
-    protected open fun validatePrepared(node: T): Boolean
+    protected open fun validatePrepared(node: T): Any?
     protected final override fun onPrepare(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode): Any?
     final override fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
 }
@@ -71,3 +73,7 @@ public expect abstract class AbstractAtomicDesc : AtomicDesc {
     protected abstract fun onPrepare(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode): Any? // non-null on failure
     protected abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
 }
+
+@JvmField
+@SharedImmutable
+internal val REMOVE_PREPARED: Any = Symbol("REMOVE_PREPARED")

--- a/kotlinx-coroutines-core/common/src/sync/Mutex.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Mutex.kt
@@ -385,7 +385,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
         @JvmField val select: SelectInstance<R>,
         @JvmField val block: suspend (Mutex) -> R
     ) : LockWaiter(owner) {
-        override fun tryResumeLockWaiter(): Any? = if (select.trySelect(null)) SELECT_SUCCESS else null
+        override fun tryResumeLockWaiter(): Any? = if (select.trySelect()) SELECT_SUCCESS else null
         override fun completeResumeLockWaiter(token: Any) {
             assert { token === SELECT_SUCCESS }
             block.startCoroutine(receiver = mutex, completion = select.completion)

--- a/kotlinx-coroutines-core/common/test/selects/SelectArrayChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/selects/SelectArrayChannelTest.kt
@@ -385,7 +385,7 @@ class SelectArrayChannelTest : TestBase() {
     // only for debugging
     internal fun <R> SelectBuilder<R>.default(block: suspend () -> R) {
         this as SelectBuilderImpl // type assertion
-        if (!trySelect(null)) return
+        if (!trySelect()) return
         block.startCoroutineUnintercepted(this)
     }
 }

--- a/kotlinx-coroutines-core/common/test/selects/SelectBuilderImplTest.kt
+++ b/kotlinx-coroutines-core/common/test/selects/SelectBuilderImplTest.kt
@@ -23,15 +23,15 @@ class SelectBuilderImplTest : TestBase() {
         val c = SelectBuilderImpl(delegate)
         // still running builder
         check(!c.isSelected)
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         c.completion.resume("OK")
         check(!resumed) // still running builder, didn't invoke delegate
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(c.getResult() === "OK") // then builder returns
     }
 
@@ -48,16 +48,16 @@ class SelectBuilderImplTest : TestBase() {
         val c = SelectBuilderImpl(delegate)
         check(c.getResult() === COROUTINE_SUSPENDED) // suspend first
         check(!c.isSelected)
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(!resumed)
         c.completion.resume("OK")
         check(resumed)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
     }
 
     @Test
@@ -73,15 +73,15 @@ class SelectBuilderImplTest : TestBase() {
         val c = SelectBuilderImpl(delegate)
         // still running builder
         check(!c.isSelected)
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         c.completion.resumeWithException(TestException())
         check(!resumed) // still running builder, didn't invoke delegate
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         try {
             c.getResult() // the builder should throw exception
             error("Failed")
@@ -103,15 +103,15 @@ class SelectBuilderImplTest : TestBase() {
         val c = SelectBuilderImpl(delegate)
         check(c.getResult() === COROUTINE_SUSPENDED) // suspend first
         check(!c.isSelected)
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
         check(!resumed)
         c.completion.resumeWithException(TestException())
         check(resumed)
         check(c.isSelected)
-        check(!c.trySelect("OTHER"))
-        check(c.trySelect("SELECT"))
+        check(c.trySelectIdempotent("OTHER") == null)
+        check(c.trySelectIdempotent("SELECT") === SELECT_STARTED)
     }
 }

--- a/kotlinx-coroutines-core/common/test/selects/SelectRendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/selects/SelectRendezvousChannelTest.kt
@@ -406,7 +406,7 @@ class SelectRendezvousChannelTest : TestBase() {
     // only for debugging
     internal fun <R> SelectBuilder<R>.default(block: suspend () -> R) {
         this as SelectBuilderImpl // type assertion
-        if (!trySelect(null)) return
+        if (!trySelect()) return
         block.startCoroutineUnintercepted(this)
     }
 

--- a/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
@@ -110,11 +110,10 @@ public actual open class RemoveFirstDesc<T> actual constructor(
     @Suppress("UNCHECKED_CAST")
     public actual val result: T get() = affectedNode as T
     protected override val affectedNode: Node = queue.nextNode
-    protected actual open fun validatePrepared(node: T): Boolean = true
+    protected actual open fun validatePrepared(node: T): Any? = null
     protected actual final override fun onPrepare(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode): Any? {
         @Suppress("UNCHECKED_CAST")
-        validatePrepared(affectedNode as T)
-        return null
+        return validatePrepared(affectedNode as T)
     }
     protected override fun onComplete() { queue.removeFirstOrNull() }
     protected actual override fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode) = Unit

--- a/kotlinx-coroutines-core/jvm/test/selects/SelectChannelStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/selects/SelectChannelStressTest.kt
@@ -70,7 +70,7 @@ class SelectChannelStressTest: TestBase() {
 
     internal fun <R> SelectBuilder<R>.default(block: suspend () -> R) {
         this as SelectBuilderImpl // type assertion
-        if (!trySelect(null)) return
+        if (!trySelect()) return
         block.startCoroutineUnintercepted(this)
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/selects/SelectDeadlockStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/selects/SelectDeadlockStressTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.selects
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import org.junit.*
+import org.junit.Test
+import kotlin.test.*
+
+class SelectDeadlockStressTest : TestBase() {
+    private val pool = newFixedThreadPoolContext(2, "SelectDeadlockStressTest")
+    private val nSeconds = 3 * stressTestMultiplier
+
+    @After
+    fun tearDown() {
+        pool.close()
+    }
+
+    @Test
+    fun testStress() = runTest {
+        val c1 = Channel<Long>()
+        val c2 = Channel<Long>()
+        val s1 = Stats()
+        val s2 = Stats()
+        launchSendReceive(c1, c2, s1)
+        launchSendReceive(c2, c1, s2)
+        for (i in 1..nSeconds) {
+            delay(1000)
+            println("$i: First: $s1; Second: $s2")
+        }
+        coroutineContext.cancelChildren()
+    }
+
+    private class Stats {
+        var sendIndex = 0L
+        var receiveIndex = 0L
+
+        override fun toString(): String = "send=$sendIndex, received=$receiveIndex"
+    }
+
+    private fun CoroutineScope.launchSendReceive(c1: Channel<Long>, c2: Channel<Long>, s: Stats) = launch(pool) {
+        while (true) {
+            if (s.sendIndex % 1000 == 0L) yield()
+            select<Unit> {
+                c1.onSend(s.sendIndex) {
+                    s.sendIndex++
+                }
+                c2.onReceive { i ->
+                    assertEquals(s.receiveIndex, i)
+                    s.receiveIndex++
+                }
+            }
+        }
+    }
+}

--- a/kotlinx-coroutines-core/native/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/native/src/internal/LinkedList.kt
@@ -108,11 +108,10 @@ public actual open class RemoveFirstDesc<T> actual constructor(
     @Suppress("UNCHECKED_CAST")
     public actual val result: T get() = affectedNode as T
     protected override val affectedNode: Node = queue.nextNode
-    protected actual open fun validatePrepared(node: T): Boolean = true
+    protected actual open fun validatePrepared(node: T): Any? = null
     protected actual final override fun onPrepare(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode): Any? {
         @Suppress("UNCHECKED_CAST")
-        validatePrepared(affectedNode as T)
-        return null
+        return validatePrepared(affectedNode as T)
     }
     protected override fun onComplete() { queue.removeFirstOrNull() }
     protected actual override fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode) = Unit


### PR DESCRIPTION
* Instead of StackOverflowError we throw IllegalStateException and leave
  the channel in the original state.

Fixes #1411