### PR TITLE
Fixed completion sequence of ChannelLFStressTest

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelLFStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelLFStressTest.kt
@@ -50,9 +50,12 @@ class ChannelLFStressTest : TestBase() {
     }
 
     private fun performLockFreedomTest() {
-        env.onCompletion { channel.close() }
-        repeat(2) { env.testThread { sender() } }
-        repeat(2) { env.testThread { receiver() } }
+        env.onCompletion {
+            // We must cancel the channel to abort both senders & receivers
+            channel.cancel(TestCompleted())
+        }
+        repeat(2) { env.testThread("sender-$it") { sender() } }
+        repeat(2) { env.testThread("receiver-$it") { receiver() } }
         env.performTest(nSeconds) {
             println("Sent: $sendIndex, Received: $receiveCount, dups: $duplicateCount")
         }
@@ -70,7 +73,7 @@ class ChannelLFStressTest : TestBase() {
         val value = sendIndex.getAndIncrement()
         try {
             channel.send(value)
-        } catch (e: ClosedSendChannelException) {
+        } catch (e: TestCompleted) {
             check(env.isCompleted) // expected when test was completed
             markReceived(value) // fake received (actually failed to send)
         }
@@ -79,7 +82,7 @@ class ChannelLFStressTest : TestBase() {
     private suspend fun receiver() {
         val value = try {
             channel.receive()
-        } catch (e: ClosedReceiveChannelException) {
+        } catch (e: TestCompleted) {
             check(env.isCompleted) // expected when test was completed
             return
         }
@@ -107,4 +110,6 @@ class ChannelLFStressTest : TestBase() {
         val bits = receivedBits.get(index)
         return bits and mask != 0L
     }
+
+    private class TestCompleted : CancellationException()
 }


### PR DESCRIPTION
A channel must be "cancelled" to abort both working senders & receivers.

Fixes #1507