### PR TITLE
Introduce SWT dispatchers for SWT UI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ suspend fun main() = coroutineScope {
 
 * [core](kotlinx-coroutines-core/README.md) &mdash; common coroutines across all platforms:
   * [launch] and [async] coroutine builders returning [Job] and [Deferred] light-weight futures with cancellation support;
-  * [Dispatchers] object with [Main][Dispatchers.Main] dispatcher for Android/Swing/JavaFx, and [Default][Dispatchers.Default] dispatcher for background coroutines;
+  * [Dispatchers] object with [Main][Dispatchers.Main] dispatcher for Android/Swing/JavaFx/SWT, and [Default][Dispatchers.Default] dispatcher for background coroutines;
   * [delay] and [yield] top-level suspending functions;
   * [Flow] &mdash; cold asynchronous stream with [flow][_flow] builder and comprehensive operator set ([filter], [map], etc);
   * [Channel], [Mutex], and [Semaphore] communication and synchronization primitives;
@@ -48,7 +48,7 @@ suspend fun main() = coroutineScope {
     RxJava 2.x ([rxFlowable], [rxSingle], etc), and 
     Project Reactor ([flux], [mono], etc). 
 * [ui](ui/README.md) &mdash; modules that provide coroutine dispatchers for various single-threaded UI libraries:
-  * Android, JavaFX, and Swing.
+  * Android, JavaFX, Swing, and SWT.
 * [integration](integration/README.md) &mdash; modules that provide integration with various asynchronous callback- and future-based libraries:
   * JDK8 [CompletionStage.await], Guava [ListenableFuture.await], and Google Play Services [Task.await];
   * SLF4J MDC integration via [MDCContext].

--- a/binary-compatibility-validator/build.gradle
+++ b/binary-compatibility-validator/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testArtifacts project(':kotlinx-coroutines-android')
     testArtifacts project(':kotlinx-coroutines-javafx')
     testArtifacts project(':kotlinx-coroutines-swing')
+    testArtifacts project(':kotlinx-coroutines-swt')
 }
 
 def testCasesDeclarationsDump = "${buildDir}/visibilities.json".toString()

--- a/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-swt.txt
+++ b/binary-compatibility-validator/reference-public-api/kotlinx-coroutines-swt.txt
@@ -1,0 +1,5 @@
+public final class kotlinx/coroutines/swt/SWTDispatcherKt {
+	public static final fun getSWT (Lkotlinx/coroutines/Dispatchers;)Lkotlinx/coroutines/MainCoroutineDispatcher;
+	public static final fun swt (Lkotlinx/coroutines/Dispatchers;Lorg/eclipse/swt/widgets/Display;)Lkotlinx/coroutines/MainCoroutineDispatcher;
+}
+

--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -40,7 +40,7 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
      * Method may throw [UnsupportedOperationException] if immediate dispatching is not supported by current dispatcher,
      * please refer to specific dispatcher documentation.
      *
-     * [Dispatchers.Main] supports immediate execution for Android, JavaFx and Swing platforms.
+     * [Dispatchers.Main] supports immediate execution for Android, JavaFx, Swing and SWT platforms.
      */
     public abstract val immediate: MainCoroutineDispatcher
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ module('ui/kotlinx-coroutines-android')
 module('ui/kotlinx-coroutines-android/android-unit-tests')
 module('ui/kotlinx-coroutines-javafx')
 module('ui/kotlinx-coroutines-swing')
+module('ui/kotlinx-coroutines-swt')
 
 module('js/js-stub')
 module('js/example-frontend-js')

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -21,6 +21,7 @@ Library support for Kotlin coroutines. This reference is a companion to
 | [kotlinx-coroutines-android](kotlinx-coroutines-android)             | `Main` dispatcher for Android applications |
 | [kotlinx-coroutines-javafx](kotlinx-coroutines-javafx)               | `JavaFx` dispatcher for JavaFX UI applications |
 | [kotlinx-coroutines-swing](kotlinx-coroutines-swing)                 | `Swing` dispatcher for Swing UI applications |
+| [kotlinx-coroutines-swt](kotlinx-coroutines-swt)                     | `SWT` dispatcher for SWT UI applications |
 | [kotlinx-coroutines-jdk8](kotlinx-coroutines-jdk8)                   | Integration with JDK8 `CompletableFuture` (Android API level 24) |
 | [kotlinx-coroutines-guava](kotlinx-coroutines-guava)                 | Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) |
 | [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j)                 | Integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html) |

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,3 +9,4 @@ Module name below corresponds to the artifact name in Maven/Gradle.
 * [kotlinx-coroutines-android](kotlinx-coroutines-android/README.md) -- `Dispatchers.Main` context for Android applications.
 * [kotlinx-coroutines-javafx](kotlinx-coroutines-javafx/README.md) -- `Dispatchers.JavaFx` context for JavaFX UI applications.
 * [kotlinx-coroutines-swing](kotlinx-coroutines-swing/README.md) -- `Dispatchers.Swing` context for Swing UI applications.
