### PR TITLE
Fixes linearizability of Channel.close in advanced receive+send case

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/InlineList.kt
+++ b/kotlinx-coroutines-core/common/src/internal/InlineList.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("UNCHECKED_CAST")
+
+package kotlinx.coroutines.internal
+
+import kotlinx.coroutines.assert
+
+/*
+ * Inline class that represents a mutable list, but does not allocate an underlying storage
+ * for zero and one elements.
+ * Cannot be parametrized with `List<*>`.
+ */
+internal inline class InlineList<E>(private val holder: Any? = null) {
+    public operator fun plus(element: E): InlineList<E>  {
+        assert { element !is List<*> } // Lists are prohibited
+        return when (holder) {
+            null -> InlineList(element)
+            is ArrayList<*> -> {
+                (holder as ArrayList<E>).add(element)
+                InlineList(holder)
+            }
+            else -> {
+                val list = ArrayList<E>(4)
+                list.add(holder as E)
+                list.add(element)
+                InlineList(list)
+            }
+        }
+    }
+
+    public inline fun forEachReversed(action: (E) -> Unit) {
+        when (holder) {
+            null -> return
+            !is ArrayList<*> -> action(holder as E)
+            else -> {
+                val list = holder as ArrayList<E>
+                for (i in (list.size - 1) downTo 0) {
+                    action(list[i])
+                }
+            }
+        }
+    }
+}

--- a/kotlinx-coroutines-core/common/test/channels/ChannelsTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ChannelsTest.kt
@@ -20,6 +20,37 @@ class ChannelsTest: TestBase() {
     }
 
     @Test
+    fun testCloseWithMultipleWaiters() = runTest {
+        val channel = Channel<Int>()
+        launch {
+            try {
+                expect(2)
+                channel.receive()
+                expectUnreached()
+            } catch (e: ClosedReceiveChannelException) {
+                expect(5)
+            }
+        }
+
+        launch {
+            try {
+                expect(3)
+                channel.receive()
+                expectUnreached()
+            } catch (e: ClosedReceiveChannelException) {
+                expect(6)
+            }
+        }
+
+        expect(1)
+        yield()
+        expect(4)
+        channel.close()
+        yield()
+        finish(7)
+    }
+
+    @Test
     fun testAssociate() = runTest {
         assertEquals(testList.associate { it * 2 to it * 3 },
             testList.asReceiveChannel().associate { it * 2 to it * 3 }.toMap())


### PR DESCRIPTION
We cannot resume closed receives until all receivers are removed from the list.
Consider channel state: head -> [receive_1] -> [receive_2] -> head
 - T1 called receive_2, and will call send() when it's receive call resumes
 - T2 calls close()

Now if T2's close resumes T1's receive_2 then it's receive gets
"closed for receive" exception, but its subsequent attempt to send
successfully rendezvous with receive_1, producing non-linearizable
execution.