### PR TITLE
Make MapTest - testErrorCancelsUpstream - actually test map operator

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/MapTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/MapTest.kt
@@ -37,8 +37,9 @@ class MapTest : TestBase() {
                     hang { cancelled = true }
                 }
                 emit(1)
+                expectUnreached()
             }
-        }.onEach {
+        }.map<Int, Int> {
             latch.receive()
             throw TestException()
         }.catch { emit(42) }


### PR DESCRIPTION
We were testing onEach {} instead of map {} operator there.