+* [kotlinx-coroutines-swt](kotlinx-coroutines-swt/README.md) -- `Dispatchers.SWT` context for SWT UI applications.

--- a/ui/coroutines-guide-ui.md
+++ b/ui/coroutines-guide-ui.md
@@ -70,9 +70,10 @@ different UI application libraries:
 * [kotlinx-coroutines-android](kotlinx-coroutines-android) -- `Dispatchers.Main` context for Android applications.
 * [kotlinx-coroutines-javafx](kotlinx-coroutines-javafx) -- `Dispatchers.JavaFx` context for JavaFX UI applications.
 * [kotlinx-coroutines-swing](kotlinx-coroutines-swing) -- `Dispatchers.Swing` context for Swing UI applications.
+* [kotlinx-coroutines-swt](kotlinx-coroutines-swt) -- `Dispatchers.SWT` context for SWT UI applications.
 
 Also, UI dispatcher is available via `Dispatchers.Main` from `kotlinx-coroutines-core` and corresponding 
-implementation (Android, JavaFx or Swing) is discovered by [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) API.
+implementation (Android, JavaFx, Swing or SWT) is discovered by [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) API.
 For example, if you are writing JavaFx application, you can use either `Dispatchers.Main` or `Dispachers.JavaFx` extension, it will be the same object.
 
 This guide covers all UI libraries simultaneously, because each of these modules consists of just one

--- a/ui/kotlinx-coroutines-swt/README.md
+++ b/ui/kotlinx-coroutines-swt/README.md
@@ -1,0 +1,16 @@
+# Module kotlinx-coroutines-swt
+
+Provides `Dispatchers.SWT` context, `Dispatchers.swt(Display)` context and `Dispatchers.Main` implementation for SWT UI 
+applications.
+
+The coroutine dispatcher `Dispatchers.SWT` (or `Dispatchers.Main`) dispatches events to the SWT default display.
+Therefore, the SWT default display should be created before calling `Dispatchers.SWT`. Otherwise a new default display
+is created (making the thread that invokes `Dispatchers.SWT` its user-interface thread).
+
+Read [Guide to UI programming with coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/ui/coroutines-guide-ui.md)
+for tutorial on this module.
+
+# Package kotlinx.coroutines.swt
+
+Provides `Dispatchers.SWT` context, `Dispatchers.swt(Display)` context and `Dispatchers.Main` implementation for SWT UI 
+applications.

--- a/ui/kotlinx-coroutines-swt/build.gradle
+++ b/ui/kotlinx-coroutines-swt/build.gradle
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+ext {
+    swtVersion = '3.113.0'
+    osgiPlatform = getOsgiPlatform()
+}
+
+dependencies {
+    compileOnly "org.eclipse.platform:org.eclipse.swt:$swtVersion"
+
+    testImplementation project(':kotlinx-coroutines-jdk8')
+    testImplementation "org.eclipse.platform:org.eclipse.swt:$swtVersion"
+}
+
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        // The maven property ${osgi.platform} is not handled by Gradle
+        // so we replace the dependency, using the osgi platform from the project settings
+        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.$osgiPlatform:$swtVersion")
+    }
+}
+
+/** Get SWT platform identifier. */
+static String getOsgiPlatform() {
+    def library = getSWTWindowingLibrary(System.properties['os.name'].toString())
+    def platform = getSWTPlatform(System.properties['os.name'].toString())
+    def arch = getSWTArch(System.properties['os.arch'].toString())
+    "$library.$platform.$arch"
+}
+
+/** Get SWT windowing library. */
+static String getSWTWindowingLibrary(String platform) {
+    switch (platform.replaceAll(' ', '').toLowerCase()) {
+        case ~/.*linux.*/: return 'gtk'
+        case ~/.*darwin.*/: return 'cocoa'
+        case ~/.*osx.*/: return 'cocoa'
+        case ~/.*win.*/: return 'win32'
+        default: return null
+    }
+}
+
+/** Get SWT platform. */
+static String getSWTPlatform(String platform) {
+    switch (platform.replaceAll(' ', '').toLowerCase()) {
+        case ~/.*linux.*/: return 'linux'
+        case ~/.*darwin.*/: return 'macosx'
+        case ~/.*osx.*/: return 'macosx'
+        case ~/.*win.*/: return 'win32'
+        default: return platform
+    }
+}
+
+/** Get SWT architecture. */
+static String getSWTArch(String arch) {
+    switch (arch) {
+        case ~/.*64.*/: return 'x86_64'
+        default: return 'x86'
+    }
+}

