### PR TITLE
Fix ArrayChannel.isBufferEmpty atomicity

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
@@ -43,7 +43,7 @@ internal open class ArrayChannel<E>(
         set(value) { _size.value = value }
 
     protected final override val isBufferAlwaysEmpty: Boolean get() = false
-    protected final override val isBufferEmpty: Boolean get() = size == 0
+    protected final override val isBufferEmpty: Boolean get() = lock.withLock { size == 0 }
     protected final override val isBufferAlwaysFull: Boolean get() = false
     protected final override val isBufferFull: Boolean get() = size == capacity
 


### PR DESCRIPTION
The following incorrect execution with parallel `offerInternal` and `isClosedForReceive` may occur:

1.  `offerInternal` increments `size`
2. `isClosedForReceive` reads `size == 1` and returns `false`, while the channel is closed and the buffer is actually empty
3. `offerInternal` detects that the channel is closed
4. `offerInternal` reverts `size` to the previous value (decrements)

Thus, `isClosedForReceive` can read an intermediate `size` state, and return incorrect results. To fix this, `isClosedForReceive` and `offerInternal` should not interfere.

Hopefully, this change also fixes #1526.