### PR TITLE
TestCoroutineDispatcher Intentional Time Skew

### DIFF
--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -189,7 +189,7 @@ Parent is not cancelled
 
 <!--- TEST-->
 
-If a coroutine encounters exception other than `CancellationException`, it cancels its parent with that exception. 
+If a coroutine encounters an exception other than `CancellationException`, it cancels its parent with that exception. 
 This behaviour cannot be overridden and is used to provide stable coroutines hierarchies for
 [structured concurrency](https://github.com/Kotlin/kotlinx.coroutines/blob/master/docs/composing-suspending-functions.md#structured-concurrency-with-async) which do not depend on 
 [CoroutineExceptionHandler] implementation.

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -708,13 +708,15 @@ fun main() = runBlocking<Unit> {
 
 This code produces the following exception:
 
-<!--- TEST EXCEPTION
+```text
 Exception in thread "main" java.lang.IllegalStateException: Flow invariant is violated:
 		Flow was collected in [CoroutineId(1), "coroutine#1":BlockingCoroutine{Active}@5511c7f8, BlockingEventLoop@2eac3323],
 		but emission happened in [CoroutineId(1), "coroutine#1":DispatchedCoroutine{Active}@2dae0000, DefaultDispatcher].
 		Please refer to 'flow' documentation or use 'flowOn' instead
 	at ...
--->
+``` 
+
+<!--- TEST EXCEPTION -->
    
 > Note that we had to use a fully qualified name of the [kotlinx.coroutines.withContext][withContext] function in this example to 
 demonstrate this exception. A short name of `withContext` would have resolved to a special stub function that

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -82,7 +82,7 @@ public class TestCoroutineDispatcher(val random: Random? = null, val standardDev
     }
 
     private fun post(block: Runnable) =
-        queue.addLast(TimedRunnable(block, _counter.getAndIncrement()))
+        postDelayed(block, 0)
 
     private fun postDelayed(block: Runnable, delayTime: Long) =
         TimedRunnable(block, _counter.getAndIncrement(), safePlus(currentTime,

--- a/kotlinx-coroutines-test/src/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineScope.kt
@@ -5,6 +5,7 @@
 package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
+import java.util.*
 import kotlin.coroutines.*
 
 /**
@@ -46,9 +47,11 @@ private class TestCoroutineScopeImpl (
  */
 @Suppress("FunctionName")
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
-public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext): TestCoroutineScope {
+public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext,
+                              random: Random? = null,
+                              standardDeviationNanos: Long? = null): TestCoroutineScope {
     var safeContext = context
-    if (context[ContinuationInterceptor] == null) safeContext += TestCoroutineDispatcher()
+    if (context[ContinuationInterceptor] == null) safeContext += TestCoroutineDispatcher(random,standardDeviationNanos)
     if (context[CoroutineExceptionHandler] == null) safeContext += TestCoroutineExceptionHandler()
     return TestCoroutineScopeImpl(safeContext)
 }

--- a/kotlinx-coroutines-test/src/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineScope.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.*
 
 /**
@@ -49,9 +50,11 @@ private class TestCoroutineScopeImpl (
 @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext,
                               random: Random? = null,
-                              standardDeviationNanos: Long? = null): TestCoroutineScope {
+                              standardDeviation: Long? = null,
+                              standardDeviationUnit: TimeUnit? = null): TestCoroutineScope {
     var safeContext = context
-    if (context[ContinuationInterceptor] == null) safeContext += TestCoroutineDispatcher(random,standardDeviationNanos)
+    if (context[ContinuationInterceptor] == null) safeContext +=
+            TestCoroutineDispatcher(random,standardDeviation,standardDeviationUnit)
     if (context[CoroutineExceptionHandler] == null) safeContext += TestCoroutineExceptionHandler()
     return TestCoroutineScopeImpl(safeContext)
 }

--- a/kotlinx-coroutines-test/test/TestConcurrentCounterTest.kt
+++ b/kotlinx-coroutines-test/test/TestConcurrentCounterTest.kt
@@ -1,0 +1,206 @@
+package kotlinx.coroutines.test
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.selects.select
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.security.NoSuchAlgorithmException
+import java.security.SecureRandom
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class TestConcurrentCounterTest {
+
+    /*
+     This coroutine is a storage location.
+     */
+    fun CoroutineScope.launchRegister(
+            readChannel: ReceiveChannel<CompletableDeferred<Int>>,
+            writeChannel: ReceiveChannel<Int>
+    ): Job = launch {
+        var storageLocation: Int = 0
+        while (true)
+            select<Unit> {
+                readChannel.onReceive {
+                    it.complete(storageLocation)
+                }
+                writeChannel.onReceive {
+                    storageLocation = it
+                }
+            }
+    }
+
+    /*
+     This coroutine does read-increment-write. It's buggy!
+     */
+    fun CoroutineScope.launchIncrementer(
+            n: Int,
+            writeChannel: SendChannel<Int>,
+            readChannel: SendChannel<CompletableDeferred<Int>>): Job = launch {
+        repeat(n) {
+            val futureValue = CompletableDeferred<Int>()
+            readChannel.send(futureValue)
+            val oldValue = futureValue.await()
+            val newValue = oldValue + 1
+            writeChannel.send(newValue)
+        }
+    }
+
+    /*
+     Run the nondeterministic test N times to demonstrate its nondeterminism.
+     In my experiments, this test usually fails, but you can't be sure it will _always_ do so.
+     */
+    @Test
+    fun nondeterministicTestN() = runBlocking {
+
+        val readChannel = Channel<CompletableDeferred<Int>>()
+        val writeChannel = Channel<Int>()
+
+        var successes = 0
+        val N = 100
+
+        repeat(N) {
+            if (nondeterministicTestOnce(readChannel, writeChannel))
+                successes++
+        }
+        assertEquals(N, successes)
+    }
+
+    /*
+     This nondeterministic "test" is obviously flaky. It sometimes returns true and other times
+     returns false (indicating that the "unit under test" failed).
+     The "unit under test" (the incrementer coroutines interacting with the register one)
+     is obviously buggy. We'd like a test that flags the a failure every time it's run.
+     */
+    private suspend fun nondeterministicTestOnce(readChannel: Channel<CompletableDeferred<Int>>, writeChannel: Channel<Int>): Boolean {
+
+        val result: Boolean
+
+        val register: Job
+
+        with(GlobalScope) {
+            register = launchRegister(readChannel, writeChannel)
+            val a = launchIncrementer(1, writeChannel, readChannel)
+            val b = launchIncrementer(1, writeChannel, readChannel)
+            joinAll(a, b)
+        }
+
+        val futureVal = CompletableDeferred<Int>()
+        readChannel.send(futureVal)
+
+        result = futureVal.await() == 2
+
+        register.cancelAndJoin()
+
+        return result
+    }
+
+    /*
+     Here is the corresponding deterministic test. It always passes, which is unfortunate
+     since the "unit under test" is buggy, as (usually) demonstrated  by the nondeterministic
+     test above.
+     */
+    @Test
+    fun deterministicTestN() = runBlockingTest {
+        val readChannel = Channel<CompletableDeferred<Int>>()
+        val writeChannel = Channel<Int>()
+
+        var successes = 0
+        val N = 100
+
+        repeat(N) {
+            if (deterministicTestOnce(readChannel, writeChannel))
+                successes++
+        }
+        assertEquals(N, successes)
+    }
+
+    private suspend fun TestCoroutineScope.deterministicTestOnce(
+            readChannel: Channel<CompletableDeferred<Int>>,
+            writeChannel: Channel<Int>): Boolean {
+
+        val register = launchRegister(readChannel, writeChannel)
+        val a = launchIncrementer(1, writeChannel, readChannel)
+        val b = launchIncrementer(1, writeChannel, readChannel)
+
+        joinAll(a, b)
+        advanceUntilIdle()
+
+        val futureVal = CompletableDeferred<Int>()
+        readChannel.send(futureVal)
+
+        advanceUntilIdle()
+
+        return (futureVal.await() == 2).also {
+            register.cancelAndJoin()
+        }
+    }
+
+    /*
+     This deterministic test uses the proposed settings on TestCoroutineScope
+     to establish a TestCoroutineDispatcher that skews scheduled run-times for
+     tasks.
+
+     This test operates in two different modes depending on the exploreInterleavings
+     parameter on createRandom(). When that's true, each call to createRandom() uses
+     a new seed derived from the system clock. When it's false, the value of the
+     trySeed parameter is used as the seed to "lock down" the pseudo-random number
+     generator.
+     */
+    @Test
+    fun deterministicInaccurateDispatcherTestN() {
+        val readChannel = Channel<CompletableDeferred<Int>>()
+        val writeChannel = Channel<Int>()
+
+        var successes = 0
+        val N = 100
+
+        repeat(N) {
+            // lock the PRNG down to a value that always passes
+            val random = createRandom(418_996_022_289_704L, false)
+            // alternately, have createRandom() use a new seed derived from the system clock
+//            val random = createRandom(418_996_022_289_704L, true)
+            val testCoroutineScope =
+                    TestCoroutineScope(
+                            random = random,
+                            standardDeviation = 10,
+                            standardDeviationUnit = TimeUnit.MILLISECONDS)
+            testCoroutineScope.runBlockingTest {
+                pauseDispatcher() {
+                    if (deterministicTestOnce(readChannel, writeChannel)) {
+                        if (deterministicTestOnce(readChannel, writeChannel)) {
+                            successes++
+                            println("success!")
+                        }
+                    }
+                }
+            }
+        }
+        assertEquals(N, successes)
+    }
+
+    fun createRandom(trySeed: Long, exploreInterleavings: Boolean): Random {
+
+        val actualSeed: Long
+
+        if (exploreInterleavings)
+            actualSeed = System.nanoTime()
+        else
+            actualSeed = trySeed
+
+        println(String.format("using seed %,d", actualSeed))
+
+        try {
+            return SecureRandom.getInstance("SHA1PRNG").also {
+                it.setSeed(actualSeed)
+            }
+        } catch (e: NoSuchAlgorithmException) {
+            throw AssertionError(e)
+        }
+
+    }
+
+}

--- a/kotlinx-coroutines-test/test/TestConcurrentCounterTest.kt
+++ b/kotlinx-coroutines-test/test/TestConcurrentCounterTest.kt
@@ -159,10 +159,17 @@ class TestConcurrentCounterTest {
         val N = 100
 
         repeat(N) {
+
             // lock the PRNG down to a value that always passes
-            val random = createRandom(418_996_022_289_704L, false)
+//            val random = createRandom(418_996_022_289_704L, false)
+
+            // lock the PRNG down to a value that always FAILS
+            val random = createRandom(420_864_149_765_280L, false)
+
             // alternately, have createRandom() use a new seed derived from the system clock
+            // this is useful for exploring various interleavings
 //            val random = createRandom(418_996_022_289_704L, true)
+
             val testCoroutineScope =
                     TestCoroutineScope(
                             random = random,
@@ -171,10 +178,8 @@ class TestConcurrentCounterTest {
             testCoroutineScope.runBlockingTest {
                 pauseDispatcher() {
                     if (deterministicTestOnce(readChannel, writeChannel)) {
-                        if (deterministicTestOnce(readChannel, writeChannel)) {
-                            successes++
-                            println("success!")
-                        }
+                        successes++
+                        println("success!")
                     }
                 }
             }


### PR DESCRIPTION
TestCoroutineDispatcher always picks the same interleaving of concurrent tasks. This is good since it is deterministic. But it is bad because there is no way to explore other interleavings (run order) of the tasks.

If TestCoroutineDispatcher could explore different interleavings, more bugs could be found. The challenge is to add the exploration ability without losing determinism.

This draft PR (for issue #1630) adds a test `TestConcurrentCounterTest.kt`. The test sets up a coroutine that acts an integer register. Then it runs a couple "incrementer" coroutines to read-modify-write to that "register" (through channels). Of course this read-modify-write approach is classically wrong and leads to "lost updates" under certain interleavings. The purpose of the various `@Test` functions in that file, is to show:

1. that a nondeterministic test often finds the bug (see `nondeterministicTestN()`)
2. a deterministic test using the built-in `TestCoroutineDispatcher` behavior (before the proposed changes) fails to find the bug&mdash;the test _passes_ every time (see `deterministicTestN()`)
3. a deterministic test using the simplest-possible change to `TestCoroutineDispatcher` that finds the bug&mdash;the test _fails_ every time (see `deterministicInaccurateDispatcherTestN()`)

That simplest-possible change to `TestCoroutineDispatcher` is to introduce random time "skew" into `postDelayed()` and `post()`. The randomness is driven by a pseudo-random number generator injected through the `TestCoroutineScope` constructor.

If you look at `deterministicInaccurateDispatcherTestN()` you'll see that this arrangement lets us explore different random seeds to give us various task interleavings. When we find an interleaving we want to replay we can "lock it down". You might imagine budgeting a certain amount of test resources for this exploration. When "troublesome" interleavings were identified we might record them as part of a regression test suite.

## Related Work

This work was inspired by the work of the FoundationDB folks. See Will Wilson's 2014 Strange Loop talk _Testing Distributed Systems w/ Deterministic Simulation_ https://www.youtube.com/watch?v=4fFDFbi3toc

See the FoundationDB page on _Simulation and Testing_: https://apple.github.io/foundationdb/testing.html#

See Carl Lerche's October, 2019 blog post _Making the Tokio scheduler 10x faster_ https://tokio.rs/blog/2019-10-scheduler/ Specifically the _Fearless (unsafe) concurrency with Loom_ section https://tokio.rs/blog/2019-10-scheduler/#fearless-unsafe-concurrency-with-loom Loom is a "a permutation testing tool for concurrent code" for Rust programs.

## Opportunities for Improvement

The approach offered in this PR is intentionally minimalistic. It could be refactored so that different (interleaving) exploration mechanisms and policies could be tried.

One such policy that might be interesting to explore is dynamic partial-order reduction described here https://users.soe.ucsc.edu/~cormac/papers/popl05.pdf and used in Lerche's Loom (mentioned above).
