### PR TITLE
Remove all traces of Hamcrest

### DIFF
--- a/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
+++ b/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
@@ -6,12 +6,11 @@ package kotlinx.coroutines.guava
 
 import com.google.common.util.concurrent.*
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
 import org.junit.*
-import org.junit.Assert.*
 import org.junit.Test
 import java.util.concurrent.*
 import java.util.concurrent.CancellationException
+import kotlin.test.*
 
 class ListenableFutureTest : TestBase() {
     @Before
@@ -27,7 +26,7 @@ class ListenableFutureTest : TestBase() {
                 "O"
             }).await() + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -64,7 +63,7 @@ class ListenableFutureTest : TestBase() {
         val future = GlobalScope.future {
             toAwait.await() + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -75,7 +74,7 @@ class ListenableFutureTest : TestBase() {
         }
         assertFalse(future.isDone)
         toAwait.set("O")
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -86,11 +85,11 @@ class ListenableFutureTest : TestBase() {
             try {
                 toAwait.await()
             } catch (e: RuntimeException) {
-                assertThat(e, IsInstanceOf(IllegalArgumentException::class.java))
+                assertTrue(e is IllegalArgumentException)
                 e.message!!
             } + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -100,13 +99,13 @@ class ListenableFutureTest : TestBase() {
             try {
                 toAwait.await()
             } catch (e: RuntimeException) {
-                assertThat(e, IsInstanceOf(IllegalArgumentException::class.java))
+                assertTrue(e is IllegalArgumentException)
                 e.message!!
             } + "K"
         }
         assertFalse(future.isDone)
         toAwait.setException(IllegalArgumentException("O"))
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -122,8 +121,8 @@ class ListenableFutureTest : TestBase() {
             future.get()
             fail("'get' should've throw an exception")
         } catch (e: ExecutionException) {
-            assertThat(e.cause, IsInstanceOf(IllegalStateException::class.java))
-            assertThat(e.cause!!.message, IsEqual("OK"))
+            assertTrue(e.cause is IllegalStateException)
+            assertEquals("OK", e.cause!!.message)
         }
     }
 
@@ -134,7 +133,7 @@ class ListenableFutureTest : TestBase() {
             GlobalScope.future(start = CoroutineStart.LAZY) {}
         }
 
-        assertThat(e.message, IsEqual("LAZY start is not supported"))
+        assertEquals("LAZY start is not supported", e.message)
         finish(2)
     }
 
@@ -147,7 +146,7 @@ class ListenableFutureTest : TestBase() {
         }
         expect(3)
         val future = deferred.asListenableFuture()
-        assertThat(future.await(), IsEqual("OK"))
+        assertEquals("OK", future.await())
         finish(4)
     }
 
@@ -160,7 +159,7 @@ class ListenableFutureTest : TestBase() {
         }
         expect(2)
         val future = deferred.asListenableFuture()
-        assertThat(future.await(), IsEqual("OK")) // await yields main thread to deferred coroutine
+        assertEquals("OK", future.await()) // await yields main thread to deferred coroutine
         finish(4)
     }
 
@@ -370,9 +369,7 @@ class ListenableFutureTest : TestBase() {
         assertTrue(asFutureAsDeferred.isCompleted)
         // By documentation, join() shouldn't throw when asDeferred is already complete.
         asFutureAsDeferred.join()
-        assertThat(
-          asFutureAsDeferred.getCompletionExceptionOrNull(),
-          IsInstanceOf(CancellationException::class.java))
+        assertTrue(asFutureAsDeferred.getCompletionExceptionOrNull() is CancellationException)
     }
 
     @Test
@@ -395,9 +392,7 @@ class ListenableFutureTest : TestBase() {
         assertTrue(asDeferred.isCompleted)
         // By documentation, join() shouldn't throw when asDeferred is already complete.
         asDeferred.join()
-        assertThat(
-          asDeferred.getCompletionExceptionOrNull(),
-          IsInstanceOf(CancellationException::class.java))
+        assertTrue(asDeferred.getCompletionExceptionOrNull() is CancellationException)
     }
 
     @Test

--- a/integration/kotlinx-coroutines-jdk8/test/future/AsFutureTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/future/AsFutureTest.kt
@@ -5,10 +5,10 @@
 package kotlinx.coroutines.future
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
 import java.util.concurrent.CancellationException
