### PR TITLE
Consistently handle undeliverable exceptions in RxJava and Reactor in…

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-reactive.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-reactive.txt
@@ -42,11 +42,11 @@ public final class kotlinx/coroutines/reactive/PublishKt {
 	public static final fun publish (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 	public static synthetic fun publish$default (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/reactivestreams/Publisher;
 	public static synthetic fun publish$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/reactivestreams/Publisher;
-	public static final fun publishInternal (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
+	public static final fun publishInternal (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 }
 
 public final class kotlinx/coroutines/reactive/PublisherCoroutine : kotlinx/coroutines/AbstractCoroutine, kotlinx/coroutines/channels/ProducerScope, kotlinx/coroutines/selects/SelectClause2, org/reactivestreams/Subscription {
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lorg/reactivestreams/Subscriber;)V
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lorg/reactivestreams/Subscriber;Lkotlin/jvm/functions/Function2;)V
 	public fun cancel ()V
 	public fun close (Ljava/lang/Throwable;)Z
 	public fun getChannel ()Lkotlinx/coroutines/channels/SendChannel;

--- a/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.coroutines.reactor
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.reactive.*
 import org.hamcrest.core.*
 import org.junit.*
@@ -129,5 +130,16 @@ class FluxTest : TestBase() {
     @Test
     fun testIllegalArgumentException() {
         assertFailsWith<IllegalArgumentException> { flux<Int>(Job()) { } }
+    }
+
+    @Test
+    fun testLeakedException() = runBlocking {
+        // Test exception is not reported to global handler
+        val flow = flux<Unit> { throw TestException() }.asFlow()
+        repeat(2000) {
+            combine(flow, flow) { _, _ -> Unit }
+                .catch {}
+                .collect { }
+        }
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxCancellable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxCancellable.kt
@@ -5,10 +5,21 @@
 package kotlinx.coroutines.rx2
 
 import io.reactivex.functions.*
+import io.reactivex.plugins.*
 import kotlinx.coroutines.*
+import kotlin.coroutines.*
 
 internal class RxCancellable(private val job: Job) : Cancellable {
     override fun cancel() {
         job.cancel()
+    }
+}
+
+internal fun handleUndeliverableException(cause: Throwable, context: CoroutineContext) {
+    if (cause is CancellationException) return // Async CE should be completely ignored
+    try {
+        RxJavaPlugins.onError(cause)
+    } catch (e: Throwable) {
+        handleCoroutineException(context, cause)
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
@@ -94,9 +94,13 @@ public fun <T: Any> Flow<T>.asObservable() : Observable<T> = Observable.create {
             emitter.onComplete()
         } catch (e: Throwable) {
             // 'create' provides safe emitter, so we can unconditionally call on* here if exception occurs in `onComplete`
-            if (e !is CancellationException) emitter.onError(e)
-            else emitter.onComplete()
-
+            if (e !is CancellationException) {
+                if (!emitter.tryOnError(e)) {
+                    handleUndeliverableException(e, coroutineContext)
+                }
+            } else {
+                emitter.onComplete()
+            }
         }
     }
     emitter.setCancellable(RxCancellable(job))

--- a/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
@@ -16,16 +16,14 @@ import kotlin.internal.*
 /**
  * Creates cold [flowable][Flowable] that will run a given [block] in a coroutine.
  * Every time the returned flowable is subscribed, it starts a new coroutine.
- * Coroutine emits items with `send`. Unsubscribing cancels running coroutine.
+ *
+ * Coroutine emits ([ObservableEmitter.onNext]) values with `send`, completes ([ObservableEmitter.onComplete])
+ * when the coroutine completes or channel is explicitly closed and emits error ([ObservableEmitter.onError])
+ * if coroutine throws an exception or closes channel with a cause.
+ * Unsubscribing cancels running coroutine.
  *
  * Invocations of `send` are suspended appropriately when subscribers apply back-pressure and to ensure that
  * `onNext` is not invoked concurrently.
- *
- * | **Coroutine action**                         | **Signal to subscriber**
- * | -------------------------------------------- | ------------------------
- * | `send`                                       | `onNext`
- * | Normal completion or `close` without cause   | `onComplete`
- * | Failure with exception or `close` with cause | `onError`
  *
  * Coroutine context can be specified with [context] argument.
  * If the context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
@@ -40,7 +38,7 @@ public fun <T: Any> rxFlowable(
 ): Flowable<T> {
     require(context[Job] === null) { "Flowable context cannot contain job in it." +
             "Its lifecycle should be managed via Disposable handle. Had $context" }
-    return Flowable.fromPublisher(publishInternal(GlobalScope, context, block))
+    return Flowable.fromPublisher(publishInternal(GlobalScope, context, RX_HANDLER, block))
 }
 
 @Deprecated(
@@ -52,4 +50,6 @@ public fun <T: Any> rxFlowable(
 public fun <T: Any> CoroutineScope.rxFlowable(
     context: CoroutineContext = EmptyCoroutineContext,
     @BuilderInference block: suspend ProducerScope<T>.() -> Unit
-): Flowable<T> = Flowable.fromPublisher(publishInternal(this, context, block))
+): Flowable<T> = Flowable.fromPublisher(publishInternal(this, context, RX_HANDLER, block))
+
+private val RX_HANDLER: (Throwable, CoroutineContext) -> Unit = ::handleUndeliverableException

--- a/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
@@ -12,16 +12,10 @@ import kotlin.coroutines.*
 import kotlin.internal.*
 
 /**
- * Creates cold [maybe][Maybe] that will run a given [block] in a coroutine.
+ * Creates cold [maybe][Maybe] that will run a given [block] in a coroutine and emits its result.
+ * If [block] result is `null`, [onComplete][MaybeObserver.onComplete] is invoked without a value.
  * Every time the returned observable is subscribed, it starts a new coroutine.
- * Coroutine returns a single, possibly null value. Unsubscribing cancels running coroutine.
- *
- * | **Coroutine action**                  | **Signal to subscriber**
- * | ------------------------------------- | ------------------------
- * | Returns a non-null value              | `onSuccess`
- * | Returns a null                        | `onComplete`
- * | Failure with exception or unsubscribe | `onError`
- *
+ * Unsubscribing cancels running coroutine.
  * Coroutine context can be specified with [context] argument.
  * If the context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
  * Method throws [IllegalArgumentException] if provided [context] contains a [Job] instance.
@@ -62,24 +56,20 @@ private class RxMaybeCoroutine<T>(
     private val subscriber: MaybeEmitter<T>
 ) : AbstractCoroutine<T>(parentContext, true) {
     override fun onCompleted(value: T) {
-        if (!subscriber.isDisposed) {
-            try {
-                if (value == null) subscriber.onComplete() else subscriber.onSuccess(value)
-            } catch(e: Throwable) {
-                handleCoroutineException(context, e)
-            }
+        try {
+            if (value == null) subscriber.onComplete() else subscriber.onSuccess(value)
+        } catch (e: Throwable) {
+            handleUndeliverableException(e, context)
         }
     }
 
     override fun onCancelled(cause: Throwable, handled: Boolean) {
-        if (!subscriber.isDisposed) {
-            try {
-                subscriber.onError(cause)
-            } catch (e: Throwable) {
-                handleCoroutineException(context, e)
+        try {
+            if (!subscriber.tryOnError(cause)) {
+                handleUndeliverableException(cause, context)
             }
-        } else if (!handled) {
-            handleCoroutineException(context, cause)
+        } catch (e: Throwable) {
+            handleUndeliverableException(e, context)
         }
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxScheduler.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxScheduler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.rx2
@@ -17,7 +17,6 @@ public fun Scheduler.asCoroutineDispatcher(): SchedulerCoroutineDispatcher = Sch
 
 /**
  * Implements [CoroutineDispatcher] on top of an arbitrary [Scheduler].
- * @param scheduler a scheduler.
  */
 public class SchedulerCoroutineDispatcher(
     /**

--- a/reactive/kotlinx-coroutines-rx2/test/Check.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/Check.kt
@@ -5,6 +5,8 @@
 package kotlinx.coroutines.rx2
 
 import io.reactivex.*
+import io.reactivex.functions.Consumer
+import io.reactivex.plugins.*
 
 fun <T> checkSingleValue(
     observable: Observable<T>,
@@ -64,3 +66,12 @@ fun checkErroneous(
     }
 }
 
+inline fun withExceptionHandler(noinline handler: (Throwable) -> Unit, block: () -> Unit) {
+    val original = RxJavaPlugins.getErrorHandler()
+    RxJavaPlugins.setErrorHandler { handler(it) }
+    try {
+        block()
+    } finally {
+        RxJavaPlugins.setErrorHandler(original)
+    }
+}

--- a/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.rx2
 
 import io.reactivex.*
 import io.reactivex.disposables.*
+import io.reactivex.exceptions.*
 import kotlinx.coroutines.*
 import org.hamcrest.core.*
 import org.junit.*
@@ -122,11 +123,11 @@ class CompletableTest : TestBase() {
     fun testUnhandledException() = runTest() {
         expect(1)
         var disposable: Disposable? = null
-        val eh = CoroutineExceptionHandler { _, t ->
-            assertTrue(t is TestException)
+        val handler = { e: Throwable ->
+            assertTrue(e is UndeliverableException && e.cause is TestException)
             expect(5)
         }
-        val completable = rxCompletable(currentDispatcher() + eh) {
+        val completable = rxCompletable(currentDispatcher()) {
             expect(4)
             disposable!!.dispose() // cancel our own subscription, so that delay will get cancelled
             try {
@@ -135,26 +136,40 @@ class CompletableTest : TestBase() {
                 throw TestException() // would not be able to handle it since mono is disposed
             }
         }
-        completable.subscribe(object : CompletableObserver {
-            override fun onSubscribe(d: Disposable) {
-                expect(2)
-                disposable = d
-            }
-            override fun onComplete() { expectUnreached() }
-            override fun onError(t: Throwable) { expectUnreached() }
-        })
-        expect(3)
-        yield() // run coroutine
-        finish(6)
+        withExceptionHandler(handler) {
+            completable.subscribe(object : CompletableObserver {
+                override fun onSubscribe(d: Disposable) {
+                    expect(2)
+                    disposable = d
+                }
+
+                override fun onComplete() {
+                    expectUnreached()
+                }
+
+                override fun onError(t: Throwable) {
+                    expectUnreached()
+                }
+            })
+            expect(3)
+            yield() // run coroutine
+            finish(6)
+        }
     }
 
     @Test
     fun testFatalExceptionInSubscribe() = runTest {
-        rxCompletable(Dispatchers.Unconfined + CoroutineExceptionHandler{ _, e -> assertTrue(e is LinkageError); expect(2)}) {
-            expect(1)
-            42
-        }.subscribe({ throw LinkageError() })
-        finish(3)
+        val handler: (Throwable) -> Unit = { e ->
+            assertTrue(e is UndeliverableException && e.cause is LinkageError); expect(2)
+        }
+
+        withExceptionHandler(handler) {
+            rxCompletable(Dispatchers.Unconfined) {
+                expect(1)
+                42
+            }.subscribe({ throw LinkageError() })
+            finish(3)
+        }
     }
 
     @Test

--- a/reactive/kotlinx-coroutines-rx2/test/FlowableExceptionHandlingTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowableExceptionHandlingTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines.rx2
 
+import io.reactivex.exceptions.*
 import kotlinx.coroutines.*
 import org.junit.*
 import org.junit.Test
@@ -16,15 +17,15 @@ class FlowableExceptionHandlingTest : TestBase() {
         ignoreLostThreads("RxComputationThreadPool-", "RxCachedWorkerPoolEvictor-", "RxSchedulerPurge-")
     }
 
-    private inline fun <reified T : Throwable> ceh(expect: Int) = CoroutineExceptionHandler { _, t ->
-        assertTrue(t is T)
+    private inline fun <reified T : Throwable> handler(expect: Int) = { t: Throwable ->
+        assertTrue(t is UndeliverableException && t.cause is T)
         expect(expect)
     }
 
     private fun cehUnreached() = CoroutineExceptionHandler { _, _ -> expectUnreached() }
 
     @Test
-    fun testException() = runTest {
+    fun testException() = withExceptionHandler({ expectUnreached() }) {
         rxFlowable<Int>(Dispatchers.Unconfined + cehUnreached()) {
             expect(1)
             throw TestException()
@@ -37,8 +38,8 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testFatalException() = runTest {
-        rxFlowable<Int>(Dispatchers.Unconfined + ceh<LinkageError>(3)) {
+    fun testFatalException() = withExceptionHandler(handler<LinkageError>(3)) {
+        rxFlowable<Int>(Dispatchers.Unconfined) {
             expect(1)
             throw LinkageError()
         }.subscribe({
@@ -50,7 +51,7 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testExceptionAsynchronous() = runTest {
+    fun testExceptionAsynchronous() = withExceptionHandler({ expectUnreached() }) {
         rxFlowable<Int>(Dispatchers.Unconfined + cehUnreached()) {
             expect(1)
             throw TestException()
@@ -65,8 +66,8 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testFatalExceptionAsynchronous() = runTest {
-        rxFlowable<Int>(Dispatchers.Unconfined + ceh<LinkageError>(3)) {
+    fun testFatalExceptionAsynchronous() = withExceptionHandler(handler<LinkageError>(3)) {
+        rxFlowable<Int>(Dispatchers.Unconfined) {
             expect(1)
             throw LinkageError()
         }.publish()
@@ -80,8 +81,8 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testFatalExceptionFromSubscribe() = runTest {
-        rxFlowable(Dispatchers.Unconfined + ceh<LinkageError>(4)) {
+    fun testFatalExceptionFromSubscribe() = withExceptionHandler(handler<LinkageError>(4)) {
+        rxFlowable(Dispatchers.Unconfined) {
             expect(1)
             send(Unit)
         }.subscribe({
@@ -92,7 +93,7 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testExceptionFromSubscribe() = runTest {
+    fun testExceptionFromSubscribe() = withExceptionHandler({ expectUnreached() }) {
         rxFlowable(Dispatchers.Unconfined + cehUnreached()) {
             expect(1)
             send(Unit)
@@ -104,7 +105,7 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testAsynchronousExceptionFromSubscribe() = runTest {
+    fun testAsynchronousExceptionFromSubscribe() = withExceptionHandler({ expectUnreached() }) {
         rxFlowable(Dispatchers.Unconfined + cehUnreached()) {
             expect(1)
             send(Unit)
@@ -118,8 +119,8 @@ class FlowableExceptionHandlingTest : TestBase() {
     }
 
     @Test
-    fun testAsynchronousFatalExceptionFromSubscribe() = runTest {
-        rxFlowable(Dispatchers.Unconfined + ceh<LinkageError>(3)) {
+    fun testAsynchronousFatalExceptionFromSubscribe() = withExceptionHandler(handler<LinkageError>(3)) {
+        rxFlowable(Dispatchers.Unconfined) {
             expect(1)
             send(Unit)
         }.publish()

--- a/reactive/kotlinx-coroutines-rx2/test/LeakedExceptionTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/LeakedExceptionTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.rx2
+
+import io.reactivex.*
+import io.reactivex.exceptions.*
+import io.reactivex.plugins.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.reactive.*
+import org.junit.Test
+import java.io.*
+import kotlin.test.*
+
+// Check that exception is not leaked to the global exception handler
+class LeakedExceptionTest : TestBase() {
+
+    private val handler: (Throwable) -> Unit =
+        { assertTrue { it is UndeliverableException && it.cause is TestException } }
+
+    @Test
+    fun testSingle() = withExceptionHandler(handler) {
+        val flow = rxSingle<Unit> { throw TestException() }.toFlowable().asFlow()
+        runBlocking {
+            repeat(10000) {
+                combine(flow, flow) { _, _ -> Unit }
+                    .catch {}
+                    .collect { }
+            }
+        }
+    }
+
+    @Test
+    fun testObservable() = withExceptionHandler(handler) {
+        val flow = rxObservable<Unit> { throw TestException() }.toFlowable(BackpressureStrategy.BUFFER).asFlow()
+        runBlocking {
+            repeat(10000) {
+                combine(flow, flow) { _, _ -> Unit }
+                    .catch {}
+                    .collect { }
+            }
+        }
+    }
+
+    @Test
+    fun testFlowable() = withExceptionHandler(handler) {
+        val flow = rxFlowable<Unit> { throw TestException() }.asFlow()
+        runBlocking {
+            repeat(10000) {
+                combine(flow, flow) { _, _ -> Unit }
+                    .catch {}
+                    .collect { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…tegrations

Use tryOnError in RxJava to make exception delivery check-and-act race free.
Deliver undeliverable exceptions via RxJavaPlugins instead of handleCoroutineException.
This is a deliberate choice for a multiple reasons:
    * When using Rx (whether with coroutines or not), undeliverable exceptions are inevitable and users should hook into RxJavaPlugins anyway. We don't want to force them using Rx-specific CoroutineExceptionHandler all over the place
    * Undeliverable exceptions provide additional helpful stacktrace and proper way to distinguish them from other unhandled exceptions
    * Be consistent with reactor where we don't have try*, thus cannot provide a completely consistent experience with CEH (at least, without wrapping all the subscribers)

Do the similar in Reactor integration, but without try*, Reactor does not have notion of undeliverable exceoptions and handles them via Operators.* on its own.

Also, get rid of ASCII tables that does not properly render in IDEA

Fixes #252
Fixes #1614