### PR TITLE
Fill in stacktrace of cancellation exception with an empty array to p…

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -40,7 +40,8 @@ internal actual class JobCancellationException public actual constructor(
         if (DEBUG) {
             return super.fillInStackTrace()
         }
-
+        // Prevent Android <= 6.0 bug, #1866
+        stackTrace = emptyArray()
         /*
          * In non-debug mode we don't want to have a stacktrace on every cancellation/close,
          * parent job reference is enough. Stacktrace of JCE is not needed most of the time (e.g., it is not logged)

--- a/kotlinx-coroutines-core/jvm/src/flow/internal/FlowExceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/flow/internal/FlowExceptions.kt
@@ -12,14 +12,18 @@ internal actual class AbortFlowException actual constructor(
 ) : CancellationException("Flow was aborted, no more elements needed") {
 
     override fun fillInStackTrace(): Throwable {
-        if (DEBUG) super.fillInStackTrace()
+        if (DEBUG) return super.fillInStackTrace()
+        // Prevent Android <= 6.0 bug, #1866
+        stackTrace = emptyArray()
         return this
     }
 }
 
 internal actual class ChildCancelledException : CancellationException("Child of the scoped flow was cancelled") {
     override fun fillInStackTrace(): Throwable {
-        if (DEBUG) super.fillInStackTrace()
+        if (DEBUG) return super.fillInStackTrace()
+        // Prevent Android <= 6.0 bug, #1866
+        stackTrace = emptyArray()
         return this
     }
 }


### PR DESCRIPTION
…roperly work on Android <= 6.0 that had a bug on a code-path with an empty stacktrace

Fixes #1866