### PR TITLE
Fix non-linearizability in `ArrayChannel` while moving an element from the waiting queue to the buffer

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
@@ -36,34 +36,38 @@ internal open class ArrayChannel<E>(
      */
     private var buffer: Array<Any?> = arrayOfNulls<Any?>(min(capacity, 8))
     private var head: Int = 0
-    private var size = 0 // Invariant: size <= capacity
+    private val size = atomic(0) // Invariant: size <= capacity
 
     protected final override val isBufferAlwaysEmpty: Boolean get() = false
-    protected final override val isBufferEmpty: Boolean get() = lock.withLock { size == 0 }
+    protected final override val isBufferEmpty: Boolean get() = size.value == 0
     protected final override val isBufferAlwaysFull: Boolean get() = false
-    protected final override val isBufferFull: Boolean get() = lock.withLock { size == capacity }
+    protected final override val isBufferFull: Boolean get() = size.value == capacity
+
+    override val isFull: Boolean get() = lock.withLock { isFullImpl }
+    override val isEmpty: Boolean get() = lock.withLock { isEmptyImpl }
+    override val isClosedForReceive: Boolean get() = lock.withLock { super.isClosedForReceive }
 
     // result is `OFFER_SUCCESS | OFFER_FAILED | Closed`
     protected override fun offerInternal(element: E): Any {
         var receive: ReceiveOrClosed<E>? = null
         lock.withLock {
-            val size = this.size
+            val size = this.size.value
             closedForSend?.let { return it }
             if (size < capacity) {
                 // tentatively put element to buffer
-                this.size = size + 1 // update size before checking queue (!!!)
+                this.size.value = size + 1 // update size before checking queue (!!!)
                 // check for receivers that were waiting on empty queue
                 if (size == 0) {
                     loop@ while (true) {
                         receive = takeFirstReceiveOrPeekClosed() ?: break@loop // break when no receivers queued
                         if (receive is Closed) {
-                            this.size = size // restore size
+                            this.size.value = size // restore size
                             return receive!!
                         }
                         val token = receive!!.tryResumeReceive(element, null)
                         if (token != null) {
                             assert { token === RESUME_TOKEN }
-                            this.size = size // restore size
+                            this.size.value = size // restore size
                             return@withLock
                         }
                     }
@@ -84,11 +88,11 @@ internal open class ArrayChannel<E>(
     protected override fun offerSelectInternal(element: E, select: SelectInstance<*>): Any {
         var receive: ReceiveOrClosed<E>? = null
         lock.withLock {
-            val size = this.size
+            val size = this.size.value
             closedForSend?.let { return it }
             if (size < capacity) {
                 // tentatively put element to buffer
-                this.size = size + 1 // update size before checking queue (!!!)
+                this.size.value = size + 1 // update size before checking queue (!!!)
                 // check for receivers that were waiting on empty queue
                 if (size == 0) {
                     loop@ while (true) {
@@ -96,14 +100,14 @@ internal open class ArrayChannel<E>(
                         val failure = select.performAtomicTrySelect(offerOp)
                         when {
                             failure == null -> { // offered successfully
-                                this.size = size // restore size
+                                this.size.value = size // restore size
                                 receive = offerOp.result
                                 return@withLock
                             }
                             failure === OFFER_FAILED -> break@loop // cannot offer -> Ok to queue to buffer
                             failure === RETRY_ATOMIC -> {} // retry
                             failure === ALREADY_SELECTED || failure is Closed<*> -> {
-                                this.size = size // restore size
+                                this.size.value = size // restore size
                                 return failure
                             }
                             else -> error("performAtomicTrySelect(describeTryOffer) returned $failure")
@@ -112,7 +116,7 @@ internal open class ArrayChannel<E>(
                 }
                 // let's try to select sending this element to buffer
                 if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
-                    this.size = size // restore size
+                    this.size.value = size // restore size
                     return ALREADY_SELECTED
                 }
                 ensureCapacity(size)
@@ -125,6 +129,10 @@ internal open class ArrayChannel<E>(
         // breaks here if offer meets receiver
         receive!!.completeResumeReceive(element)
         return receive!!.offerResult
+    }
+
+    override fun enqueueSend(send: Send): Any? = lock.withLock {
+        super.enqueueSend(send)
     }
 
     // Guarded by lock
@@ -146,12 +154,12 @@ internal open class ArrayChannel<E>(
         var resumed = false
         var result: Any? = null
         lock.withLock {
-            val size = this.size
+            val size = this.size.value
             if (size == 0) return closedForSend ?: POLL_FAILED // when nothing can be read from buffer
             // size > 0: not empty -- retrieve element
             result = buffer[head]
             buffer[head] = null
-            this.size = size - 1 // update size before checking queue (!!!)
+            this.size.value = size - 1 // update size before checking queue (!!!)
             // check for senders that were waiting on full queue
             var replacement: Any? = POLL_FAILED
             if (size == capacity) {
@@ -167,7 +175,7 @@ internal open class ArrayChannel<E>(
                 }
             }
             if (replacement !== POLL_FAILED && replacement !is Closed<*>) {
-                this.size = size // restore size
+                this.size.value = size // restore size
                 buffer[(head + size) % buffer.size] = replacement
             }
             head = (head + 1) % buffer.size
@@ -184,12 +192,12 @@ internal open class ArrayChannel<E>(
         var success = false
         var result: Any? = null
         lock.withLock {
-            val size = this.size
+            val size = this.size.value
             if (size == 0) return closedForSend ?: POLL_FAILED
             // size > 0: not empty -- retrieve element
             result = buffer[head]
             buffer[head] = null
-            this.size = size - 1 // update size before checking queue (!!!)
+            this.size.value = size - 1 // update size before checking queue (!!!)
             // check for senders that were waiting on full queue
             var replacement: Any? = POLL_FAILED
             if (size == capacity) {
@@ -206,7 +214,7 @@ internal open class ArrayChannel<E>(
                         failure === POLL_FAILED -> break@loop // cannot poll -> Ok to take from buffer
                         failure === RETRY_ATOMIC -> {} // retry
                         failure === ALREADY_SELECTED -> {
-                            this.size = size // restore size
+                            this.size.value = size // restore size
                             buffer[head] = result // restore head
                             return failure
                         }
@@ -221,12 +229,12 @@ internal open class ArrayChannel<E>(
                 }
             }
             if (replacement !== POLL_FAILED && replacement !is Closed<*>) {
-                this.size = size // restore size
+                this.size.value = size // restore size
                 buffer[(head + size) % buffer.size] = replacement
             } else {
                 // failed to poll or is already closed --> let's try to select receiving this element from buffer
                 if (!select.trySelect()) { // :todo: move trySelect completion outside of lock
-                    this.size = size // restore size
+                    this.size.value = size // restore size
                     buffer[head] = result // restore head
                     return ALREADY_SELECTED
                 }
@@ -239,16 +247,20 @@ internal open class ArrayChannel<E>(
         return result
     }
 
+    override fun enqueueReceiveInternal(receive: Receive<E>): Boolean = lock.withLock {
+        super.enqueueReceiveInternal(receive)
+    }
+
     // Note: this function is invoked when channel is already closed
     override fun onCancelIdempotent(wasClosed: Boolean) {
         // clear buffer first, but do not wait for it in helpers
         if (wasClosed) {
             lock.withLock {
-                repeat(size) {
+                repeat(size.value) {
                     buffer[head] = 0
                     head = (head + 1) % buffer.size
                 }
-                size = 0
+                size.value = 0
             }
         }
         // then clean all queued senders
@@ -258,5 +270,5 @@ internal open class ArrayChannel<E>(
     // ------ debug ------
 
     override val bufferDebugString: String
-        get() = "(buffer:capacity=$capacity,size=$size)"
+        get() = "(buffer:capacity=$capacity,size=${size.value})"
 }


### PR DESCRIPTION
The following non-linearizable execution can occur in `ArrayChannel` without this fix (here, capacity = 1):
```
| receive(): SUSPENDED + Closed    | offer(3): true             | receive():  3    |
|                                  | send(5):  SUSPENDED + void |                  |
|                                  | close(): true              |                  |
```
1. The 1st thread `receive()` checks whether the channel is empty.
2. `offer(3)` и `send(5)` from the 2nd thread are executed, the last one suspends.
3. The 3rd thread `receive()` retrieves `3` from the buffer and `send(5)` request from the waiting queue, resuming the last one. Thus, it holds the channel lock, but both the buffer and the waiting queue are empty (it should put `5` to the buffer)
4. After that, the 1st thread `receive` completes its operation by adding itself to the waiting queue. 
5. While `send(5)` from the 2nd thread is resumed, the following `close()` operation is invoked, which resumes the waiting in the queue `receive` with an error.
6. At last, the 3rd thread `receive` completes its execution and adds `5` to the buffer.

This fix wraps adding requests to the waiting queue with the channel lock.  