### PR TITLE
java.time adapter for Flow.debounce and Flow.sample

### DIFF
--- a/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
@@ -4,6 +4,7 @@
 package kotlinx.coroutines.time
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.selects.*
 import java.time.*
 import java.time.temporal.*
@@ -13,6 +14,18 @@ import java.time.temporal.*
  */
 public suspend fun delay(duration: Duration) =
         kotlinx.coroutines.delay(duration.coerceToMillis())
+
+/**
+ * "java.time" adapter method for [kotlinx.coroutines.flow.debounce].
+ */
+@FlowPreview
+public fun <T> Flow<T>.debounce(timeout: Duration) = debounce(timeout.coerceToMillis())
+
+/**
+ * "java.time" adapter method for [kotlinx.coroutines.flow.sample].
+ */
+@FlowPreview
+public fun <T> Flow<T>.sample(period: Duration) = sample(period.coerceToMillis())
 
 /**
  * "java.time" adapter method for [SelectBuilder.onTimeout].

--- a/integration/kotlinx-coroutines-jdk8/test/time/FlowDebounceTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/FlowDebounceTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.time
+
+import kotlinx.coroutines.TestBase
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withVirtualTime
+import org.junit.Test
+import java.time.Duration
+import kotlin.test.assertEquals
+
+class FlowDebounceTest : TestBase() {
+    @Test
+    public fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(Duration.ofMillis(1500))
+            emit("B")
+            delay(Duration.ofMillis(500))
+            emit("C")
+            delay(Duration.ofMillis(250))
+            emit("D")
+            delay(Duration.ofMillis(2000))
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.debounce(Duration.ofMillis(1000)).toList()
+        assertEquals(listOf("A", "D", "E"), result)
+        finish(5)
+    }
+}

--- a/integration/kotlinx-coroutines-jdk8/test/time/FlowSampleTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/FlowSampleTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.time
+
+import kotlinx.coroutines.TestBase
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withVirtualTime
+import org.junit.Test
+import java.time.Duration
+import kotlin.test.assertEquals
+
+
+class SampleTest : TestBase() {
+    @Test
+    public fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(Duration.ofMillis(1500))
+            emit("B")
+            delay(Duration.ofMillis(500))
+            emit("C")
+            delay(Duration.ofMillis(250))
+            emit("D")
+            delay(Duration.ofMillis(2000))
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.sample(Duration.ofMillis(1000)).toList()
+        assertEquals(listOf("A", "B", "D"), result)
+        finish(5)
+    }
+}


### PR DESCRIPTION
I get trouble problem with tests

```
No tests found for given includes: [time.FlowDebounceTest](filter.includeTestsMatching)
```

However it should be ok (I hope :)