--- a/ui/kotlinx-coroutines-swt/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
+++ b/ui/kotlinx-coroutines-swt/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
@@ -1,0 +1,1 @@
+kotlinx.coroutines.swt.SWTDispatcherFactory

--- a/ui/kotlinx-coroutines-swt/src/SWTDispatcher.kt
+++ b/ui/kotlinx-coroutines-swt/src/SWTDispatcher.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.swt
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.internal.MainDispatcherFactory
+import kotlinx.coroutines.swt.SwtDefault.delay
+import org.eclipse.swt.widgets.Display
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Dispatches execution onto SWT event dispatching thread of the **default** [Display] and provides native [delay] support.
+ *
+ * **NOTE:** Be aware that calling this method creates a default [Display] (making the thread that invokes this
+ * method its user-interface thread) if it did not already exist.
+ */
+@Suppress("unused")
+public val Dispatchers.SWT: MainCoroutineDispatcher
+    get() = kotlinx.coroutines.swt.SwtDefault
+
+/**
+ * Dispatches execution onto SWT event dispatching thread of the given [Display] and provides native [delay] support.
+ */
+@Suppress("unused")
+public fun Dispatchers.swt(display: Display): MainCoroutineDispatcher =
+        SwtDispatcherImpl(display)
+
+/**
+ * Base dispatcher for SWT event dispatching thread.
+ *
+ * This class provides type-safety and a point for future extensions.
+ */
+internal abstract class SwtDispatcher(
+        internal val display: Display,
+        internal val name: String
+) : MainCoroutineDispatcher(), Delay {
+
+    /** @suppress */
+    override fun dispatch(context: CoroutineContext, block: Runnable) = display.asyncExec(block)
+
+    /** @suppress */
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        val action = Runnable {
+            with(continuation) { resumeUndispatched(Unit) }
+        }
+        schedule(timeMillis, action)
+        continuation.invokeOnCancellation { display.disposeExec(action) }
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+        schedule(timeMillis, block)
+        return object : DisposableHandle {
+            override fun dispose() {
+                display.disposeExec(block)
+            }
+        }
+    }
+
+    private fun schedule(timeMillis: Long, action: Runnable) {
+        display.timerExec(timeMillis.toInt(), action)
+    }
+
+    override fun toString() = "SWT-$name"
+}
+
+/**
+ * Immediate dispatcher for SWT event dispatching for the given [Display].
+ */
+private class ImmediateSWTDispatcher(display: Display, name: String) : SwtDispatcher(display, name) {
+    override val immediate: MainCoroutineDispatcher
+        get() = this
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean =
+            Thread.currentThread() != display.thread
+
+    override fun toString() = "${super.toString()} [immediate]"
+}
+
+/**
+ * Dispatcher for SWT event dispatching for the given [Display].
+ */
+internal open class SwtDispatcherImpl(display: Display, name: String = display.toString()) : SwtDispatcher(display, name) {
+    override val immediate: MainCoroutineDispatcher
+        get() = ImmediateSWTDispatcher(display, name)
+}
+
+/**
+ * [MainDispatcherFactory] that dispatches events for the **default** SWT [Display].
+ */
+internal class SWTDispatcherFactory : MainDispatcherFactory {
+    override val loadPriority: Int
+        get() = 2 // Swing has 0; JavaFx has 1
+
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher = SwtDefault
+}
+
+/**
+ * Dispatches execution onto SWT event dispatching thread of the **default** [Display] and provides native [delay] support.
+ */
+internal object SwtDefault : SwtDispatcherImpl(Display.getDefault(), "Default")

