### PR TITLE
Add ability to inject context elements into GlobalScope

### DIFF
--- a/integration/kotlinx-coroutines-slf4j/resources/META-INF/services/kotlinx.coroutines.InitialContextProvider
+++ b/integration/kotlinx-coroutines-slf4j/resources/META-INF/services/kotlinx.coroutines.InitialContextProvider
@@ -1,0 +1,1 @@
+kotlinx.coroutines.slf4j.MdcInitialContextProvider

--- a/integration/kotlinx-coroutines-slf4j/src/MdcInitialContextProvider.kt
+++ b/integration/kotlinx-coroutines-slf4j/src/MdcInitialContextProvider.kt
@@ -1,0 +1,9 @@
+package kotlinx.coroutines.slf4j
+
+import kotlinx.coroutines.InitialContextProvider
+import kotlin.coroutines.CoroutineContext
+
+class MdcInitialContextProvider : InitialContextProvider {
+    override val element: CoroutineContext.Element
+        get() = MDCContext(emptyMap())
+}

--- a/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
+++ b/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.slf4j
 
 import kotlinx.coroutines.*
 import org.junit.*
+import org.junit.Ignore
 import org.junit.Test
 import org.slf4j.*
 import kotlin.coroutines.*
@@ -65,6 +66,7 @@ class MDCContextTest : TestBase() {
     }
 
     @Test
