### PR TITLE
Proguard rule to keep volatile name of SafeContinuation

### DIFF
--- a/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
@@ -8,3 +8,8 @@
 -keepclassmembernames class kotlinx.** {
     volatile <fields>;
 }
+
+# Same story for the standard library's SafeContinuation that also uses AtomicReferenceFieldUpdater
+-keepclassmembernames class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}


### PR DESCRIPTION
Fixes #1694