--- a/ui/kotlinx-coroutines-swt/test/SWTDefaultDisplayDispatchThread.kt
+++ b/ui/kotlinx-coroutines-swt/test/SWTDefaultDisplayDispatchThread.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.swt
+
+import org.eclipse.swt.widgets.Display
+import org.eclipse.swt.widgets.Shell
+import java.util.concurrent.CompletableFuture
+import kotlin.concurrent.thread
+
+/**
+ * Dispatcher thread for the SWT default [Display].
+ *
+ * Creates [Display.getDefault] in a new thread.
+ * The new thread handles all dispatched events for the default [Display].
+ */
+class SWTDefaultDisplayDispatchThread {
+
+    /** The name of the thread. */
+    val name = "SWTDefaultDisplayDispatchThread"
+
+    private var thread: Thread
+
+    private val shell: Shell
+
+    /** Get or create default [Display] and dispatcher. */
+    val display: Display
+        get() = shell.display
+
+    init {
+        // Start new thread and let it initialize Display and Shell
+        val future = CompletableFuture<Shell>()
+        thread = thread(name = name) {
+            val display = Display.getDefault()
+            val shell = Shell(display)
+            future.complete(shell)
+
+            // Start dispatch loop
+            while (!shell.isDisposed) {
+                if (!display.readAndDispatch()) {
+                    display.sleep()
+                }
+            }
+            display.dispose()
+        }
+
+        // Wait until Shell is ready
+        shell = future.get()
+    }
+
+    /** Dispose the display and stop the event dispatcher thread. */
+    fun dispose() {
+        if (!display.isDisposed) {
+            display.syncExec {
+                shell.close()
+            }
+
+            thread.join()
+        }
+    }
+}

