### PR TITLE
Implement `mapForEach` Flow operator

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -57,6 +57,14 @@ public inline fun <T, R: Any> Flow<T>.mapNotNull(crossinline transform: suspend 
 }
 
 /**
+ * Returns a flow containing a list of the results of applying the given [transform] function to each value of the original flow
+ */
+public inline fun <T, R> Flow<Iterable<T>>.mapForEach(crossinline transform: suspend (value: T) -> R): Flow<List<R>> = transform { value ->
+    val transformed = value.map { transform(it) }
+    return@transform emit(transformed)
+}
+
+/**
  * Returns a flow that wraps each element into [IndexedValue], containing value and its index (starting from zero).
  */
 @ExperimentalCoroutinesApi

--- a/kotlinx-coroutines-core/common/test/flow/operators/MapForEachTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/MapForEachTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.TestBase
+import kotlinx.coroutines.TestException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.hang
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MapForEachTest : TestBase() {
+    @Test
+    fun testMap() = runTest {
+        val flow = flow {
+            emit(listOf(1, 2))
+        }
+
+        val result = flow.mapForEach { it + 1 }.single()
+        val expectedList = listOf(2, 3)
+        assertEquals(expectedList, result)
+    }
+
+    @Test
+    fun testEmptyFlow() = runTest {
+        val result = emptyFlow<List<Int>>().mapForEach { expectUnreached(); it }.singleOrNull() ?: emptyList()
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun testErrorCancelsUpstream() = runTest {
+        var cancelled = false
+        val latch = Channel<Unit>()
+        val flow = flow {
+            coroutineScope {
+                launch {
+                    latch.send(Unit)
+                    hang { cancelled = true }
+                }
+                emit(listOf(1))
+            }
+        }.mapForEach {
+            latch.receive()
+            throw TestException()
+            it + 1
+        }.catch { emit(listOf(42)) }
+
+        assertEquals(listOf(42), flow.single())
+        assertTrue(cancelled)
+    }
+}


### PR DESCRIPTION
This `mapForEach` operator helps coroutines users avoid nested mapping function, for mapping items of an Iterable.
#### Current situation:
```kotlin
flow {
    emit(listOf(1, 2, 3))
}.map { items ->
    items.map {
        it.toString()
    }
}
```
#### With `mapForEach` operator:
```kotlin
flow {
    emit(listOf(1, 2, 3))
}.mapForEach {
    it.toString()
}
```