### PR TITLE
Throw NoSuchElementException instead of UnsupportedOperationException…

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
+++ b/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
@@ -15,7 +15,7 @@ import kotlin.jvm.*
 
 /**
  * Accumulates value starting with the first element and applying [operation] to current accumulator value and each element.
- * Throws [UnsupportedOperationException] if flow was empty.
+ * Throws [NoSuchElementException] if flow was empty.
  */
 @ExperimentalCoroutinesApi
 public suspend fun <S, T : S> Flow<T>.reduce(operation: suspend (accumulator: S, value: T) -> S): S {
@@ -30,7 +30,7 @@ public suspend fun <S, T : S> Flow<T>.reduce(operation: suspend (accumulator: S,
         }
     }
 
-    if (accumulator === NULL) throw UnsupportedOperationException("Empty flow can't be reduced")
+    if (accumulator === NULL) throw NoSuchElementException("Empty flow can't be reduced")
     @Suppress("UNCHECKED_CAST")
     return accumulator as S
 }

--- a/kotlinx-coroutines-core/common/test/flow/terminal/ReduceTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/terminal/ReduceTest.kt
@@ -23,7 +23,7 @@ class ReduceTest : TestBase() {
     @Test
     fun testEmptyReduce() = runTest {
         val flow = emptyFlow<Int>()
-        assertFailsWith<UnsupportedOperationException> { flow.reduce { acc, value -> value + acc } }
+        assertFailsWith<NoSuchElementException> { flow.reduce { acc, value -> value + acc } }
     }
 
     @Test
@@ -42,7 +42,7 @@ class ReduceTest : TestBase() {
     fun testReduceNulls() = runTest {
         assertNull(flowOf(null).reduce { _, value -> value })
         assertNull(flowOf(null, null).reduce { _, value -> value })
-        assertFailsWith<UnsupportedOperationException> { flowOf<Nothing?>().reduce { _, value -> value } }
+        assertFailsWith<NoSuchElementException> { flowOf<Nothing?>().reduce { _, value -> value } }
     }
 
     @Test


### PR DESCRIPTION
… in Flow.reduce

    * We can do it safely because reduce is still experimental
    * We will be consistent with stdlib (as soon as KT-33874 is implemented)