--- a/ui/kotlinx-coroutines-swt/test/SwtTest.kt
+++ b/ui/kotlinx-coroutines-swt/test/SwtTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.swt
+
+import kotlinx.coroutines.*
+import org.eclipse.swt.widgets.Display
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertTrue
+
+class SwtTest : TestBase() {
+
+    private val display
+        get() = DISPATCHER.display
+
+    @Before
+    fun setup() {
+        ignoreLostThreads(DISPATCHER.name)
+    }
+
+    @Test
+    fun testDelay() = runBlocking(Dispatchers.IO) {
+        check(!display.isEventDispatchThread())
+
+        expect(1)
+        display.asyncExec { expect(2) }
+        val job = launch(Dispatchers.SWT) {
+            check(display.isEventDispatchThread())
+            expect(3)
+            display.asyncExec { expect(4) }
+            delay(100)
+            check(display.isEventDispatchThread())
+            expect(5)
+        }
+
+        job.join()
+        finish(6)
+    }
+
+    @Test
+    fun testLaunchInMainScope() = runTest {
+        check(!display.isEventDispatchThread())
+
+        val component = SwtComponent(display)
+        val job = component.testLaunch()
+
+        job.join()
+
+        assertTrue(component.executed)
+        component.cancel()
+        component.coroutineContext[Job]!!.join()
+    }
+
+    @Test
+    fun testFailureInMainScope() = runTest {
+        check(!display.isEventDispatchThread())
+
+        var exception: Throwable? = null
+        val component = SwtComponent(display, CoroutineExceptionHandler { _, e -> exception = e })
+        val job = component.testFailure()
+
+        job.join()
+
+        assertTrue(exception is TestException)
+        component.cancel()
+        join(component)
+    }
+
+    @Test
+    fun testCancellationInMainScope() = runTest {
+        check(!display.isEventDispatchThread())
+
+        val component = SwtComponent(display)
+        component.cancel()
+        component.testCancellation().join()
+        join(component)
+    }
+
+    @Test
+    fun testImmediateDispatcherYield() = runBlocking(Dispatchers.SWT) {
+        expect(1)
+        // launch in the immediate dispatcher
+        launch(Dispatchers.SWT.immediate) {
+            expect(2)
+            yield()
+            expect(4)
+        }
+        expect(3) // after yield
+        yield() // yield back
+        finish(5)
+    }
+
+    private suspend fun join(component: SwtComponent) {
+        component.coroutineContext[Job]!!.join()
+    }
+
+    private class SwtComponent(
+            private val display: Display,
+            coroutineContext: CoroutineContext = EmptyCoroutineContext
+    ) : CoroutineScope by MainScope() + coroutineContext {
+
+        var executed = false
+
+        fun testLaunch(): Job = launch {
+            check(display.isEventDispatchThread())
+            executed = true
+        }
+
+        fun testFailure(): Job = launch {
+            check(display.isEventDispatchThread())
+            throw TestException()
+        }
+
+        fun testCancellation(): Job = launch(start = CoroutineStart.ATOMIC) {
+            check(display.isEventDispatchThread())
+            delay(Long.MAX_VALUE)
+        }
+    }
+
+    companion object {
+
+        private lateinit var DISPATCHER: SWTDefaultDisplayDispatchThread
+
+        @BeforeClass
+        @JvmStatic
+        fun init() {
+            DISPATCHER = SWTDefaultDisplayDispatchThread()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun cleanup() {
+            DISPATCHER.dispose()
+        }
+    }
+}
+
+private fun Display.isEventDispatchThread() = thread == Thread.currentThread()

--- a/ui/kotlinx-coroutines-swt/test/examples/SWTExampleApp.kt
+++ b/ui/kotlinx-coroutines-swt/test/examples/SWTExampleApp.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package examples
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.swt.swt
+import org.eclipse.swt.SWT
+import org.eclipse.swt.layout.GridLayout
+import org.eclipse.swt.widgets.Display
+import org.eclipse.swt.widgets.ProgressBar
+import org.eclipse.swt.widgets.Shell
+import org.eclipse.swt.widgets.Text
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Main entry point of the SWT application.
+ */
+fun main() {
+    // Create and show GUI
+    val display = Display.getDefault()
+    val shell = Shell(display)
+    val gui = Gui(display, shell)
+    gui.open()
+
+    // Execute long running background operation and close window when finished
+    GlobalScope.launch(Dispatchers.Default) {
+        expensiveComputation(gui)
+        gui.close()
+    }
+
+    // Start a coroutines using [Dispatchers.Main] to update time.
+    // This works since timeText widget is part of the default display.
+    GlobalScope.launch(Dispatchers.Main) {
+        while (true) {
+            gui.timeText.text = SimpleDateFormat("HH:mm:ss.SSS").format(Date())
+            delay(250)
+        }
+    }
+
+    // Dispatch events until SWT window is closed
+    while (!shell.isDisposed) {
+        if (!display.readAndDispatch()) {
+            display.sleep()
+        }
+    }
+    display.dispose()
+}
+
+/**
+ * Execute long running operation and show progress in [gui] window.
+ *
+ * @param gui The [Gui] that will get updated.
+ */
+private fun expensiveComputation(gui: Gui) {
+    for (i in 0..10) {
+        val percent = i * 10
+        gui.updateProgress(percent)
+        Thread.sleep(1_000)
+    }
+}
+
+/**
+ * Allow to make changes to the GUI window.
+ *
+ * All updates are executed within SWT event dispatch thread.
+ */
+class Gui(
+        private val display: Display,
+        private val shell: Shell
+) : CoroutineScope {
+
+    override val coroutineContext = Dispatchers.swt(display)
+
+    private val progressBar = ProgressBar(shell, SWT.SMOOTH).apply {
+        minimum = 0
+        maximum = 100
+    }
+
+    private val progressText = Text(shell, SWT.SINGLE).apply {
+        editable = false
+    }
+
+    val timeText = Text(shell, SWT.SINGLE).apply {
+        editable = false
+    }
+
+    init {
+        shell.apply {
+            text = "Async UI example"
+            layout = GridLayout(2, true).apply {
+                marginWidth = 0
+                marginHeight = 0
+            }
+        }
+    }
+
+    /** Open GUI window.*/
+    fun open() = launch {
+        // Called within SWT event dispatch thread
+        shell.open()
+    }
+
+    /** Close GUI window.*/
+    fun close() = launch {
+        // Called within SWT event dispatch thread
+        shell.close()
+    }
+
+    /** Update progress information.*/
+    fun updateProgress(percent: Int) = launch {
+        // textArea and progressBar are updated within SWT event dispatch thread
+        progressText.text = "$percent %"
+        progressBar.selection = percent
+        shell.layout(true, true)
+    }
+}


### PR DESCRIPTION
1. Add `Dispatchers.SWT` that dispatches execution onto SWT event dispatching thread of the **default** SWT  `Display`.
2. Add `Dispatchers.swt(display: Display)` that disaptches to arbitrary SWT `Display`.
3. Implement `MainDispatcherFactory` for SWT that dispatches to default `Display`.

Is there an interest in having SWT support directly in the `Kotlin/kotlinx.coroutines` repository? Otherwise I would release `kotlinx-coroutines-swt` separately.