+import kotlin.test.*
 
 class AsFutureTest : TestBase() {
 

--- a/integration/kotlinx-coroutines-jdk8/test/future/FutureExceptionsTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/future/FutureExceptionsTest.kt
@@ -5,10 +5,10 @@
 package kotlinx.coroutines.future
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.io.*
 import java.util.concurrent.*
+import kotlin.test.*
 
 class FutureExceptionsTest : TestBase() {
 

--- a/integration/kotlinx-coroutines-jdk8/test/future/FutureTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/future/FutureTest.kt
@@ -6,9 +6,8 @@ package kotlinx.coroutines.future
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import org.hamcrest.core.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import java.util.concurrent.locks.*
@@ -16,6 +15,7 @@ import java.util.function.*
 import kotlin.concurrent.*
 import kotlin.coroutines.*
 import kotlin.reflect.*
+import kotlin.test.*
 
 class FutureTest : TestBase() {
     @Before
@@ -30,7 +30,7 @@ class FutureTest : TestBase() {
                 "O"
             }.await() + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -40,7 +40,7 @@ class FutureTest : TestBase() {
         val future = GlobalScope.future {
             toAwait.await() + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -51,7 +51,7 @@ class FutureTest : TestBase() {
         val future = GlobalScope.future {
             toAwait.await() + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -62,7 +62,7 @@ class FutureTest : TestBase() {
         }
         assertFalse(future.isDone)
         toAwait.complete("O")
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -74,7 +74,7 @@ class FutureTest : TestBase() {
         }
         assertFalse(future.isDone)
         completable.complete("O")
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -88,7 +88,7 @@ class FutureTest : TestBase() {
                 e.message!!
             } + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -104,7 +104,7 @@ class FutureTest : TestBase() {
                 e.message!!
             } + "K"
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -125,7 +125,7 @@ class FutureTest : TestBase() {
         assertFalse(future.isDone)
         toAwait.completeExceptionally(TestException("O"))
         yield() // to future coroutine
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
         finish(5)
     }
 
@@ -142,7 +142,7 @@ class FutureTest : TestBase() {
         }
         assertFalse(future.isDone)
         completable.completeExceptionally(TestException("O"))
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test
@@ -158,7 +158,7 @@ class FutureTest : TestBase() {
             fail("'get' should've throw an exception")
         } catch (e: ExecutionException) {
             assertTrue(e.cause is IllegalStateException)
-            assertThat(e.cause!!.message, IsEqual("OK"))
+            assertEquals("OK", e.cause!!.message)
         }
     }
 
@@ -191,22 +191,22 @@ class FutureTest : TestBase() {
             it()
             depth.andDecrement
         }) {
-            assertEquals("Part before first suspension must be wrapped", 1, depth.get())
+            assertEquals(1, depth.get(), "Part before first suspension must be wrapped")
             val result =
                     CompletableFuture.supplyAsync {
                         while (depth.get() > 0);
-                        assertEquals("Part inside suspension point should not be wrapped", 0, depth.get())
+                        assertEquals(0, depth.get(), "Part inside suspension point should not be wrapped")
                         "OK"
                     }.await()
-            assertEquals("Part after first suspension should be wrapped", 1, depth.get())
+            assertEquals(1, depth.get(), "Part after first suspension should be wrapped")
             CompletableFuture.supplyAsync {
                 while (depth.get() > 0);
-                assertEquals("Part inside suspension point should not be wrapped", 0, depth.get())
+                assertEquals(0, depth.get(), "Part inside suspension point should not be wrapped")
                 "ignored"
             }.await()
             result
         }
-        assertThat(future.get(), IsEqual("OK"))
+        assertEquals("OK", future.get())
     }
 
     @Test

--- a/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
+++ b/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
@@ -28,7 +28,7 @@ class MDCContextTest : TestBase() {
         MDC.put("myKey", "myValue")
         // Standalone launch
         GlobalScope.launch {
-            assertEquals(null, MDC.get("myKey"))
+            assertNull(MDC.get("myKey"))
             expect(2)
         }.join()
         finish(3)
@@ -92,7 +92,7 @@ class MDCContextTest : TestBase() {
     @Test
     fun testContextMayBeEmpty() {
         runBlocking(MDCContext()) {
-            assertEquals(null, MDC.get("myKey"))
+            assertNull(MDC.get("myKey"))
         }
     }
 

--- a/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
+++ b/kotlinx-coroutines-core/common/test/AbstractCoroutineTest.kt
@@ -19,7 +19,7 @@ class AbstractCoroutineTest : TestBase() {
             }
 
             override fun onCancelling(cause: Throwable?) {
-                assertEquals(null, cause)
+                assertNull(cause)
                 expect(5)
             }
 
@@ -34,12 +34,12 @@ class AbstractCoroutineTest : TestBase() {
         }
 
         coroutine.invokeOnCompletion(onCancelling = true) {
-            assertEquals(null, it)
+            assertNull(it)
             expect(7)
         }
 
         coroutine.invokeOnCompletion {
-            assertEquals(null, it)
+            assertNull(it)
             expect(8)
         }
         expect(2)

--- a/kotlinx-coroutines-core/common/test/CompletableDeferredTest.kt
+++ b/kotlinx-coroutines-core/common/test/CompletableDeferredTest.kt
@@ -50,7 +50,7 @@ class CompletableDeferredTest : TestBase() {
         assertEquals(false, c.isCancelled)
         assertEquals(true, c.isCompleted)
         assertTrue(c.getCancellationException() is JobCancellationException)
-        assertEquals(null, c.getCompletionExceptionOrNull())
+        assertNull(c.getCompletionExceptionOrNull())
     }
 
     private fun checkCancel(c: CompletableDeferred<String>) {

--- a/kotlinx-coroutines-core/common/test/WithTimeoutOrNullTest.kt
+++ b/kotlinx-coroutines-core/common/test/WithTimeoutOrNullTest.kt
@@ -77,7 +77,7 @@ class WithTimeoutOrNullTest : TestBase() {
                 yield()
             }
         }
-        assertEquals(null, result)
+        assertNull(result)
         finish(2)
     }
 
@@ -135,11 +135,11 @@ class WithTimeoutOrNullTest : TestBase() {
                         yield()
                     }
                 }
-                assertEquals(null, inner)
+                assertNull(inner)
                 counter++
             }
         }
-        assertEquals(null, result)
+        assertNull(result)
         check(counter in 1..2) {"Executed: $counter times"}
     }
 
@@ -167,7 +167,7 @@ class WithTimeoutOrNullTest : TestBase() {
             expectUnreached()
             "OK"
         }
-        assertEquals(null, result)
+        assertNull(result)
         finish(3)
     }
 
@@ -183,7 +183,7 @@ class WithTimeoutOrNullTest : TestBase() {
             }
             "OK"
         }
-        assertEquals(null, result)
+        assertNull(result)
         finish(4)
     }
 

--- a/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
@@ -48,7 +48,7 @@ class ArrayChannelTest : TestBase() {
             assertEquals(42, q.receiveOrNull())
             expect(6)
             check(!q.isEmpty && q.isClosedForSend && q.isClosedForReceive)
-            assertEquals(null, q.receiveOrNull())
+            assertNull(q.receiveOrNull())
             expect(7)
         }
         expect(2)
@@ -94,13 +94,13 @@ class ArrayChannelTest : TestBase() {
             expect(3)
             assertEquals(1, q.poll())
             expect(4)
-            assertEquals(null, q.poll())
+            assertNull(q.poll())
             expect(5)
             assertEquals(2, q.receive()) // suspends
             expect(9)
             assertEquals(3, q.poll())
             expect(10)
-            assertEquals(null, q.poll())
+            assertNull(q.poll())
             expect(11)
         }
         expect(2)

--- a/kotlinx-coroutines-core/common/test/channels/ChannelsTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ChannelsTest.kt
@@ -258,8 +258,8 @@ class ChannelsTest: TestBase() {
         testList.indices.forEach { i ->
             assertEquals(testList[i], testList.asReceiveChannel().elementAtOrNull(i))
         }
-        assertEquals(null, testList.asReceiveChannel().elementAtOrNull(-1))
-        assertEquals(null, testList.asReceiveChannel().elementAtOrNull(testList.size))
+        assertNull(testList.asReceiveChannel().elementAtOrNull(-1))
+        assertNull(testList.asReceiveChannel().elementAtOrNull(testList.size))
     }
 
     @Test
