### PR TITLE
Get rid of deprecated FlowCollector<*>.withContext

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-core.txt
@@ -969,7 +969,6 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun transform (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun transformLatest (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun unsafeTransform (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun withContext (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
 	public static final fun withIndex (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun zip (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 }

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -708,17 +708,15 @@ fun main() = runBlocking<Unit> {
 
 This code produces the following exception:
 
-<!--- TEST EXCEPTION
+```text
 Exception in thread "main" java.lang.IllegalStateException: Flow invariant is violated:
 		Flow was collected in [CoroutineId(1), "coroutine#1":BlockingCoroutine{Active}@5511c7f8, BlockingEventLoop@2eac3323],
 		but emission happened in [CoroutineId(1), "coroutine#1":DispatchedCoroutine{Active}@2dae0000, DefaultDispatcher].
 		Please refer to 'flow' documentation or use 'flowOn' instead
 	at ...
--->
-   
-> Note that we had to use a fully qualified name of the [kotlinx.coroutines.withContext][withContext] function in this example to 
-demonstrate this exception. A short name of `withContext` would have resolved to a special stub function that
-produces a compilation error to prevent us from running into this problem.   
+``` 
+
+<!--- TEST EXCEPTION -->
 
 #### flowOn operator
    

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -127,14 +127,6 @@ public fun <T> Flow<T>.onErrorResume(fallback: Flow<T>): Flow<T> = noImpl()
 public fun <T> Flow<T>.onErrorResumeNext(fallback: Flow<T>): Flow<T> = noImpl()
 
 /**
- * Self-explanatory, the reason of deprecation is "context preservation" property (you can read more in [Flow] documentation)
- * @suppress
- **/
-@Suppress("UNUSED_PARAMETER", "UNUSED", "DeprecatedCallableAddReplaceWith")
-@Deprecated(message = "withContext in flow body is deprecated, use flowOn instead", level = DeprecationLevel.ERROR)
-public fun <T, R> FlowCollector<T>.withContext(context: CoroutineContext, block: suspend () -> R): Unit = noImpl()
-
-/**
  * `subscribe` is Rx-specific API that has no direct match in flows.
  * One can use [launchIn] instead, for example the following:
  * ```

--- a/kotlinx-coroutines-core/common/test/flow/FlowInvariantsTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/FlowInvariantsTest.kt
@@ -40,22 +40,22 @@ class FlowInvariantsTest : TestBase() {
     @Test
     fun testWithContextContract() = runParametrizedTest<Int>(IllegalStateException::class) { flow ->
         flow {
-            kotlinx.coroutines.withContext(NonCancellable) {
+            withContext(NonCancellable) {
                 emit(1)
             }
         }.collect {
-            assertEquals(1, it)
+            expectUnreached()
         }
     }
 
     @Test
     fun testWithDispatcherContractViolated() = runParametrizedTest<Int>(IllegalStateException::class) { flow ->
         flow {
-            kotlinx.coroutines.withContext(NamedDispatchers("foo")) {
+            withContext(NamedDispatchers("foo")) {
                 emit(1)
             }
         }.collect {
-            fail()
+            expectUnreached()
         }
     }
 
@@ -63,16 +63,14 @@ class FlowInvariantsTest : TestBase() {
     fun testCachedInvariantCheckResult() = runParametrizedTest<Int> { flow ->
         flow {
             emit(1)
-
             try {
-                kotlinx.coroutines.withContext(NamedDispatchers("foo")) {
+                withContext(NamedDispatchers("foo")) {
                     emit(1)
                 }
                 fail()
             } catch (e: IllegalStateException) {
                 expect(2)
             }
-
             emit(3)
         }.collect {
             expect(it)
@@ -83,11 +81,11 @@ class FlowInvariantsTest : TestBase() {
     @Test
     fun testWithNameContractViolated() = runParametrizedTest<Int>(IllegalStateException::class) { flow ->
         flow {
-            kotlinx.coroutines.withContext(CoroutineName("foo")) {
+            withContext(CoroutineName("foo")) {
                 emit(1)
             }
         }.collect {
-            fail()
+            expectUnreached()
         }
     }
 
@@ -107,7 +105,6 @@ class FlowInvariantsTest : TestBase() {
                     }
                 }.join()
         }
-
         assertEquals("original", result)
     }
 
@@ -116,7 +113,6 @@ class FlowInvariantsTest : TestBase() {
         flow { emit(1) }.buffer(EmptyCoroutineContext, flow).collect {
             expect(1)
         }
-
         finish(2)
     }
 
@@ -125,7 +121,6 @@ class FlowInvariantsTest : TestBase() {
         flow { emit(1) }.buffer(Dispatchers.Unconfined, flow).collect {
             expect(1)
         }
-
         finish(2)
     }
 


### PR DESCRIPTION
This migration was motivated by the limited invariant preservation check, which is now more advanced; Additionally, such migration prohibits meaningful use-cases like "compute value in encapsulated context and then emit in flow context"

Fixes #1616