### PR TITLE
Migrate to androidx.annotation from legacy android.support.annotion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ jna_version=5.5.0
 
 # Android versions
 android_version=4.1.1.4
-android_support_version=26.1.0
+androidx_annotation_version=1.1.0
 robolectric_version=4.0.2
 baksmali_version=2.2.7
 

--- a/ui/kotlinx-coroutines-android/android-unit-tests/build.gradle
+++ b/ui/kotlinx-coroutines-android/android-unit-tests/build.gradle
@@ -4,7 +4,6 @@
 
 dependencies {
     testImplementation "com.google.android:android:$android_version"
-    testImplementation "com.android.support:support-annotations:$android_support_version"
     testImplementation "org.robolectric:robolectric:$robolectric_version"
     testImplementation project(":kotlinx-coroutines-test")
     testImplementation project(":kotlinx-coroutines-android")

--- a/ui/kotlinx-coroutines-android/build.gradle
+++ b/ui/kotlinx-coroutines-android/build.gradle
@@ -12,7 +12,7 @@ configurations {
 
 dependencies {
     compileOnly "com.google.android:android:$android_version"
-    compileOnly "com.android.support:support-annotations:$android_support_version"
+    compileOnly "androidx.annotation:annotation:$androidx_annotation_version"
 
     testImplementation "com.google.android:android:$android_version"
     testImplementation "org.robolectric:robolectric:$robolectric_version"

--- a/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
+++ b/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
@@ -5,7 +5,7 @@
 package kotlinx.coroutines.android
 
 import android.os.*
-import android.support.annotation.*
+import androidx.annotation.*
 import kotlinx.coroutines.*
 import java.lang.reflect.*
 import kotlin.coroutines.*

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -7,7 +7,7 @@
 package kotlinx.coroutines.android
 
 import android.os.*
-import android.support.annotation.*
+import androidx.annotation.*
 import android.view.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*


### PR DESCRIPTION
Legacy -> new artifact mappings: https://developer.android.com/jetpack/androidx/migrate/artifact-mappings
The most recent version: https://developer.android.com/jetpack/androidx/releases/annotation
