### PR TITLE
Introduce DebugProbes.isInstalled method

### DIFF
--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-debug.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-debug.txt
@@ -15,6 +15,7 @@ public final class kotlinx/coroutines/debug/DebugProbes {
 	public final fun dumpCoroutinesInfo ()Ljava/util/List;
 	public final fun getSanitizeStackTraces ()Z
 	public final fun install ()V
+	public final fun isInstalled ()Z
 	public final fun jobToString (Lkotlinx/coroutines/Job;)Ljava/lang/String;
 	public final fun printJob (Lkotlinx/coroutines/Job;Ljava/io/PrintStream;)V
 	public static synthetic fun printJob$default (Lkotlinx/coroutines/debug/DebugProbes;Lkotlinx/coroutines/Job;Ljava/io/PrintStream;ILjava/lang/Object;)V

--- a/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -19,6 +19,7 @@ import kotlin.coroutines.*
  * Debug probes is a dynamic attach mechanism which installs multiple hooks into coroutines machinery.
  * It slows down all coroutine-related code, but in return provides a lot of diagnostic information, including
  * asynchronous stack-traces and coroutine dumps (similar to [ThreadMXBean.dumpAllThreads] and `jstack` via [DebugProbes.dumpCoroutines].
+ * All introspecting methods throw [IllegalStateException] if debug probes were not installed.
  *
  * Installed hooks:
  *
@@ -40,6 +41,11 @@ public object DebugProbes {
      * the first one and the last one to simplify diagnostic.
      */
     public var sanitizeStackTraces: Boolean = true
+
+    /**
+     * Determines whether debug probes were [installed][DebugProbes.install].
+     */
+    public val isInstalled: Boolean get() = DebugProbesImpl.isInstalled
 
     /**
      * Installs a [DebugProbes] instead of no-op stdlib probes by redefining

--- a/kotlinx-coroutines-debug/src/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-debug/src/internal/DebugProbesImpl.kt
@@ -29,7 +29,7 @@ internal object DebugProbesImpl {
     private val capturedCoroutines = HashSet<CoroutineOwner<*>>()
     @Volatile
     private var installations = 0
-    private val isInstalled: Boolean get() = installations > 0
+    internal val isInstalled: Boolean get() = installations > 0
     // To sort coroutines by creation order, used as unique id
     private var sequenceNumber: Long = 0
 


### PR DESCRIPTION
This method is required to simplify integration with IDEA during an arbitrary remote debugging session