### PR TITLE
Readme improvement

### DIFF
--- a/kotlinx-coroutines-test/README.md
+++ b/kotlinx-coroutines-test/README.md
@@ -277,7 +277,7 @@ important to ensure that [cleanupTestCoroutines][TestCoroutineScope.cleanupTestC
 ```kotlin
 class TestClass {
     private val testScope = TestCoroutineScope()
-    private lateinit var subject: Subject = null 
+    private lateinit var subject: Subject
     
     @Before
     fun setup() {


### PR DESCRIPTION
There was a small mistake in the Readme of kotlinx-coroutines-test. A lateinit variable evaluated to null at the beginning.