### PR TITLE
Typo in CoroutineScope's javadoc

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -181,7 +181,7 @@ public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R 
  * Creates a [CoroutineScope] that wraps the given coroutine [context].
  *
  * If the given [context] does not contain a [Job] element, then a default `Job()` is created.
- * This way, cancellation or failure or any child coroutine in this scope cancels all the other children,
+ * This way, cancellation or failure of any child coroutine in this scope cancels all the other children,
  * just like inside [coroutineScope] block.
  */
 @Suppress("FunctionName")


### PR DESCRIPTION
Seems like a javadoc points that all other children would be cancelled in case any other child coroutine would be cancelled or failed. Changed javadoc accordingly.