### PR TITLE
Consistent naming for stress tests

### DIFF
--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -72,23 +72,23 @@ jvmTest {
     maxHeapSize = '1g'
     enableAssertions = true
     systemProperty 'java.security.manager', 'kotlinx.coroutines.TestSecurityManager'
-    exclude '**/*LFTest.*'
+    exclude '**/*LFStressTest.*'
     systemProperty 'kotlinx.coroutines.scheduler.keep.alive.sec', '100000' // any unpark problem hangs test
 }
 
 task lockFreedomTest(type: Test, dependsOn: compileTestKotlinJvm) {
     classpath = files { jvmTest.classpath }
     testClassesDirs = files { jvmTest.testClassesDirs }
-    include '**/*LFTest.*'
+    include '**/*LFStressTest.*'
 }
 
 task jdk16Test(type: Test, dependsOn: [compileTestKotlinJvm, checkJdk16]) {
     classpath = files { jvmTest.classpath }
     testClassesDirs = files { jvmTest.testClassesDirs }
     executable = "$System.env.JDK_16/bin/java"
-    exclude '**/*LinearizabilityTest*.*'
-    exclude '**/*LFTest.*'
-    exclude '**/exceptions/**'
+    exclude '**/*LFStressTest.*' // lock-freedom tests use LockFreedomTestEnvironment which needs JDK8
+    exclude '**/*LCStressTest.*' // lic-check tests use LinChecker which needs JDK8
+    exclude '**/exceptions/**'   // exceptions tests check suppressed exception which needs JDK8
     exclude '**/ExceptionsGuideTest.*'
 }
 

--- a/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListAtomicLFStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListAtomicLFStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.internal
@@ -16,8 +16,8 @@ import java.util.concurrent.atomic.AtomicReference
  * This stress test has 4 threads adding randomly to the list and them immediately undoing
  * this addition by remove, and 4 threads trying to remove nodes from two lists simultaneously (atomically).
  */