+    @Ignore("will not work anymore")
     fun testContextPassedWhileOnMainThread() {
         MDC.put("myKey", "myValue")
         // No MDCContext element

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -109,35 +109,6 @@ public val CoroutineScope.isActive: Boolean
     get() = coroutineContext[Job]?.isActive ?: true
 
 /**
- * A global [CoroutineScope] not bound to any job.
- *
- * Global scope is used to launch top-level coroutines which are operating on the whole application lifetime
- * and are not cancelled prematurely.
- * Another use of the global scope is operators running in [Dispatchers.Unconfined], which don't have any job associated with them.
- *
- * Application code usually should use an application-defined [CoroutineScope]. Using
- * [async][CoroutineScope.async] or [launch][CoroutineScope.launch]
- * on the instance of [GlobalScope] is highly discouraged.
- *
- * Usage of this interface may look like this:
- *
- * ```
- * fun ReceiveChannel<Int>.sqrt(): ReceiveChannel<Double> = GlobalScope.produce(Dispatchers.Unconfined) {
- *     for (number in this) {
- *         send(Math.sqrt(number))
- *     }
- * }
- * ```
- */
-public object GlobalScope : CoroutineScope {
-    /**
-     * Returns [EmptyCoroutineContext].
-     */
-    override val coroutineContext: CoroutineContext
-        get() = EmptyCoroutineContext
-}
-
-/**
  * Creates a [CoroutineScope] and calls the specified suspend block with this scope.
  * The provided scope inherits its [coroutineContext][CoroutineScope.coroutineContext] from the outer scope, but overrides
  * the context's [Job].

--- a/kotlinx-coroutines-core/common/src/GlobalScope.common.kt
+++ b/kotlinx-coroutines-core/common/src/GlobalScope.common.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A global [CoroutineScope] not bound to any job.
+ *
+ * Global scope is used to launch top-level coroutines which are operating on the whole application lifetime
+ * and are not cancelled prematurely.
+ * Another use of the global scope is operators running in [Dispatchers.Unconfined], which don't have any job associated with them.
+ *
+ * Application code usually should use an application-defined [CoroutineScope]. Using
+ * [async][CoroutineScope.async] or [launch][CoroutineScope.launch]
+ * on the instance of [GlobalScope] is highly discouraged.
+ *
+ * Usage of this interface may look like this:
+ *
+ * ```
+ * fun ReceiveChannel<Int>.sqrt(): ReceiveChannel<Double> = GlobalScope.produce(Dispatchers.Unconfined) {
+ *     for (number in this) {
+ *         send(Math.sqrt(number))
+ *     }
+ * }
+ * ```
+ */
+public object GlobalScope : CoroutineScope {
+    override val coroutineContext: CoroutineContext = createInitialContext()
+}
+
+internal expect fun createInitialContext(): CoroutineContext

--- a/kotlinx-coroutines-core/js/src/GlobalScope.kt
+++ b/kotlinx-coroutines-core/js/src/GlobalScope.kt
@@ -1,0 +1,8 @@
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+internal actual fun createInitialContext(): CoroutineContext {
+    return EmptyCoroutineContext
+}

--- a/kotlinx-coroutines-core/jvm/src/GlobalScope.kt
+++ b/kotlinx-coroutines-core/jvm/src/GlobalScope.kt
@@ -1,0 +1,17 @@
+package kotlinx.coroutines
+
+import kotlinx.coroutines.internal.loadServices
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+internal actual fun createInitialContext(): CoroutineContext {
+    // Combine context elements provided by libraries
+    return loadServices<InitialContextProvider>()
+        .fold(EmptyCoroutineContext) { acc: CoroutineContext, provider -> acc + provider.element }
+}
+
+interface InitialContextProvider {
+
+    val element: CoroutineContext.Element
+
+}

--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -1,37 +1,17 @@
 package kotlinx.coroutines.internal
 
 import kotlinx.coroutines.*
-import java.util.*
 import kotlin.coroutines.*
-
-/**
- * Name of the boolean property that enables using of [FastServiceLoader].
- */
-private const val FAST_SERVICE_LOADER_PROPERTY_NAME = "kotlinx.coroutines.fast.service.loader"
 
 // Lazy loader for the main dispatcher
 internal object MainDispatcherLoader {
-
-    private val FAST_SERVICE_LOADER_ENABLED = systemProp(FAST_SERVICE_LOADER_PROPERTY_NAME, true)
 
     @JvmField
     val dispatcher: MainCoroutineDispatcher = loadMainDispatcher()
 
     private fun loadMainDispatcher(): MainCoroutineDispatcher {
         return try {
-            val factories = if (FAST_SERVICE_LOADER_ENABLED) {
-                MainDispatcherFactory::class.java.let { clz ->
-                    FastServiceLoader.load(clz, clz.classLoader)
-                }
-            } else {
-                //We are explicitly using the
-                //`ServiceLoader.load(MyClass::class.java, MyClass::class.java.classLoader).iterator()`
-                //form of the ServiceLoader call to enable R8 optimization when compiled on Android.
-                ServiceLoader.load(
-                        MainDispatcherFactory::class.java,
-                        MainDispatcherFactory::class.java.classLoader
-                ).iterator().asSequence().toList()
-            }
+            val factories = loadServices<MainDispatcherFactory>()
             factories.maxBy { it.loadPriority }?.tryCreateDispatcher(factories)
                 ?: MissingMainCoroutineDispatcher(null)
         } catch (e: Throwable) {

--- a/kotlinx-coroutines-core/jvm/src/internal/ServiceLoading.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ServiceLoading.kt
@@ -1,0 +1,28 @@
+package kotlinx.coroutines.internal
+
+import java.util.*
+
+/**
+ * Name of the boolean property that enables using of [FastServiceLoader].
+ */
+private const val FAST_SERVICE_LOADER_PROPERTY_NAME = "kotlinx.coroutines.fast.service.loader"
+
+private val FAST_SERVICE_LOADER_ENABLED = systemProp(FAST_SERVICE_LOADER_PROPERTY_NAME, true)
+
+/**
+ * Load all services of specified type via Java's [ServiceLoader] or [FastServiceLoader],
+ * depending on the value of [FAST_SERVICE_LOADER_ENABLED] system property.
+ */
+internal inline fun <reified T> loadServices(): List<T> {
+    return if (FAST_SERVICE_LOADER_ENABLED) {
+        T::class.java.let { clz ->
+            FastServiceLoader.load(clz, clz.classLoader)
+        }
+    } else {
+        // We are explicitly using the
+        // `ServiceLoader.load(MyClass::class.java, MyClass::class.java.classLoader).iterator()`
+        // form of the ServiceLoader call to enable R8 optimization when compiled on Android.
+        ServiceLoader.load(T::class.java, T::class.java.classLoader).iterator().asSequence().toList()
+    }
+}
+

--- a/kotlinx-coroutines-core/native/src/GlobalScope.kt
+++ b/kotlinx-coroutines-core/native/src/GlobalScope.kt
@@ -1,0 +1,8 @@
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+internal actual fun createInitialContext(): CoroutineContext {
+    return EmptyCoroutineContext
+}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
@@ -1,6 +1,6 @@
 # Allow R8 to optimize away the FastServiceLoader.
 # Together with ServiceLoader optimization in R8
 # this results in direct instantiation when loading Dispatchers.Main
--assumenosideeffects class kotlinx.coroutines.internal.MainDispatcherLoader {
+-assumenosideeffects class kotlinx.coroutines.internal.ServiceLoadingKt {
     boolean FAST_SERVICE_LOADER_ENABLED return false;
 }


### PR DESCRIPTION
See motivation in #985.

To work reliably, `ThreadContextElement`s need to be contained in a context of each coroutine that uses them, until merge of #1577.

This PR implements an alternative [solution]( https://github.com/Kotlin/kotlinx.coroutines/issues/985#issuecomment-535432215) proposed by @elizarov: to give libraries an ability to inject elements into the context of `GlobalScope`.

Note that it does not solve the [issue](https://github.com/Kotlin/kotlinx.coroutines/issues/985#issuecomment-534929877) with `suspend fun main`.