### PR TITLE
Update flow.md

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1070,7 +1070,7 @@ fun main() = runBlocking<Unit> {
 //sampleStart                                                                           
     val nums = (1..3).asFlow().onEach { delay(300) } // numbers 1..3 every 300 ms
     val strs = flowOf("one", "two", "three").onEach { delay(400) } // strings every 400 ms          
-    val startTime = currentTimeMillis() // remember the start time 
+    val startTime = System.currentTimeMillis() // remember the start time 
     nums.combine(strs) { a, b -> "$a -> $b" } // compose a single string with "combine"
         .collect { value -> // collect and print 
             println("$value at ${System.currentTimeMillis() - startTime} ms from start") 
@@ -1152,7 +1152,7 @@ fun requestFlow(i: Int): Flow<String> = flow {
 
 fun main() = runBlocking<Unit> { 
 //sampleStart
-    val startTime = currentTimeMillis() // remember the start time 
+    val startTime = System.currentTimeMillis() // remember the start time 
     (1..3).asFlow().onEach { delay(100) } // a number every 100 ms 
         .flatMapConcat { requestFlow(it) }                                                                           
         .collect { value -> // collect and print 
@@ -1201,7 +1201,7 @@ fun requestFlow(i: Int): Flow<String> = flow {
 
 fun main() = runBlocking<Unit> { 
 //sampleStart
-    val startTime = currentTimeMillis() // remember the start time 
+    val startTime = System.currentTimeMillis() // remember the start time 
     (1..3).asFlow().onEach { delay(100) } // a number every 100 ms 
         .flatMapMerge { requestFlow(it) }                                                                           
         .collect { value -> // collect and print 
@@ -1253,7 +1253,7 @@ fun requestFlow(i: Int): Flow<String> = flow {
 
 fun main() = runBlocking<Unit> { 
 //sampleStart
-    val startTime = currentTimeMillis() // remember the start time 
+    val startTime = System.currentTimeMillis() // remember the start time 
     (1..3).asFlow().onEach { delay(100) } // a number every 100 ms 
         .flatMapLatest { requestFlow(it) }                                                                           
         .collect { value -> // collect and print 


### PR DESCRIPTION
use `System.currentTimeMillis()` instead of internal one

if you run the previous code one playground you get an error like:

> Cannot access 'currentTimeMillis': it is internal in 'kotlinx.coroutines'