-class LockFreeLinkedListAtomicStressLFTest : TestBase() {
-    private val env = LockFreedomTestEnvironment("LockFreeLinkedListAtomicStressLFTest")
+class LockFreeLinkedListAtomicLFStressTest : TestBase() {
+    private val env = LockFreedomTestEnvironment("LockFreeLinkedListAtomicLFStressTest")
 
     data class IntNode(val i: Int) : LockFreeLinkedListNode()
 

--- a/kotlinx-coroutines-core/jvm/test/internal/SegmentQueueLCStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/SegmentQueueLCStressTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.coroutines.internal
 
 import com.devexperts.dxlab.lincheck.LinChecker
@@ -8,7 +12,7 @@ import com.devexperts.dxlab.lincheck.strategy.stress.StressCTest
 import org.junit.Test
 
 @StressCTest
-class SegmentQueueLinearizabilityTest {
+class SegmentQueueLCStressTest {
     private val q = SegmentBasedQueue<Int>()
 
     @Operation
@@ -21,6 +25,6 @@ class SegmentQueueLinearizabilityTest {
 
     @Test
     fun test() {
-        LinChecker.check(SegmentQueueLinearizabilityTest::class.java)
+        LinChecker.check(SegmentQueueLCStressTest::class.java)
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/linearizability/ChannelIsClosedLCStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/linearizability/ChannelIsClosedLCStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 @file:Suppress("unused")
 
@@ -15,15 +15,10 @@ import org.junit.*
 import java.io.*
 
 @Param(name = "value", gen = IntGen::class, conf = "1:3")
-class ChannelLinearizabilityTest : TestBase() {
-
-    private companion object {
-        // Emulating ctor argument for lincheck
-        var capacity = 0
-    }
+class ChannelIsClosedLCStressTest : TestBase() {
 
     private val lt = LinTesting()
-    private var channel: Channel<Int> = Channel(capacity)
+    private val channel = Channel<Int>()
 
     @Operation(runOnce = true)
     fun send1(@Param(name = "value") value: Int) = lt.run("send1") { channel.send(value) }
@@ -41,33 +36,19 @@ class ChannelLinearizabilityTest : TestBase() {
     fun close1() = lt.run("close1") { channel.close(IOException("close1")) }
 
     @Operation(runOnce = true)
-    fun close2() = lt.run("close2") { channel.close(IOException("close2")) }
+    fun isClosedForReceive() = lt.run("isClosedForReceive") { channel.isClosedForReceive }
+
+    @Operation(runOnce = true)
+    fun isClosedForSend() = lt.run("isClosedForSend") { channel.isClosedForSend }
 
     @Test
-    fun testRendezvousChannelLinearizability() {
-        runTest(0)
-    }
-
-    @Test
-    fun testArrayChannelLinearizability() {
-        for (i in listOf(1, 2, 16)) {
-            runTest(i)
-        }
-    }
-
-    @Test
-    fun testConflatedChannelLinearizability() = runTest(Channel.CONFLATED)
-
-    @Test
-    fun testUnlimitedChannelLinearizability() = runTest(Channel.UNLIMITED)
-
-    private fun runTest(capacity: Int) {
-        ChannelLinearizabilityTest.capacity = capacity
+    fun testLinearizability() {
         val options = StressOptions()
-            .iterations(50 * stressTestMultiplierSqrt)
-            .invocationsPerIteration(500 * stressTestMultiplierSqrt)
+            .iterations(100 * stressTestMultiplierSqrt)
+            .invocationsPerIteration(1000 * stressTestMultiplierSqrt)
             .threads(3)
             .verifier(LinVerifier::class.java)
-        LinChecker.check(ChannelLinearizabilityTest::class.java, options)
+
+        LinChecker.check(ChannelIsClosedLCStressTest::class.java, options)
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/linearizability/LockFreeListLCStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/linearizability/LockFreeListLCStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 @file:Suppress("unused")
 
@@ -14,7 +14,7 @@ import kotlinx.coroutines.internal.*
 import kotlin.test.*
 
 @Param(name = "value", gen = IntGen::class, conf = "1:3")
-class LockFreeListLinearizabilityTest : TestBase() {
+class LockFreeListLCStressTest : TestBase() {
     class Node(val value: Int): LockFreeLinkedListNode()
 
     private val q: LockFreeLinkedListHead = LockFreeLinkedListHead()
@@ -49,7 +49,7 @@ class LockFreeListLinearizabilityTest : TestBase() {
             .iterations(100 * stressTestMultiplierSqrt)
             .invocationsPerIteration(1000 * stressTestMultiplierSqrt)
             .threads(3)
-        LinChecker.check(LockFreeListLinearizabilityTest::class.java, options)
+        LinChecker.check(LockFreeListLCStressTest::class.java, options)
     }
 
     private var _curElements: ArrayList<Int>? = null
@@ -62,7 +62,7 @@ class LockFreeListLinearizabilityTest : TestBase() {
     }
 
     override fun equals(other: Any?): Boolean {
-        other as LockFreeListLinearizabilityTest
+        other as LockFreeListLCStressTest
         return curElements == other.curElements
     }
 

--- a/kotlinx-coroutines-core/jvm/test/linearizability/LockFreeTaskQueueLCStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/linearizability/LockFreeTaskQueueLCStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 @file:Suppress("unused")
 
@@ -19,7 +19,7 @@ internal data class Snapshot(val elements: List<Int>, val isClosed: Boolean) {
 
 @OpGroupConfig.OpGroupConfigs(OpGroupConfig(name = "consumer", nonParallel = true))
 @Param(name = "value", gen = IntGen::class, conf = "1:3")
-class LockFreeTaskQueueLinearizabilityTestSC : LockFreeTaskQueueLinearizabilityTestBase() {
+class SCLockFreeTaskQueueLCStressTest : LockFreeTaskQueueLCTestBase() {
     private val q: LockFreeTaskQueue<Int> = LockFreeTaskQueue(singleConsumer = true)
 
     @Operation
@@ -42,7 +42,7 @@ class LockFreeTaskQueueLinearizabilityTestSC : LockFreeTaskQueueLinearizabilityT
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as LockFreeTaskQueueLinearizabilityTestSC
+        other as SCLockFreeTaskQueueLCStressTest
 
         return Snapshot(q) == Snapshot(other.q)
     }
@@ -51,7 +51,7 @@ class LockFreeTaskQueueLinearizabilityTestSC : LockFreeTaskQueueLinearizabilityT
 }
 
 @Param(name = "value", gen = IntGen::class, conf = "1:3")
-class LockFreeTaskQueueLinearizabilityTestMC : LockFreeTaskQueueLinearizabilityTestBase() {
+class MCLockFreeTaskQueueLCStressTest : LockFreeTaskQueueLCTestBase() {
     private val q: LockFreeTaskQueue<Int> = LockFreeTaskQueue(singleConsumer = false)
 
     @Operation
@@ -74,7 +74,7 @@ class LockFreeTaskQueueLinearizabilityTestMC : LockFreeTaskQueueLinearizabilityT
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as LockFreeTaskQueueLinearizabilityTestMC
+        other as MCLockFreeTaskQueueLCStressTest
 
         return Snapshot(q) == Snapshot(other.q)
     }
@@ -82,7 +82,7 @@ class LockFreeTaskQueueLinearizabilityTestMC : LockFreeTaskQueueLinearizabilityT
     override fun hashCode(): Int = Snapshot(q).hashCode()
 }
 
-open class LockFreeTaskQueueLinearizabilityTestBase : TestBase() {
+open class LockFreeTaskQueueLCTestBase : TestBase() {
     fun linTest() {
         val options = StressOptions()
             .iterations(100 * stressTestMultiplierSqrt)


### PR DESCRIPTION
* All stress tests end with StressTest, also:
* LFStressTest checks lock-freedom
* LCStressTest checks linearizability via LinCheck
* Gradle build exclusion/inclusion patterns are properly updated:
  - jdk16Test excludes both LFStressTest and LCStressTest since they
    depends on JDK8
  - Regular tests exclude LFStressTest since they are long (5 sec each)
  - A separate lockFreedomTest target that is run on "build"