### PR TITLE
Fix context support in Publisher.asFlow.flowOn

### DIFF
--- a/reactive/kotlinx-coroutines-reactive/test/PublisherAsFlowTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherAsFlowTest.kt
@@ -120,7 +120,7 @@ class PublisherAsFlowTest : TestBase() {
                     7 -> try {
                         send(value)
                     } catch (e: CancellationException) {
-                        finish(6)
+                        expect(5)
                         throw e
                     }
                     else -> expectUnreached()
@@ -143,6 +143,6 @@ class PublisherAsFlowTest : TestBase() {
                 }
             }
         }
-        expect(5)
+        finish(6)
     }
 }

--- a/reactive/kotlinx-coroutines-reactor/test/FlowAsFluxTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FlowAsFluxTest.kt
@@ -4,16 +4,17 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.reactive.*
 import org.junit.Test
-import reactor.core.publisher.Mono
+import reactor.core.publisher.*
 import reactor.util.context.Context
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class FlowAsFluxTest : TestBase() {
     @Test
-    fun testFlowToFluxContextPropagation() {
+    fun testFlowAsFluxContextPropagation() {
         val flux = flow<String> {
             (1..4).forEach { i -> emit(createMono(i).awaitFirst()) }
-        }   .asFlux()
+        }
+            .asFlux()
             .subscriberContext(Context.of(1, "1"))
             .subscriberContext(Context.of(2, "2", 3, "3", 4, "4"))
         val list = flux.collectList().block()!!
@@ -23,5 +24,48 @@ class FlowAsFluxTest : TestBase() {
     private fun createMono(i: Int): Mono<String> = mono {
         val ctx = coroutineContext[ReactorContext]!!.context
         ctx.getOrDefault(i, "noValue")
+    }
+
+    @Test
+    fun testFluxAsFlowContextPropagationWithFlowOn() = runTest {
+        expect(1)
+        Flux.create<String> {
+            it.next("OK")
+            it.complete()
+        }
+            .subscriberContext { ctx ->
+                expect(2)
+                assertEquals("CTX", ctx.get(1))
+                ctx
+            }
+            .asFlow()
+            .flowOn(ReactorContext(Context.of(1, "CTX")))
+            .collect {
+                expect(3)
+                assertEquals("OK", it)
+            }
+        finish(4)
+    }
+
+    @Test
+    fun testFluxAsFlowContextPropagationFromScope() = runTest {
+        expect(1)
+        withContext(ReactorContext(Context.of(1, "CTX"))) {
+            Flux.create<String> {
+                    it.next("OK")
+                    it.complete()
+                }
+            .subscriberContext { ctx ->
+                expect(2)
+                assertEquals("CTX", ctx.get(1))
+                ctx
+            }
+            .asFlow()
+            .collect {
+                expect(3)
+                assertEquals("OK", it)
+            }
+        }
+        finish(4)
     }
 }

--- a/reactive/kotlinx-coroutines-reactor/test/FluxContextTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxContextTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.reactor
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.reactive.*
+import org.junit.*
+import org.junit.Test
+import reactor.core.publisher.*
+import kotlin.test.*
+
+class FluxContextTest : TestBase() {
+    private val dispatcher = newSingleThreadContext("FluxContextTest")
+
+    @After
+    fun tearDown() {
+        dispatcher.close()
+    }
+
+    @Test
+    fun testFluxCreateAsFlowThread() = runTest {
+        expect(1)
+        val mainThread = Thread.currentThread()
+        val dispatcherThread = withContext(dispatcher) { Thread.currentThread() }
+        assertTrue(dispatcherThread != mainThread)
+        Flux.create<String> {
+            assertEquals(dispatcherThread, Thread.currentThread())
+            it.next("OK")
+            it.complete()
+        }
+            .asFlow()
+            .flowOn(dispatcher)
+            .collect {
+                expect(2)
+                assertEquals("OK", it)
+                assertEquals(mainThread, Thread.currentThread())
+            }
+        finish(3)
+    }
+}

--- a/reactive/kotlinx-coroutines-rx2/test/FlowableContextTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowableContextTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.rx2
+
+import io.reactivex.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.reactive.*
+import org.junit.*
+import org.junit.Test
+import kotlin.test.*
+
+class FlowableContextTest : TestBase() {
+    private val dispatcher = newSingleThreadContext("FlowableContextTest")
+
+    @After
+    fun tearDown() {
+        dispatcher.close()
+    }
+
+    @Test
+    fun testFlowableCreateAsFlowThread() = runTest {
+        expect(1)
+        val mainThread = Thread.currentThread()
+        val dispatcherThread = withContext(dispatcher) { Thread.currentThread() }
+        assertTrue(dispatcherThread != mainThread)
+        Flowable.create<String>({
+            assertEquals(dispatcherThread, Thread.currentThread())
+            it.onNext("OK")
+            it.onComplete()
+        }, BackpressureStrategy.BUFFER)
+            .asFlow()
+            .flowOn(dispatcher)
+            .collect {
+                expect(2)
+                assertEquals("OK", it)
+                assertEquals(mainThread, Thread.currentThread())
+            }
+        finish(3)
+    }
+}


### PR DESCRIPTION
* When using asFlow().flowOn(...) context is now properly tracked and taken into account for both execution context of the reactive subscription and for injection into Reactor context.
* Publisher.asFlow slow-path implementation is simplified. It does not sure specialized openSubscription anymore, but always uses the same flow request logic.

Fixes #1765