### PR TITLE
Simpler and faster lock-free linked list

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/ConflatedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedChannel.kt
@@ -7,12 +7,12 @@ package kotlinx.coroutines.channels
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.*
-import kotlin.native.concurrent.SharedImmutable
+import kotlin.native.concurrent.*
 
 /**
  * Channel that buffers at most one element and conflates all subsequent `send` and `offer` invocations,
  * so that the receiver always gets the most recently sent element.
- * Back-to-send sent elements are _conflated_ -- only the the most recently sent element is received,
+ * Back-to-send sent elements are _conflated_ -- only the most recently sent element is received,
  * while previously sent elements **are lost**.
  * Sender to this channel never suspends and [offer] always returns `true`.
  *

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
+import org.junit.*
 import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
@@ -43,12 +44,20 @@ class ChannelSendReceiveStressTest(
     private val receivedTotal = AtomicInteger()
     private val receivedBy = IntArray(nReceivers)
 
+    private val pool =
+        newFixedThreadPoolContext(nSenders + nReceivers, "ChannelSendReceiveStressTest")
+
+    @After
+    fun tearDown() {
+        pool.close()
+    }
+
     @Test
     fun testSendReceiveStress() = runBlocking {
         println("--- ChannelSendReceiveStressTest $kind with nSenders=$nSenders, nReceivers=$nReceivers")
         val receivers = List(nReceivers) { receiverIndex ->
             // different event receivers use different code
-            launch(Dispatchers.Default + CoroutineName("receiver$receiverIndex")) {
+            launch(pool + CoroutineName("receiver$receiverIndex")) {
                 when (receiverIndex % 5) {
                     0 -> doReceive(receiverIndex)
                     1 -> doReceiveOrNull(receiverIndex)
@@ -60,7 +69,7 @@ class ChannelSendReceiveStressTest(
             }
         }
         val senders = List(nSenders) { senderIndex ->
-            launch(Dispatchers.Default + CoroutineName("sender$senderIndex")) {
+            launch(pool + CoroutineName("sender$senderIndex")) {
                 when (senderIndex % 2) {
                     0 -> doSend(senderIndex)
                     1 -> doSendSelect(senderIndex)


### PR DESCRIPTION
Lock-free list implementation is considerably simplified, taking into
account a limited number of operations that it needs to support.

* prev pointers in the list are not marked for removal, since we
  don't need to support linearizable backwards iteration.
* helpDelete method is completely removed. All "delete-helping" is
  performed only by correctPrev method.
* correctPrev method bails out when the node it works on is removed to
  reduce contention during concurrent removals.
* Special open methods "isRemoved" and "nextIfRemoved" are introduced
  and are overriden in list head class (which is never removed).
  This ensures that on long list "removeFist" operation (touching head)
  does not interfere with "addLast" (touch tail). There is still
  sharing of cache-lines in this case, but no helping between them.

All in all, this improvement reduces the size of implementation code
and makes it considerably faster. Operations on LinkedListChannel are
now much faster (see timings of ChannelSendReceiveStressTest).