### PR TITLE
Fix propagation for stressTest property for nightly stress tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,14 @@ allprojects {
     }
 
     ext.unpublished = unpublished
+
+    // This project property is set during nightly stress test
+    def stressTest = project.properties['stressTest']
+
+    // Copy it to all test tasks
+    tasks.withType(Test) {
+        systemProperty 'stressTest', stressTest
+    }
 }
 
 allprojects {

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -80,6 +80,8 @@ task lockFreedomTest(type: Test, dependsOn: compileTestKotlinJvm) {
     classpath = files { jvmTest.classpath }
     testClassesDirs = files { jvmTest.testClassesDirs }
     include '**/*LFStressTest.*'
+    enableAssertions = true
+    testLogging.showStandardStreams = true
 }
 
 task jdk16Test(type: Test, dependsOn: [compileTestKotlinJvm, checkJdk16]) {


### PR DESCRIPTION
Also enable assertions and test output while running (long) LFStressTest