### PR TITLE
Fix race in channel select/cancel

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
@@ -399,7 +399,7 @@ public actual open class LockFreeLinkedListNode {
 
         // Returns REMOVE_PREPARED or null (it makes decision on any failure)
         override fun perform(affected: Any?): Any? {
-            assert(affected === this.affected)
+            assert { affected === this.affected }
             affected as Node // type assertion
             val decision = desc.onPrepare(this)
             if (decision === REMOVE_PREPARED) {


### PR DESCRIPTION
This bug was introduced by PR #1524. It was reproducing when there
is a regular "send" operation on one side of a channel and
"select { onReceive }" on another side of the channel and the
"send" coroutine gets cancelled. The problem is that
SendElement.tryResumeSend implementation was calling finishPrepare
before it has successfully resumed continuation, so if that
continuation was already cancelled, the code in "finishPrepare" had
already stored the wrong affected node which it would later try to
call "completeResume" on.

This patch also adds hexAddress to the debug toString method of
all internal node classes in channel implementation.

Fixes #1588