@@ -310,14 +310,14 @@ class ChannelsTest: TestBase() {
     @Test
     fun testLastOrNull() = runTest {
         assertEquals(testList.lastOrNull(), testList.asReceiveChannel().lastOrNull())
-        assertEquals(null, emptyList<Int>().asReceiveChannel().lastOrNull())
+        assertNull(emptyList<Int>().asReceiveChannel().lastOrNull())
     }
 
     @Test
     fun testSingleOrNull() = runTest {
         assertEquals(1, listOf(1).asReceiveChannel().singleOrNull())
-        assertEquals(null, listOf(1, 2).asReceiveChannel().singleOrNull())
-        assertEquals(null, emptyList<Int>().asReceiveChannel().singleOrNull())
+        assertNull(listOf(1, 2).asReceiveChannel().singleOrNull())
+        assertNull(emptyList<Int>().asReceiveChannel().singleOrNull())
         repeat(testList.size + 1) { i ->
             assertEquals(testList.singleOrNull { it == i },
                 testList.asReceiveChannel().singleOrNull { it == i })

--- a/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
@@ -44,7 +44,7 @@ class RendezvousChannelTest : TestBase() {
             expect(3)
             assertEquals(42, q.receiveOrNull())
             expect(4)
-            assertEquals(null, q.receiveOrNull())
+            assertNull(q.receiveOrNull())
             expect(6)
         }
         expect(2)
@@ -86,11 +86,11 @@ class RendezvousChannelTest : TestBase() {
         expect(1)
         launch {
             expect(3)
-            assertEquals(null, q.poll())
+            assertNull(q.poll())
             expect(4)
             assertEquals(2, q.receive())
             expect(7)
-            assertEquals(null, q.poll())
+            assertNull(q.poll())
             yield()
             expect(9)
             assertEquals(3, q.poll())

--- a/kotlinx-coroutines-core/common/test/flow/operators/FlowContextOptimizationsTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/FlowContextOptimizationsTest.kt
@@ -80,7 +80,7 @@ class FlowContextOptimizationsTest : TestBase() {
         }
             .flowOn(CoroutineName("Name"))
             .collect { value ->
-                assertEquals(null, currentContext[CoroutineName]?.name)
+                assertNull(currentContext[CoroutineName]?.name)
                 if (value == 1) expect(2)
                 else expect(4)
             }
@@ -102,8 +102,8 @@ class FlowContextOptimizationsTest : TestBase() {
             .flowOn(CoroutineName("Name2"))
             .flowOn(CoroutineName("Name3") + CustomContextElement("OK")) // but this is not lost
             .collect { value ->
-                assertEquals(null, currentContext[CoroutineName]?.name)
-                assertEquals(null, currentContext[CustomContextElement]?.str)
+                assertNull(currentContext[CoroutineName]?.name)
+                assertNull(currentContext[CustomContextElement]?.str)
                 if (value == 1) expect(2)
                 else expect(4)
             }

--- a/kotlinx-coroutines-core/jvm/test/CommonPoolTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/CommonPoolTest.kt
@@ -4,11 +4,10 @@
 
 package kotlinx.coroutines
 
-import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.lang.reflect.*
 import java.util.concurrent.*
+import kotlin.test.*
 
 @Suppress("DEPRECATION")
 class CommonPoolTest {

--- a/kotlinx-coroutines-core/jvm/test/DelayJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/DelayJvmTest.kt
@@ -4,11 +4,10 @@
 
 package kotlinx.coroutines
 
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.core.*
 import org.junit.*
 import java.util.concurrent.*
 import kotlin.coroutines.*
+import kotlin.test.assertEquals
 
 class DelayJvmTest : TestBase() {
     /**
@@ -22,12 +21,12 @@ class DelayJvmTest : TestBase() {
         }
         val context = CustomInterceptor(pool)
         val c = async(context) {
-            assertThat(Thread.currentThread(), IsEqual(thread))
+            assertEquals(thread, Thread.currentThread())
             delay(100)
-            assertThat(Thread.currentThread(), IsEqual(thread))
+            assertEquals(thread, Thread.currentThread())
             42
         }
-        assertThat(c.await(), IsEqual(42))
+        assertEquals(42, c.await())
         pool.shutdown()
     }
 
@@ -38,7 +37,7 @@ class DelayJvmTest : TestBase() {
             delay(100)
             42
         }
-        assertThat(c.await(), IsEqual(42))
+        assertEquals(42, c.await())
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/ExecutorsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ExecutorsTest.kt
@@ -4,10 +4,10 @@
 
 package kotlinx.coroutines
 
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
 import kotlin.coroutines.*
+import kotlin.test.*
 
 class ExecutorsTest : TestBase() {
     private fun checkThreadName(prefix: String) {

--- a/kotlinx-coroutines-core/jvm/test/WithTimeoutOrNullJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/WithTimeoutOrNullJvmTest.kt
@@ -19,7 +19,7 @@ class WithTimeoutOrNullJvmTest : TestBase() {
             expectUnreached() // should not be reached, because it is outer timeout
         }
         // outer timeout results in null
-        assertEquals(null, result)
+        assertNull(result)
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/WithTimeoutOrNullThreadDispatchTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/WithTimeoutOrNullThreadDispatchTest.kt
@@ -74,7 +74,7 @@ class WithTimeoutOrNullThreadDispatchTest : TestBase() {
                 }
             }
             assertEquals(thread, Thread.currentThread())
-            assertEquals(null, result)
+            assertNull(result)
             expect(5)
         }
         finish(6)

--- a/kotlinx-coroutines-core/jvm/test/channels/ActorLazyTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ActorLazyTest.kt
@@ -5,9 +5,8 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class ActorLazyTest : TestBase() {
     @Test
@@ -17,22 +16,22 @@ class ActorLazyTest : TestBase() {
             expect(5)
         }
         actor as Job // type assertion
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertFalse(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(2)
         yield() // to actor code --> nothing happens (not started!)
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertFalse(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(3)
         // start actor explicitly
         actor.start()
         expect(4)
         yield() // to started actor
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(true))
-        assertThat(actor.isClosedForSend, IsEqual(true))
+        assertFalse(actor.isActive)
+        assertTrue(actor.isCompleted)
+        assertTrue(actor.isClosedForSend)
         finish(6)
     }
 
@@ -41,24 +40,24 @@ class ActorLazyTest : TestBase() {
         expect(1)
         val actor = actor<String>(start = CoroutineStart.LAZY) {
             expect(4)
-            assertThat(receive(), IsEqual("OK"))
+            assertEquals("OK", receive())
             expect(5)
         }
         actor as Job // type assertion
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertFalse(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(2)
         yield() // to actor code --> nothing happens (not started!)
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertFalse(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(3)
         // send message to actor --> should start it
         actor.send("OK")
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(true))
-        assertThat(actor.isClosedForSend, IsEqual(true))
+        assertFalse(actor.isActive)
+        assertTrue(actor.isCompleted)
+        assertTrue(actor.isClosedForSend)
         finish(6)
     }
 

--- a/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
@@ -5,12 +5,11 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
 import java.io.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class ActorTest(private val capacity: Int) : TestBase() {
@@ -28,14 +27,14 @@ class ActorTest(private val capacity: Int) : TestBase() {
             expect(3)
         }
         actor as Job // type assertion
-        assertThat(actor.isActive, IsEqual(true))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertTrue(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(2)
         yield() // to actor code
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(true))
-        assertThat(actor.isClosedForSend, IsEqual(true))
+        assertFalse(actor.isActive)
+        assertTrue(actor.isCompleted)
+        assertTrue(actor.isClosedForSend)
         finish(4)
     }
 
@@ -44,26 +43,26 @@ class ActorTest(private val capacity: Int) : TestBase() {
         expect(1)
         val actor = actor<String>(capacity = capacity) {
             expect(3)
-            assertThat(receive(), IsEqual("OK"))
+            assertEquals("OK", receive())
             expect(6)
         }
         actor as Job // type assertion
-        assertThat(actor.isActive, IsEqual(true))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertTrue(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(2)
         yield() // to actor code
-        assertThat(actor.isActive, IsEqual(true))
-        assertThat(actor.isCompleted, IsEqual(false))
-        assertThat(actor.isClosedForSend, IsEqual(false))
+        assertTrue(actor.isActive)
+        assertFalse(actor.isCompleted)
+        assertFalse(actor.isClosedForSend)
         expect(4)
         // send message to actor
         actor.send("OK")
         expect(5)
         yield() // to actor code
-        assertThat(actor.isActive, IsEqual(false))
-        assertThat(actor.isCompleted, IsEqual(true))
-        assertThat(actor.isClosedForSend, IsEqual(true))
+        assertFalse(actor.isActive)
+        assertTrue(actor.isCompleted)
+        assertTrue(actor.isClosedForSend)
         finish(7)
     }
 

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelAtomicCancelStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelAtomicCancelStressTest.kt
@@ -6,12 +6,13 @@ package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
 import kotlin.random.Random
 import java.util.concurrent.atomic.*
+import kotlin.test.*
 
 /**
  * Tests cancel atomicity for channel send & receive operations, including their select versions.

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelSelectStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelSelectStressTest.kt
@@ -7,9 +7,10 @@ package kotlinx.coroutines.channels
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.After
+import org.junit.Test
 import java.util.concurrent.atomic.AtomicLongArray
+import kotlin.test.*
 
 class ChannelSelectStressTest : TestBase() {
     private val pairedCoroutines = 3

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
@@ -6,11 +6,11 @@ package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
 import java.util.concurrent.atomic.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class ChannelSendReceiveStressTest(
@@ -101,7 +101,7 @@ class ChannelSendReceiveStressTest(
         assertEquals(nEvents, sentTotal.get())
         if (!kind.isConflated) assertEquals(nEvents, receivedTotal.get())
         repeat(nReceivers) { receiveIndex ->
-            assertTrue("Each receiver should have received something", receivedBy[receiveIndex] > 0)
+            assertTrue(receivedBy[receiveIndex] > 0, "Each receiver should have received something")
         }
     }
 

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelsConsumeTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelsConsumeTest.kt
@@ -76,7 +76,7 @@ class ChannelsConsumeTest : TestBase() {
             assertEquals(4, elementAtOrNull(3))
         }
         checkTerminal {
-            assertEquals(null, elementAtOrNull(10))
+            assertNull(elementAtOrNull(10))
         }
     }
 
@@ -124,7 +124,7 @@ class ChannelsConsumeTest : TestBase() {
             assertEquals(3, firstOrNull { it % 3 == 0 })
         }
         checkTerminal {
-            assertEquals(null, firstOrNull { it > 10 })
+            assertNull(firstOrNull { it > 10 })
         }
     }
 
@@ -195,7 +195,7 @@ class ChannelsConsumeTest : TestBase() {
             assertEquals(9, lastOrNull { it % 3 == 0 })
         }
         checkTerminal {
-            assertEquals(null, lastOrNull { it > 10 })
+            assertNull(lastOrNull { it > 10 })
         }
     }
 
@@ -222,7 +222,7 @@ class ChannelsConsumeTest : TestBase() {
     @Test
     fun testSingleOrNull() {
         checkTerminal {
-            assertEquals(null, singleOrNull())
+            assertNull(singleOrNull())
         }
     }
 
@@ -232,10 +232,10 @@ class ChannelsConsumeTest : TestBase() {
             assertEquals(7, singleOrNull { it % 7 == 0 })
         }
         checkTerminal {
-            assertEquals(null, singleOrNull { it % 3 == 0 })
+            assertNull(singleOrNull { it % 3 == 0 })
         }
         checkTerminal {
-            assertEquals(null, singleOrNull { it > 10 })
+            assertNull(singleOrNull { it > 10 })
         }
     }
 
@@ -898,7 +898,7 @@ class ChannelsConsumeTest : TestBase() {
                 res.cancel()
             } else {
                 // then check that result is closed
-                assertEquals(null, res.receiveOrNull(), "Result has unexpected values")
+                assertNull(res.receiveOrNull(), "Result has unexpected values")
             }
             src
         }

--- a/kotlinx-coroutines-core/jvm/test/channels/ConflatedBroadcastChannelNotifyStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ConflatedBroadcastChannelNotifyStressTest.kt
@@ -5,10 +5,9 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.core.*
-import org.junit.*
+import org.junit.Test
 import java.util.concurrent.atomic.*
+import kotlin.test.*
 
 class ConflatedBroadcastChannelNotifyStressTest : TestBase() {
     private val nSenders = 2
@@ -76,9 +75,9 @@ class ConflatedBroadcastChannelNotifyStressTest : TestBase() {
         println("Completed successfully ${receiversCompleted.get()} receiver coroutines")
         println("                  Sent ${sentTotal.get()} events")
         println("              Received ${receivedTotal.get()} events")
-        assertThat(sendersCompleted.get(), IsEqual(nSenders))
-        assertThat(receiversCompleted.get(), IsEqual(nReceivers))
-        assertThat(sentTotal.get(), IsEqual(nEvents))
+        assertEquals(nSenders, sendersCompleted.get())
+        assertEquals(nReceivers, receiversCompleted.get())
+        assertEquals(nEvents, sentTotal.get())
     }
 
     private suspend fun waitForEvent(): Int =

--- a/kotlinx-coroutines-core/jvm/test/channels/ProduceConsumeJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ProduceConsumeJvmTest.kt
@@ -5,10 +5,10 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class ProduceConsumeJvmTest(

--- a/kotlinx-coroutines-core/jvm/test/channels/SimpleSendReceiveJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/SimpleSendReceiveJvmTest.kt
@@ -5,12 +5,10 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
-import kotlin.coroutines.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class SimpleSendReceiveJvmTest(
@@ -42,14 +40,14 @@ class SimpleSendReceiveJvmTest(
         var expected = 0
         for (x in channel) {
             if (!kind.isConflated) {
-                assertThat(x, IsEqual(expected++))
+                assertEquals(expected++, x)
             } else {
                 assertTrue(x >= expected)
                 expected = x + 1
             }
         }
         if (!kind.isConflated) {
-            assertThat(expected, IsEqual(n))
+            assertEquals(n, expected)
         }
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/guide/test/TestUtil.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/test/TestUtil.kt
@@ -7,9 +7,9 @@ package kotlinx.coroutines.guide.test
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.scheduling.*
-import org.junit.Assert.*
 import java.io.*
 import java.util.concurrent.*
+import kotlin.test.*
 
 fun wrapTask(block: Runnable) = kotlinx.coroutines.wrapTask(block)
 
@@ -145,7 +145,7 @@ private fun List<String>.verifyCommonLines(expected: Array<out String>, mode: Sa
     for (i in 0 until n) {
         val exp = sanitize(expected[i], mode)
         val act = sanitize(get(i), mode)
-        assertEquals("Line ${i + 1}", exp, act)
+        assertEquals(exp, act, "Line ${i + 1}")
     }
 }
 
@@ -163,7 +163,7 @@ fun List<String>.verifyLines(vararg expected: String) = verify {
 
 fun List<String>.verifyLinesStartWith(vararg expected: String) = verify {
     verifyCommonLines(expected)
-    assertTrue("Number of lines", expected.size <= size)
+    assertTrue(expected.size <= size, "Number of lines")
 }
 
 fun List<String>.verifyLinesArbitraryTime(vararg expected: String) = verify {
@@ -197,7 +197,7 @@ fun List<String>.verifyExceptions(vararg expected: String) {
     for (i in 0 until n) {
         val exp = sanitize(expected[i], SanitizeMode.FLEXIBLE_THREAD)
         val act = sanitize(actual[i], SanitizeMode.FLEXIBLE_THREAD)
-        assertEquals("Line ${i + 1}", exp, act)
+        assertEquals(exp, act, "Line ${i + 1}")
     }
 }
 
@@ -207,7 +207,7 @@ fun List<String>.verifyLinesStart(vararg expected: String) = verify {
     for (i in 0 until n) {
         val exp = sanitize(expected[i], SanitizeMode.FLEXIBLE_THREAD)
         val act = sanitize(get(i), SanitizeMode.FLEXIBLE_THREAD)
-        assertEquals("Line ${i + 1}", exp, act.substring(0, minOf(act.length, exp.length)))
+        assertEquals(exp, act.substring(0, minOf(act.length, exp.length)), "Line ${i + 1}")
     }
     checkEqualNumberOfLines(expected)
 }

--- a/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListAtomicLFStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListAtomicLFStressTest.kt
@@ -6,11 +6,11 @@ package kotlinx.coroutines.internal
 
 import kotlinx.atomicfu.LockFreedomTestEnvironment
 import kotlinx.coroutines.stressTestMultiplier
-import org.junit.Assert.*
 import org.junit.Test
 import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.*
 
 /**
  * This stress test has 4 threads adding randomly to the list and them immediately undoing

--- a/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListShortStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListShortStressTest.kt
@@ -5,11 +5,11 @@
 package kotlinx.coroutines.internal
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.*
 import java.util.concurrent.atomic.*
 import kotlin.concurrent.*
+import kotlin.test.*
 
 /**
  * This stress test has 6 threads adding randomly first to the list and them immediately undoing

--- a/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/LockFreeLinkedListTest.kt
@@ -4,8 +4,8 @@
 
 package kotlinx.coroutines.internal
 
-import org.junit.Assert.*
 import org.junit.Test
+import kotlin.test.*
 
 class LockFreeLinkedListTest {
     data class IntNode(val i: Int) : LockFreeLinkedListNode()
@@ -79,7 +79,7 @@ class LockFreeLinkedListTest {
         var index = 0
         list.forEach<IntNode> { actual[index++] = it.i }
         assertEquals(n, index)
-        for (i in 0 until n) assertEquals("item i", expected[i], actual[i])
+        for (i in 0 until n) assertEquals(expected[i], actual[i], "item $i")
         assertEquals(expected.isEmpty(), list.isEmpty)
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/internal/SegmentQueueTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/SegmentQueueTest.kt
@@ -7,14 +7,14 @@ import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlin.random.Random
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class SegmentQueueTest : TestBase() {
     @Test
     fun testSimpleTest() {
         val q = SegmentBasedQueue<Int>()
         assertEquals(1, q.numberOfSegments)
-        assertEquals(null, q.dequeue())
+        assertNull(q.dequeue())
         q.enqueue(1)
         assertEquals(1, q.numberOfSegments)
         q.enqueue(2)
@@ -23,7 +23,7 @@ class SegmentQueueTest : TestBase() {
         assertEquals(2, q.numberOfSegments)
         assertEquals(2, q.dequeue())
         assertEquals(1, q.numberOfSegments)
-        assertEquals(null, q.dequeue())
+        assertNull(q.dequeue())
     }
 
     @Test
@@ -37,7 +37,7 @@ class SegmentQueueTest : TestBase() {
         assertEquals(2, q.numberOfSegments)
         assertEquals(1, q.dequeue())
         assertEquals(3, q.dequeue())
-        assertEquals(null, q.dequeue())
+        assertNull(q.dequeue())
     }
 
     @Test
@@ -49,7 +49,7 @@ class SegmentQueueTest : TestBase() {
         q.enqueue(3)
         s.removeSegment()
         assertEquals(3, q.dequeue())
-        assertEquals(null, q.dequeue())
+        assertNull(q.dequeue())
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/internal/ThreadSafeHeapTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/internal/ThreadSafeHeapTest.kt
@@ -21,7 +21,7 @@ class ThreadSafeHeapTest : TestBase() {
     @Test
     fun testBasic() {
         val h = ThreadSafeHeap<Node>()
-        assertEquals(null, h.peek())
+        assertNull(h.peek())
         val n1 = Node(1)
         h.addLast(n1)
         assertEquals(n1, h.peek())
@@ -47,7 +47,7 @@ class ThreadSafeHeapTest : TestBase() {
         h.remove(n3)
         assertEquals(n5, h.peek())
         h.remove(n5)
-        assertEquals(null, h.peek())
+        assertNull(h.peek())
     }
 
     @Test
@@ -59,7 +59,7 @@ class ThreadSafeHeapTest : TestBase() {
         repeat(n) { h.addLast(Node(a[it])) }
         a.sort()
         repeat(n) { assertEquals(Node(a[it]), h.removeFirstOrNull()) }
-        assertEquals(null, h.peek())
+        assertNull(h.peek())
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/selects/SelectPhilosophersStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/selects/SelectPhilosophersStressTest.kt
@@ -6,8 +6,8 @@ package kotlinx.coroutines.selects
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class SelectPhilosophersStressTest : TestBase() {
     private val TEST_DURATION = 3000L * stressTestMultiplier
@@ -59,7 +59,7 @@ class SelectPhilosophersStressTest : TestBase() {
         val eats = withTimeout(5 * TEST_DURATION) { philosophers.map { it.await() } }
         debugJob.cancel()
         eats.withIndex().forEach { (id, eats) ->
-            assertTrue("$id shall not starve", eats > 0)
+            assertTrue(eats > 0, "$id shall not starve")
         }
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/test/TestCoroutineContextTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/test/TestCoroutineContextTest.kt
@@ -6,8 +6,9 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import kotlin.coroutines.*
+import kotlin.test.*
 
 class TestCoroutineContextTest {
     private val injectedContext = TestCoroutineContext()
@@ -309,7 +310,7 @@ class TestCoroutineContextTest {
         advanceTimeBy(delay)
 
         val e = result.getCompletionExceptionOrNull()
-        assertTrue("Expected to be thrown: '$expectedError' but was '$e'", expectedError === e)
+        assertTrue(expectedError === e, "Expected to be thrown: '$expectedError' but was '$e'")
     }
 
     @Test
@@ -341,7 +342,7 @@ class TestCoroutineContextTest {
         } catch (e: AssertionError) {
             throw e
         } catch (e: Throwable) {
-            assertTrue("Expected to be thrown: '$expectedError' but was '$e'", expectedError === e)
+            assertTrue(expectedError === e, "Expected to be thrown: '$expectedError' but was '$e'")
         }
     }
 

--- a/kotlinx-coroutines-test/test/TestBuildersTest.kt
+++ b/kotlinx-coroutines-test/test/TestBuildersTest.kt
@@ -5,9 +5,9 @@
 package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import kotlin.coroutines.*
+import kotlin.test.*
 
 class TestBuildersTest {
 

--- a/publication-validator/src/test/kotlin/kotlinx/coroutines/tools/MavenPublicationValidator.kt
+++ b/publication-validator/src/test/kotlin/kotlinx/coroutines/tools/MavenPublicationValidator.kt
@@ -5,7 +5,6 @@
 package kotlinx.coroutines.validator
 
 import org.junit.*
-import org.junit.Assert.*
 import java.io.*
 import java.util.jar.*
 

--- a/publication-validator/src/test/kotlin/kotlinx/coroutines/tools/NpmPublicationValidator.kt
+++ b/publication-validator/src/test/kotlin/kotlinx/coroutines/tools/NpmPublicationValidator.kt
@@ -7,7 +7,6 @@ package kotlinx.coroutines.validator
 import com.google.gson.*
 import org.apache.commons.compress.archivers.tar.*
 import org.junit.*
-import org.junit.Assert.*
 import java.io.*
 import java.util.zip.*
 

--- a/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
@@ -5,13 +5,12 @@
 package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.core.*
-import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
 import org.reactivestreams.*
 import kotlin.coroutines.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class IntegrationTest(
@@ -44,14 +43,14 @@ class IntegrationTest(
             // does not send anything
         }
         assertNSE { pub.awaitFirst() }
-        assertThat(pub.awaitFirstOrDefault("OK"), IsEqual("OK"))
-        assertThat(pub.awaitFirstOrNull(), IsNull())
-        assertThat(pub.awaitFirstOrElse { "ELSE" }, IsEqual("ELSE"))
+        assertEquals("OK", pub.awaitFirstOrDefault("OK"))
+        assertNull(pub.awaitFirstOrNull())
+        assertEquals("ELSE", pub.awaitFirstOrElse { "ELSE" })
         assertNSE { pub.awaitLast() }
         assertNSE { pub.awaitSingle() }
         var cnt = 0
         pub.collect { cnt++ }
-        assertThat(cnt, IsEqual(0))
+        assertEquals(0, cnt)
     }
 
     @Test
@@ -60,18 +59,18 @@ class IntegrationTest(
             if (delay) delay(1)
             send("OK")
         }
-        assertThat(pub.awaitFirst(), IsEqual("OK"))
-        assertThat(pub.awaitFirstOrDefault("!"), IsEqual("OK"))
-        assertThat(pub.awaitFirstOrNull(), IsEqual("OK"))
-        assertThat(pub.awaitFirstOrElse { "ELSE" }, IsEqual("OK"))
-        assertThat(pub.awaitLast(), IsEqual("OK"))
-        assertThat(pub.awaitSingle(), IsEqual("OK"))
+        assertEquals("OK", pub.awaitFirst())
+        assertEquals("OK", pub.awaitFirstOrDefault("!"))
+        assertEquals("OK", pub.awaitFirstOrNull())
+        assertEquals("OK", pub.awaitFirstOrElse { "ELSE" })
+        assertEquals("OK", pub.awaitLast())
+        assertEquals("OK", pub.awaitSingle())
         var cnt = 0
         pub.collect {
-            assertThat(it, IsEqual("OK"))
+            assertEquals("OK", it)
             cnt++
         }
-        assertThat(cnt, IsEqual(1))
+        assertEquals(1, cnt)
     }
 
     @Test
@@ -83,11 +82,11 @@ class IntegrationTest(
                 if (delay) delay(1)
             }
         }
-        assertThat(pub.awaitFirst(), IsEqual(1))
-        assertThat(pub.awaitFirstOrDefault(0), IsEqual(1))
-        assertThat(pub.awaitLast(), IsEqual(n))
-        assertThat(pub.awaitFirstOrNull(), IsEqual(1))
-        assertThat(pub.awaitFirstOrElse { 0 }, IsEqual(1))
+        assertEquals(1, pub.awaitFirst())
+        assertEquals(1, pub.awaitFirstOrDefault(0))
+        assertEquals(n, pub.awaitLast())
+        assertEquals(1, pub.awaitFirstOrNull())
+        assertEquals(1, pub.awaitFirstOrElse { 0 })
         assertIAE { pub.awaitSingle() }
         checkNumbers(n, pub)
         val channel = pub.openSubscription()
@@ -125,9 +124,9 @@ class IntegrationTest(
     private suspend fun checkNumbers(n: Int, pub: Publisher<Int>) {
         var last = 0
         pub.collect {
-            assertThat(it, IsEqual(++last))
+            assertEquals(++last, it)
         }
-        assertThat(last, IsEqual(n))
+        assertEquals(n, last)
     }
 
     private inline fun assertIAE(block: () -> Unit) {
@@ -135,7 +134,7 @@ class IntegrationTest(
             block()
             expectUnreached()
         } catch (e: Throwable) {
-            assertThat(e, IsInstanceOf(IllegalArgumentException::class.java))
+            assertTrue(e is IllegalArgumentException)
         }
     }
 
@@ -144,7 +143,7 @@ class IntegrationTest(
             block()
             expectUnreached()
         } catch (e: Throwable) {
-            assertThat(e, IsInstanceOf(NoSuchElementException::class.java))
+            assertTrue(e is NoSuchElementException)
         }
     }
 }

--- a/reactive/kotlinx-coroutines-reactive/test/IterableFlowTckTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IterableFlowTckTest.kt
@@ -8,16 +8,18 @@ package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.flow.*
 import org.junit.*
+import org.junit.Ignore
+import org.junit.Test
 import org.reactivestreams.*
 import org.reactivestreams.tck.*
 
-import org.junit.Assert.*
 import org.reactivestreams.Subscription
 import org.reactivestreams.Subscriber
 import java.util.ArrayList
 import java.util.concurrent.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ForkJoinPool.commonPool
+import kotlin.test.*
 
 class IterableFlowTckTest : PublisherVerification<Long>(TestEnvironment()) {
 

--- a/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublishTest.kt
@@ -5,10 +5,9 @@
 package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.reactivestreams.*
+import kotlin.test.*
 
 class PublishTest : TestBase() {
     @Test
@@ -45,7 +44,7 @@ class PublishTest : TestBase() {
             }
             override fun onNext(t: Int) {
                 expect(6)
-                assertThat(t, IsEqual(42))
+                assertEquals(42, t)
             }
             override fun onComplete() { expect(8) }
             override fun onError(t: Throwable?) { expectUnreached() }
@@ -72,8 +71,8 @@ class PublishTest : TestBase() {
             override fun onComplete() { expectUnreached() }
             override fun onError(t: Throwable) {
                 expect(6)
-                assertThat(t, IsInstanceOf(RuntimeException::class.java))
-                assertThat(t.message, IsEqual("OK"))
+                assertTrue(t is RuntimeException)
+                assertEquals("OK", t.message)
             }
         })
         expect(4)

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherMultiTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherMultiTest.kt
@@ -5,9 +5,8 @@
 package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class PublisherMultiTest : TestBase() {
     @Test
@@ -27,6 +26,6 @@ class PublisherMultiTest : TestBase() {
         observable.collect {
             assertTrue(resultSet.add(it))
         }
-        assertThat(resultSet.size, IsEqual(n))
+        assertEquals(n, resultSet.size)
     }
 }

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherSubscriptionSelectTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherSubscriptionSelectTest.kt
@@ -6,10 +6,10 @@ package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class PublisherSubscriptionSelectTest(private val request: Int) : TestBase() {

--- a/reactive/kotlinx-coroutines-reactor/test/ConvertTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/ConvertTest.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.reactive.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class ConvertTest : TestBase() {
     @Test
@@ -66,9 +67,9 @@ class ConvertTest : TestBase() {
             null
         }
         val mono1 = d.asMono(Dispatchers.Unconfined)
-        checkMonoValue(mono1, ::assertNull)
+        checkMonoValue(mono1, Assert::assertNull)
         val mono2 = d.asMono(Dispatchers.Unconfined)
-        checkMonoValue(mono2, ::assertNull)
+        checkMonoValue(mono2, Assert::assertNull)
     }
 
     @Test

--- a/reactive/kotlinx-coroutines-reactor/test/FluxMultiTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxMultiTest.kt
@@ -7,9 +7,10 @@ package kotlinx.coroutines.reactor
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactive.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import reactor.core.publisher.*
 import java.io.*
+import kotlin.test.*
 
 class FluxMultiTest : TestBase() {
     @Test

--- a/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
@@ -7,9 +7,10 @@ package kotlinx.coroutines.reactor
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactive.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import reactor.core.publisher.*
 import java.time.Duration.*
+import kotlin.test.*
 
 class FluxSingleTest : TestBase() {
 

--- a/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxTest.kt
@@ -7,7 +7,6 @@ package kotlinx.coroutines.reactor
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.reactive.*
-import org.hamcrest.core.*
 import org.junit.*
 import org.junit.Test
 import kotlin.test.*
@@ -23,7 +22,7 @@ class FluxTest : TestBase() {
         expect(2)
         flux.subscribe { value ->
             expect(5)
-            Assert.assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -42,8 +41,8 @@ class FluxTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            Assert.assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            Assert.assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-reactor/test/MonoTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/MonoTest.kt
@@ -7,15 +7,15 @@ package kotlinx.coroutines.reactor
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.reactive.*
-import org.hamcrest.core.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import org.reactivestreams.*
 import reactor.core.publisher.*
 import reactor.util.context.*
 import java.time.*
 import java.time.Duration.*
 import java.util.function.*
+import kotlin.test.*
 
 class MonoTest : TestBase() {
     @Before
@@ -33,7 +33,7 @@ class MonoTest : TestBase() {
         expect(2)
         mono.subscribe { value ->
             expect(5)
-            assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -52,8 +52,8 @@ class MonoTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-reactor/test/SchedulerTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/SchedulerTest.kt
@@ -5,12 +5,10 @@
 package kotlinx.coroutines.reactor
 
 import kotlinx.coroutines.*
-import org.hamcrest.core.IsEqual
-import org.hamcrest.core.IsNot
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
 import reactor.core.scheduler.Schedulers
+import kotlin.test.*
 
 class SchedulerTest : TestBase() {
     @Before
@@ -24,11 +22,11 @@ class SchedulerTest : TestBase() {
         val mainThread = Thread.currentThread()
         withContext(Schedulers.single().asCoroutineDispatcher()) {
             val t1 = Thread.currentThread()
-            assertThat(t1, IsNot(IsEqual(mainThread)))
+            assertNotSame(t1, mainThread)
             expect(2)
             delay(100)
             val t2 = Thread.currentThread()
-            assertThat(t2, IsNot(IsEqual(mainThread)))
+            assertNotSame(t2, mainThread)
             expect(3)
         }
         finish(4)

--- a/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/CompletableTest.kt
@@ -8,9 +8,8 @@ import io.reactivex.*
 import io.reactivex.disposables.*
 import io.reactivex.exceptions.*
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class CompletableTest : TestBase() {
     @Test
@@ -40,8 +39,8 @@ class CompletableTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to completable coroutine
@@ -95,7 +94,7 @@ class CompletableTest : TestBase() {
             expectUnreached()
         } catch (e: RuntimeException) {
             finish(4)
-            assertThat(e.message, IsEqual("OK"))
+            assertEquals("OK", e.message)
         }
     }
 

--- a/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ConvertTest.kt
@@ -6,8 +6,9 @@ package kotlinx.coroutines.rx2
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Assert
+import org.junit.Test
+import kotlin.test.*
 
 class ConvertTest : TestBase() {
     @Test
@@ -64,9 +65,9 @@ class ConvertTest : TestBase() {
             null
         }
         val maybe1 = d.asMaybe(Dispatchers.Unconfined)
-        checkMaybeValue(maybe1, ::assertNull)
+        checkMaybeValue(maybe1, Assert::assertNull)
         val maybe2 = d.asMaybe(Dispatchers.Unconfined)
-        checkMaybeValue(maybe2, ::assertNull)
+        checkMaybeValue(maybe2, Assert::assertNull)
     }
 
     @Test

--- a/reactive/kotlinx-coroutines-rx2/test/FlowAsObservableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowAsObservableTest.kt
@@ -6,9 +6,8 @@ package kotlinx.coroutines.rx2
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import org.hamcrest.core.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class FlowAsObservableTest : TestBase() {
     @Test
@@ -39,7 +38,7 @@ class FlowAsObservableTest : TestBase() {
         expect(2)
         observable.subscribe({ expectUnreached() }, { error ->
             expect(4)
-            assertThat(error, IsInstanceOf(RuntimeException::class.java))
+            assertTrue(error is RuntimeException)
             assertEquals("OK", error.message)
         })
         finish(5)

--- a/reactive/kotlinx-coroutines-rx2/test/FlowableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/FlowableTest.kt
@@ -6,7 +6,6 @@ package kotlinx.coroutines.rx2
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactive.*
-import org.hamcrest.core.*
 import org.junit.*
 import org.junit.Test
 import kotlin.test.*
@@ -22,7 +21,7 @@ class FlowableTest : TestBase() {
         expect(2)
         observable.subscribe { value ->
             expect(5)
-            Assert.assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -41,8 +40,8 @@ class FlowableTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            Assert.assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            Assert.assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-rx2/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/IntegrationTest.kt
@@ -6,12 +6,11 @@ package kotlinx.coroutines.rx2
 
 import io.reactivex.*
 import kotlinx.coroutines.*
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.core.*
-import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import org.junit.runners.*
 import kotlin.coroutines.*
+import kotlin.test.*
 
 @RunWith(Parameterized::class)
 class IntegrationTest(
@@ -44,16 +43,16 @@ class IntegrationTest(
             // does not send anything
         }
         assertNSE { observable.awaitFirst() }
-        assertThat(observable.awaitFirstOrDefault("OK"), IsEqual("OK"))
-        assertThat(observable.awaitFirstOrNull(), IsNull())
-        assertThat(observable.awaitFirstOrElse { "ELSE" }, IsEqual("ELSE"))
+        assertEquals("OK", observable.awaitFirstOrDefault("OK"))
+        assertNull(observable.awaitFirstOrNull())
+        assertEquals("ELSE", observable.awaitFirstOrElse { "ELSE" })
         assertNSE { observable.awaitLast() }
         assertNSE { observable.awaitSingle() }
         var cnt = 0
         observable.collect {
             cnt++
         }
-        assertThat(cnt, IsEqual(0))
+        assertEquals(0, cnt)
     }
 
     @Test
@@ -62,18 +61,18 @@ class IntegrationTest(
             if (delay) delay(1)
             send("OK")
         }
-        assertThat(observable.awaitFirst(), IsEqual("OK"))
-        assertThat(observable.awaitFirstOrDefault("OK"), IsEqual("OK"))
-        assertThat(observable.awaitFirstOrNull(), IsEqual("OK"))
-        assertThat(observable.awaitFirstOrElse { "ELSE" }, IsEqual("OK"))
-        assertThat(observable.awaitLast(), IsEqual("OK"))
-        assertThat(observable.awaitSingle(), IsEqual("OK"))
+        assertEquals("OK", observable.awaitFirst())
+        assertEquals("OK", observable.awaitFirstOrDefault("OK"))
+        assertEquals("OK", observable.awaitFirstOrNull())
+        assertEquals("OK", observable.awaitFirstOrElse { "ELSE" })
+        assertEquals("OK", observable.awaitLast())
+        assertEquals("OK", observable.awaitSingle())
         var cnt = 0
         observable.collect {
-            assertThat(it, IsEqual("OK"))
+            assertEquals("OK", it)
             cnt++
         }
-        assertThat(cnt, IsEqual(1))
+        assertEquals(1, cnt)
     }
 
     @Test
@@ -85,11 +84,11 @@ class IntegrationTest(
                 if (delay) delay(1)
             }
         }
-        assertThat(observable.awaitFirst(), IsEqual(1))
-        assertThat(observable.awaitFirstOrDefault(0), IsEqual(1))
-        assertThat(observable.awaitFirstOrNull(), IsEqual(1))
-        assertThat(observable.awaitFirstOrElse { 0 }, IsEqual(1))
-        assertThat(observable.awaitLast(), IsEqual(n))
+        assertEquals(1, observable.awaitFirst())
+        assertEquals(1, observable.awaitFirstOrDefault(0))
+        assertEquals(1, observable.awaitFirstOrNull())
+        assertEquals(1, observable.awaitFirstOrElse { 0 })
+        assertEquals(n, observable.awaitLast())
         assertIAE { observable.awaitSingle() }
         checkNumbers(n, observable)
         val channel = observable.openSubscription()
@@ -127,9 +126,9 @@ class IntegrationTest(
     private suspend fun checkNumbers(n: Int, observable: Observable<Int>) {
         var last = 0
         observable.collect {
-            assertThat(it, IsEqual(++last))
+            assertEquals(++last, it)
         }
-        assertThat(last, IsEqual(n))
+        assertEquals(n, last)
     }
 
 
@@ -138,7 +137,7 @@ class IntegrationTest(
             block()
             expectUnreached()
         } catch (e: Throwable) {
-            assertThat(e, IsInstanceOf(IllegalArgumentException::class.java))
+            assertTrue(e is IllegalArgumentException)
         }
     }
 
@@ -147,7 +146,7 @@ class IntegrationTest(
             block()
             expectUnreached()
         } catch (e: Throwable) {
-            assertThat(e, IsInstanceOf(NoSuchElementException::class.java))
+            assertTrue(e is NoSuchElementException)
         }
     }
 }

--- a/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/MaybeTest.kt
@@ -10,11 +10,11 @@ import io.reactivex.exceptions.*
 import io.reactivex.functions.*
 import io.reactivex.internal.functions.Functions.*
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
 import java.util.concurrent.CancellationException
+import kotlin.test.*
 
 class MaybeTest : TestBase() {
     @Before
@@ -32,7 +32,7 @@ class MaybeTest : TestBase() {
         expect(2)
         maybe.subscribe { value ->
             expect(5)
-            assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -67,8 +67,8 @@ class MaybeTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableMultiTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableMultiTest.kt
@@ -6,10 +6,9 @@ package kotlinx.coroutines.rx2
 
 import io.reactivex.*
 import kotlinx.coroutines.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.io.*
-import kotlin.experimental.*
+import kotlin.test.*
 
 /**
  * Test emitting multiple values with [rxObservable].

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableSingleTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableSingleTest.kt
@@ -7,8 +7,9 @@ package kotlinx.coroutines.rx2
 import io.reactivex.*
 import kotlinx.coroutines.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
+import kotlin.test.*
 
 class ObservableSingleTest : TestBase() {
     @Before

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableSubscriptionSelectTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableSubscriptionSelectTest.kt
@@ -6,8 +6,8 @@ package kotlinx.coroutines.rx2
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
-import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
+import kotlin.test.*
 
 class ObservableSubscriptionSelectTest : TestBase() {
     @Test

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableTest.kt
@@ -8,7 +8,6 @@ import io.reactivex.*
 import io.reactivex.plugins.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import org.hamcrest.core.*
 import org.junit.*
 import org.junit.Test
 import java.util.concurrent.*
@@ -30,7 +29,7 @@ class ObservableTest : TestBase() {
         expect(2)
         observable.subscribe { value ->
             expect(5)
-            Assert.assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -49,8 +48,8 @@ class ObservableTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            Assert.assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            Assert.assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine

--- a/reactive/kotlinx-coroutines-rx2/test/SchedulerTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/SchedulerTest.kt
@@ -6,11 +6,9 @@ package kotlinx.coroutines.rx2
 
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.*
-import org.hamcrest.core.IsEqual
-import org.hamcrest.core.IsNot
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.*
 
 class SchedulerTest : TestBase() {
     @Before
@@ -24,11 +22,11 @@ class SchedulerTest : TestBase() {
         val mainThread = Thread.currentThread()
         withContext(Schedulers.io().asCoroutineDispatcher()) {
             val t1 = Thread.currentThread()
-            assertThat(t1, IsNot(IsEqual(mainThread)))
+            assertNotSame(t1, mainThread)
             expect(2)
             delay(100)
             val t2 = Thread.currentThread()
-            assertThat(t2, IsNot(IsEqual(mainThread)))
+            assertNotSame(t2, mainThread)
             expect(3)
         }
         finish(4)

--- a/reactive/kotlinx-coroutines-rx2/test/SingleTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/SingleTest.kt
@@ -9,10 +9,10 @@ import io.reactivex.disposables.*
 import io.reactivex.exceptions.*
 import io.reactivex.functions.*
 import kotlinx.coroutines.*
-import org.hamcrest.core.*
 import org.junit.*
-import org.junit.Assert.*
+import org.junit.Test
 import java.util.concurrent.*
+import kotlin.test.*
 
 class SingleTest : TestBase() {
     @Before
@@ -30,7 +30,7 @@ class SingleTest : TestBase() {
         expect(2)
         single.subscribe { value ->
             expect(5)
-            assertThat(value, IsEqual("OK"))
+            assertEquals("OK", value)
         }
         expect(3)
         yield() // to started coroutine
@@ -49,8 +49,8 @@ class SingleTest : TestBase() {
             expectUnreached()
         }, { error ->
             expect(5)
-            assertThat(error, IsInstanceOf(RuntimeException::class.java))
-            assertThat(error.message, IsEqual("OK"))
+            assertTrue(error is RuntimeException)
+            assertEquals("OK", error.message)
         })
         expect(3)
         yield() // to started coroutine


### PR DESCRIPTION
Did it in a semi-automated manner, doing minimal fixes over the output of the command:
```sh
git grep hamcrest |
cut -d: -f1 |
xargs sed -iE -e 's/assertThat(\(.*\),\s*IsEqual(\(.*\)))/assertEquals(\2, \1)/' \
-e 's/assertThat(\(.*\),\s*IsInstanceOf(\(.*\)::class.java))/assert(\1 is \2)/' \
-e 's/assertThat(\(.*\),\s*IsNull())/assertEquals(null, \1)/' \
-e 's/assertThat(\(.*\),\s*IsNot(IsEqual(\(.*\))))/assert(\1 != \2)/' \
-e '/import.*hamcrest/d'
```

There are still some problems with style: in some cases `org.junit.Assert.*` are used, while in some others the native versions provided by Kotlin are.