### PR TITLE
Call BroadcastChannel.asFlow.onStart() after openSubscription()

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Channels.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Channels.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.internal.*
 import kotlin.coroutines.*
 import kotlin.jvm.*
-import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
  * Emits all elements from the given [channel] to this flow collector and [cancels][cancel] (consumes)
@@ -128,7 +127,7 @@ private class ChannelAsFlow<T>(
             check(!consumed.getAndSet(true)) { "ReceiveChannel.consumeAsFlow can be collected just once" }
         }
     }
-    
+
     override fun create(context: CoroutineContext, capacity: Int): ChannelFlow<T> =
         ChannelAsFlow(channel, consume, context, capacity)
 
@@ -170,9 +169,7 @@ private class ChannelAsFlow<T>(
  * 3) If the flow consumer fails with an exception, subscription is cancelled.
  */
 @FlowPreview
-public fun <T> BroadcastChannel<T>.asFlow(): Flow<T> = flow {
-    emitAll(openSubscription())
-}
+public fun <T> BroadcastChannel<T>.asFlow(): Flow<T> = BroadcastChannelAsFlow(this)
 
 /**
  * Creates a [broadcast] coroutine that collects the given flow.

--- a/kotlinx-coroutines-core/common/src/flow/internal/BroadcastChannelAsFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/BroadcastChannelAsFlow.kt
@@ -1,0 +1,35 @@
+package kotlinx.coroutines.flow.internal
+
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.*
+
+/**
+ * Accumulator for pending `onStart` callbacks when consuming a [BroadcastChannel] as a Flow.
+ *
+ * `BroadcastChannel.openSubscription()` must be called before values sent to the `BroadcastChannel`
+ * will be forwarded to the [ReceiveChannel].  That subscription should only be made upon collection of the Flow,
+ * so it is necessary to wait until that point to invoke any `onStart` callbacks.
+ *
+ * @param source The source `BroadcastChannel`
+ * @param startAction The callback to be executed after subscription but before `emitAll()`
+ */
+internal class BroadcastChannelAsFlow<T>(
+    private val source: BroadcastChannel<T>,
+    private val startAction: suspend FlowCollector<T>.() -> Unit = {}
+) : Flow<T> {
+
+    fun update(
+        action: suspend FlowCollector<T>.() -> Unit
+    ): BroadcastChannelAsFlow<T> = BroadcastChannelAsFlow(source) {
+        // new or upstream actions are invoked before old/downstream ones
+        action()
+        startAction()
+    }
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        // open the ReceiveChannel before invoking the actions so that any sent values will be received
+        val channel = source.openSubscription()
+        collector.startAction()
+        collector.emitAll(channel)
+    }
+}

--- a/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
@@ -70,9 +70,13 @@ internal inline fun <T, R> Flow<T>.unsafeTransform(
 @ExperimentalCoroutinesApi // tentatively stable in 1.3.0
 public fun <T> Flow<T>.onStart(
     action: suspend FlowCollector<T>.() -> Unit
-): Flow<T> = unsafeFlow { // Note: unsafe flow is used here, but safe collector is used to invoke start action
-    SafeCollector<T>(this, coroutineContext).action()
-    collect(this) // directly delegate
+): Flow<T> = if (this is BroadcastChannelAsFlow) {
+    update(action)
+} else {
+    unsafeFlow { // Note: unsafe flow is used here, but safe collector is used to invoke start action
+        SafeCollector<T>(this, coroutineContext).action()
+        collect(this) // directly delegate
+    }
 }
 
 /**

--- a/kotlinx-coroutines-core/common/test/flow/channels/ChannelBuildersFlowTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/channels/ChannelBuildersFlowTest.kt
@@ -265,4 +265,28 @@ class ChannelBuildersFlowTest : TestBase() {
             fail()
         }
     }
+
+    @Test
+    fun testBroadcastAsFlowOnStart() = runTest {
+        val channel = broadcast(capacity = 2) {
+            expect(4)
+            send("c")
+        }
+
+        expect(1)
+
+        val result = channel.asFlow()
+            .onStart {
+                expect(3)
+                channel.send("b")
+            }
+            .onStart {
+                expect(2)
+                channel.send("a")
+            }
+            .toList()
+
+        assertEquals(listOf("a", "b", "c"), result)
+        finish(5)
+    }
 }


### PR DESCRIPTION
Fixes #1758

Introduces the `BroadcastChannelAsFlow` internal class to accumulate `onStart` callbacks and only invoke them inside `collect(...)`, after `openSubscription()` has been called.