### PR TITLE
Add more documentation about a case where .offer() can throw

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -298,7 +298,7 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  *             // Also, offer will throw if the channel is canceled.
  *             // To avoid that, we wrap the call in runBlocking.
  *             // See https://github.com/Kotlin/kotlinx.coroutines/issues/974
- *             runBlocking {
+ *             runCatching {
  *                 offer(value)
  *             }
  *         }

--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -293,9 +293,14 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  * fun flowFrom(api: CallbackBasedApi): Flow<T> = callbackFlow {
  *     val callback = object : Callback { // implementation of some callback interface
  *         override fun onNextValue(value: T) {
- *             // Note: offer drops value when buffer is full
+ *             // Note: offer drops values when the buffer is full
  *             // Use either buffer(Channel.CONFLATED) or buffer(Channel.UNLIMITED) to avoid overfill
- *             offer(value)
+ *             // Also, offer will throw if the channel is canceled.
+ *             // To avoid that, we wrap the call in runBlocking.
+ *             // See https://github.com/Kotlin/kotlinx.coroutines/issues/974
+ *             runBlocking {
+ *                 offer(value)
+ *             }
  *         }
  *         override fun onApiError(cause: Throwable) {
  *             cancel(CancellationException("API Error", cause))

--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -296,7 +296,7 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  *             // Note: offer drops values when the buffer is full
  *             // Use either buffer(Channel.CONFLATED) or buffer(Channel.UNLIMITED) to avoid overfill
  *             // Also, offer will throw if the channel is canceled.
- *             // To avoid that, we wrap the call in runBlocking.
+ *             // To avoid that, we wrap the call in runCatching.
  *             // See https://github.com/Kotlin/kotlinx.coroutines/issues/974
  *             runCatching {
  *                 offer(value)


### PR DESCRIPTION
Calling offer on a closed channel will throw. See https://github.com/Kotlin/kotlinx.coroutines/issues/974.

Make this explicit in the code snippets.