### PR TITLE
Fix class cast exception during undispatched resume of cancellable co…

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt
+++ b/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt
@@ -117,7 +117,7 @@ internal fun <T> DispatchedTask<T>.resume(delegate: Continuation<T>, useMode: In
     // slow-path - use delegate
     val state = takeState()
     val exception = getExceptionalResult(state)?.let { recoverStackTrace(it, delegate) }
-    val result = if (exception != null) Result.failure(exception) else Result.success(state as T)
+    val result = if (exception != null) Result.failure(exception) else Result.success(getSuccessfulResult<T>(state))
     when (useMode) {
         MODE_ATOMIC_DEFAULT -> delegate.resumeWith(result)
         MODE_CANCELLABLE -> delegate.resumeCancellableWith(result)

--- a/kotlinx-coroutines-core/common/test/CancellableResumeTest.kt
+++ b/kotlinx-coroutines-core/common/test/CancellableResumeTest.kt
@@ -119,4 +119,16 @@ class CancellableResumeTest : TestBase() {
         yield() // to coroutine -- throws cancellation exception
         finish(9)
     }
+
+
+    @Test
+    fun testResumeUnconfined() = runTest {
+        val outerScope = this
+        withContext(Dispatchers.Unconfined) {
+            val result = suspendCancellableCoroutine<String> {
+                outerScope.launch { it.resume("OK", {}) }
+            }
+            assertEquals("OK", result)
+        }
+    }
 }


### PR DESCRIPTION
…ntinuation with onCancellation block

Fixes #1966

This is indeed fixed in #1937, but it would be nice to have this fix in 1.3.6 as well