### PR TITLE
Kotlin DSL - 'js-stub'

### DIFF
--- a/js/js-stub/build.gradle.kts
+++ b/js/js-stub/build.gradle.kts
@@ -2,7 +2,9 @@
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-compileKotlin {
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+tasks.named<KotlinCompile>("compileKotlin") {
     kotlinOptions {
         freeCompilerArgs += "-Xallow-kotlin-package"
     }


### PR DESCRIPTION
Part of #1938