### PR TITLE
Fixed linearizability of Channel.close operation

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/LinkedListChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/LinkedListChannel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -29,8 +29,7 @@ internal open class LinkedListChannel<E> : AbstractChannel<E>() {
             when {
                 result === OFFER_SUCCESS -> return OFFER_SUCCESS
                 result === OFFER_FAILED -> { // try to buffer
-                    val sendResult = sendBuffered(element)
-                    when (sendResult) {
+                    when (val sendResult = sendBuffered(element)) {
                         null -> return OFFER_SUCCESS
                         is Closed<*> -> return sendResult
                     }

--- a/kotlinx-coroutines-core/jvm/test/linearizability/ChannelCloseLCStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/linearizability/ChannelCloseLCStressTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:Suppress("unused")
+
+package kotlinx.coroutines.linearizability
+
+import com.devexperts.dxlab.lincheck.*
+import com.devexperts.dxlab.lincheck.annotations.*
+import com.devexperts.dxlab.lincheck.paramgen.*
+import com.devexperts.dxlab.lincheck.strategy.stress.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import org.junit.*
+import java.io.*
+
+/**
+ * This is stress test that is fine-tuned to catch the problem
+ * [#1419](https://github.com/Kotlin/kotlinx.coroutines/issues/1419)
+ */
+@Param(name = "value", gen = IntGen::class, conf = "2:2")
+@OpGroupConfig.OpGroupConfigs(
+    OpGroupConfig(name = "send", nonParallel = true),
+    OpGroupConfig(name = "receive", nonParallel = true),
+    OpGroupConfig(name = "close", nonParallel = true)
+)
+class ChannelCloseLCStressTest : TestBase() {
+
+    private companion object {
+        // Emulating ctor argument for lincheck
+        var capacity = 0
+    }
+
+    private val lt = LinTesting()
+    private var channel: Channel<Int> = Channel(capacity)
+
+    @Operation(runOnce = true, group = "send")
+    fun send1(@Param(name = "value") value: Int) = lt.run("send1") { channel.send(value) }
+
+    @Operation(runOnce = true, group = "send")
+    fun send2(@Param(name = "value") value: Int) = lt.run("send2") { channel.send(value) }
+
+    @Operation(runOnce = true, group = "receive")
+    fun receive1() = lt.run("receive1") { channel.receive() }
+
+    @Operation(runOnce = true, group = "receive")
+    fun receive2() = lt.run("receive2") { channel.receive() }
+
+    @Operation(runOnce = true, group = "close")
+    fun close1() = lt.run("close1") { channel.close(IOException("close1")) }
+
+    @Operation(runOnce = true, group = "close")
+    fun close2() = lt.run("close2") { channel.close(IOException("close2")) }
+
+    @Test
+    fun testRendezvousChannelLinearizability() {
+        runTest(0)
+    }
+
+    @Test
+    fun testArrayChannelLinearizability() {
+        for (i in listOf(1, 2, 16)) {
+            runTest(i)
+        }
+    }
+
+    @Test
+    fun testConflatedChannelLinearizability() = runTest(Channel.CONFLATED)
+
+    @Test
+    fun testUnlimitedChannelLinearizability() = runTest(Channel.UNLIMITED)
+
+    private fun runTest(capacity: Int) {
+        ChannelCloseLCStressTest.capacity = capacity
+        val options = StressOptions()
+            .iterations(1) // only one iteration -- test scenario is fixed
+            .invocationsPerIteration(10_000 * stressTestMultiplierSqrt)
+            .threads(3)
+            .verifier(LinVerifier::class.java)
+        LinChecker.check(ChannelCloseLCStressTest::class.java, options)
+    }
+}


### PR DESCRIPTION
Send operations must ALWAYS help close the channel when they observe
that it was closed before throwing an exception.

Fixes #1419