### PR TITLE
Deprecate delayFlow and delayEach

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -8,6 +8,9 @@
 
 package kotlinx.coroutines.flow
 
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.internal.*
+import kotlinx.coroutines.flow.internal.unsafeFlow
 import kotlin.coroutines.*
 import kotlin.jvm.*
 
@@ -361,3 +364,26 @@ public fun <T> Flow<T>.concatWith(value: T): Flow<T> = noImpl()
 )
 public fun <T> Flow<T>.concatWith(other: Flow<T>): Flow<T> = noImpl()
 
+/**
+ * Delays the emission of values from this flow for the given [timeMillis].
+ * Use `onStart { delay(timeMillis) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.WARNING, // since 1.3.0, error in 1.4.0
+    message = "Use 'onStart { delay(timeMillis) }'",
+    replaceWith = ReplaceWith("onStart { delay(timeMillis) }")
+)
+public fun <T> Flow<T>.delayFlow(timeMillis: Long): Flow<T> = onStart { delay(timeMillis) }
+
+/**
+ * Delays each element emitted by the given flow for the given [timeMillis].
+ * Use `onEach { delay(timeMillis) }`.
+ * @suppress
+ */
+@Deprecated(
+    level = DeprecationLevel.WARNING, // since 1.3.0, error in 1.4.0
+    message = "Use 'onEach { delay(timeMillis) }'",
+    replaceWith = ReplaceWith("onEach { delay(timeMillis) }")
+)
+public fun <T> Flow<T>.delayEach(timeMillis: Long): Flow<T> = onEach { delay(timeMillis) }

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -15,26 +15,6 @@ import kotlin.jvm.*
 import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
- * Delays the emission of values from this flow for the given [timeMillis].
- */
-@ExperimentalCoroutinesApi
-public fun <T> Flow<T>.delayFlow(timeMillis: Long): Flow<T> = flow {
-    delay(timeMillis)
-    collect(this@flow)
-}
-
-/**
- * Delays each element emitted by the given flow for the given [timeMillis].
- */
-@ExperimentalCoroutinesApi
-public fun <T> Flow<T>.delayEach(timeMillis: Long): Flow<T> = flow {
-    collect { value ->
-        delay(timeMillis)
-        emit(value)
-    }
-}
-
-/**
  * Returns a flow that mirrors the original flow, but filters out values
  * that are followed by the newer values within the given [timeout][timeoutMillis].
  * The latest value is always emitted.


### PR DESCRIPTION
This will make Flow API surface more orthogonal with less operators to
remember. Both of them can be easily written without too much additional
code and still produce quite readable and easy to understand code:

delayFlow(time) = onStart { delay(time) }
delayEach(time) = onEach { delay(time) }

Fixes #1429