### PR TITLE
Fix some tests hanging when `verifyDump` fails

### DIFF
--- a/kotlinx-coroutines-debug/test/RunningThreadStackMergeTest.kt
+++ b/kotlinx-coroutines-debug/test/RunningThreadStackMergeTest.kt
@@ -33,8 +33,9 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\t(Coroutine creation stacktrace)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
             ignoredCoroutine = ":BlockingCoroutine"
-        )
-        coroutineBlocker.await()
+        ) {
+            coroutineBlocker.await()
+        }
     }
 
     private fun awaitCoroutineStarted() {
@@ -87,8 +88,9 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\t(Coroutine creation stacktrace)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
             ignoredCoroutine = ":BlockingCoroutine"
-        )
-        coroutineBlocker.await()
+        ) {
+            coroutineBlocker.await()
+        }
     }
 
     private fun CoroutineScope.launchEscapingCoroutine() {
@@ -125,8 +127,9 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\t(Coroutine creation stacktrace)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
             ignoredCoroutine = ":BlockingCoroutine"
-        )
-        coroutineBlocker.await()
+        ) {
+            coroutineBlocker.await()
+        }
     }
 
     private fun CoroutineScope.launchEscapingCoroutineWithoutContext() {


### PR DESCRIPTION
`runBlocking` waits for all the threads it spawned to finish, so
if `verifyDump` failed in `RunningThreadStackMergeTest.kt`, the
tests would just hang: one of the threads would wait for a
barrier to break, which would never happen.

Maybe a commit this granular does not make sense in `develop` and should be cherry-picked in some other branch, for example, `jdk-11`, but that one is busy now.