### PR TITLE
Add test to ensure parent scope is not frozen by child coroutine

### DIFF
--- a/kotlinx-coroutines-core/nativeDarwin/test/MainDispatcherTest.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/test/MainDispatcherTest.kt
@@ -4,10 +4,22 @@
 
 package kotlinx.coroutines
 
+import kotlin.native.concurrent.isFrozen
 import kotlin.test.*
 
 class MainDispatcherTest : TestBase() {
     private val testThread = currentThread()
+
+    @Test
+    fun testParentIsFrozen() {
+        runTest {
+            assertEquals(this.isFrozen, false)
+            withContext(Dispatchers.Default) {
+                "anything"
+            }
+            assertEquals(this.isFrozen, false)
+        }
+    }
 
     @Test
     fun testWithContext() {


### PR DESCRIPTION
If this test fails, then we have no have a reasonable means of communicating information from one thread to another. Freezing should enforce that the object returned from another thread is frozen; it should not freeze the callback that receives the object.