### PR TITLE
Cancel current Job on RejectedExecutionException

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -257,13 +257,13 @@ public final class kotlinx/coroutines/Deferred$DefaultImpls {
 
 public abstract interface class kotlinx/coroutines/Delay {
 	public abstract fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public abstract fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public abstract fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 }
 
 public final class kotlinx/coroutines/Delay$DefaultImpls {
 	public static fun delay (Lkotlinx/coroutines/Delay;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun invokeOnTimeout (Lkotlinx/coroutines/Delay;JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public static fun invokeOnTimeout (Lkotlinx/coroutines/Delay;JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 }
 
 public final class kotlinx/coroutines/DelayKt {

--- a/kotlinx-coroutines-core/common/src/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/Delay.kt
@@ -54,8 +54,8 @@ public interface Delay {
      *
      * This implementation uses a built-in single-threaded scheduled executor service.
      */
-    public fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle =
-        DefaultDelay.invokeOnTimeout(timeMillis, block)
+    public fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
+        DefaultDelay.invokeOnTimeout(timeMillis, block, context)
 }
 
 /**

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -114,7 +114,7 @@ private fun <U, T: U> setupTimeout(
     // schedule cancellation of this coroutine on time
     val cont = coroutine.uCont
     val context = cont.context
-    coroutine.disposeOnCompletion(context.delay.invokeOnTimeout(coroutine.time, coroutine))
+    coroutine.disposeOnCompletion(context.delay.invokeOnTimeout(coroutine.time, coroutine, coroutine.context))
     // restart the block using a new coroutine with a new job,
     // however, start it undispatched, because we already are in the proper context
     return coroutine.startUndispatchedOrReturnIgnoreTimeout(coroutine, block)

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -655,7 +655,7 @@ internal class SelectBuilderImpl<in R>(
             if (trySelect())
                 block.startCoroutineCancellable(completion) // shall be cancellable while waits for dispatch
         }
-        disposeOnSelect(context.delay.invokeOnTimeout(timeMillis, action))
+        disposeOnSelect(context.delay.invokeOnTimeout(timeMillis, action, context))
     }
 
     private class DisposeNode(

--- a/kotlinx-coroutines-core/common/test/flow/VirtualTime.kt
+++ b/kotlinx-coroutines-core/common/test/flow/VirtualTime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines
@@ -50,7 +50,7 @@ private class VirtualTimeDispatcher(enclosingScope: CoroutineScope) : CoroutineD
     @ExperimentalCoroutinesApi
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = originalDispatcher.isDispatchNeeded(context)
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val task = TimedTask(block, currentTime + timeMillis)
         heap += task
         return task

--- a/kotlinx-coroutines-core/js/src/JSDispatcher.kt
+++ b/kotlinx-coroutines-core/js/src/JSDispatcher.kt
@@ -35,7 +35,7 @@ internal sealed class SetTimeoutBasedDispatcher: CoroutineDispatcher(), Delay {
         messageQueue.enqueue(block)
     }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val handle = setTimeout({ block.run() }, delayToInt(timeMillis))
         return ClearTimeout(handle)
     }
@@ -81,7 +81,7 @@ internal class WindowDispatcher(private val window: Window) : CoroutineDispatche
         window.setTimeout({ with(continuation) { resumeUndispatched(Unit) } }, delayToInt(timeMillis))
     }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val handle = window.setTimeout({ block.run() }, delayToInt(timeMillis))
         return object : DisposableHandle {
             override fun dispose() {

--- a/kotlinx-coroutines-core/jvm/src/CommonPool.kt
+++ b/kotlinx-coroutines-core/jvm/src/CommonPool.kt
@@ -103,6 +103,8 @@ internal object CommonPool : ExecutorCoroutineDispatcher() {
             (pool ?: getOrCreatePoolSync()).execute(wrapTask(block))
         } catch (e: RejectedExecutionException) {
             unTrackTask()
+            // CommonPool only rejects execution when it is being closed and this behavior is reserved
+            // for testing purposes, so we don't have to worry about cancelling the affected Job here.
             DefaultExecutor.enqueue(block)
         }
     }

--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -5,6 +5,7 @@
 package kotlinx.coroutines
 
 import java.util.concurrent.*
+import kotlin.coroutines.*
 
 internal actual val DefaultDelay: Delay = DefaultExecutor
 
@@ -54,7 +55,7 @@ internal actual object DefaultExecutor : EventLoopImplBase(), Runnable {
      * Livelock is possible only if `runBlocking` is called on internal default executed (which is used by default [delay]),
      * but it's not exposed as public API.
      */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle =
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
         scheduleInvokeOnTimeout(timeMillis, block)
 
     override fun run() {

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -39,8 +39,9 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
 /**
  * Converts an instance of [ExecutorService] to an implementation of [ExecutorCoroutineDispatcher].
  *
- * Note, that if the underlying executor throws [RejectedExecutionException] on
- * attempt to submit a continuation task (it typically happens on executor shutdown or when it uses limited queues),
+ * If the underlying executor throws [RejectedExecutionException] on
+ * attempt to submit a continuation task (it happens when [closing][ExecutorCoroutineDispatcher.close] the
+ * resulting dispatcher, on underlying executor [shutdown][ExecutorService.shutdown], or when it uses limited queues),
  * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
  * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
  */
@@ -51,8 +52,9 @@ public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher 
 /**
  * Converts an instance of [Executor] to an implementation of [CoroutineDispatcher].
  *
- * Note, that if the underlying executor throws [RejectedExecutionException] on
- * attempt to submit a continuation task (it typically happens on executor shutdown or when it uses limited queues),
+ * If the underlying executor throws [RejectedExecutionException] on
+ * attempt to submit a continuation task (it happens when [closing][ExecutorCoroutineDispatcher.close] the
+ * resulting dispatcher, on underlying executor [shutdown][ExecutorService.shutdown], or when it uses limited queues),
  * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
  * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
  */

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -38,6 +38,11 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
 
 /**
  * Converts an instance of [ExecutorService] to an implementation of [ExecutorCoroutineDispatcher].
+ *
+ * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
+ * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
+ * task is submitted to the default single-threaded executor, so that the affected coroutine can cleanup its
+ * resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
 public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher =
@@ -45,6 +50,11 @@ public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher 
 
 /**
  * Converts an instance of [Executor] to an implementation of [CoroutineDispatcher].
+ *
+ * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
+ * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
+ * task is submitted to the default single-threaded executor, so that the affected coroutine can cleanup its
+ * resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
 public fun Executor.asCoroutineDispatcher(): CoroutineDispatcher =

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -41,7 +41,7 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
  *
  * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
  * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
- * task is submitted to the default single-threaded executor, so that the affected coroutine can cleanup its
+ * task is submitted to the [Dispatchers.IO], so that the affected coroutine can cleanup its
  * resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
@@ -53,7 +53,7 @@ public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher 
  *
  * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
  * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
- * task is submitted to the default single-threaded executor, so that the affected coroutine can cleanup its
+ * task is submitted to the [Dispatchers.IO], so that the affected coroutine can cleanup its
  * resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
@@ -93,7 +93,7 @@ internal abstract class ExecutorCoroutineDispatcherBase : ExecutorCoroutineDispa
         } catch (e: RejectedExecutionException) {
             unTrackTask()
             cancelJobOnRejection(context, e)
-            DefaultExecutor.enqueue(block)
+            Dispatchers.IO.dispatch(context, block)
         }
     }
 

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -39,10 +39,10 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
 /**
  * Converts an instance of [ExecutorService] to an implementation of [ExecutorCoroutineDispatcher].
  *
- * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
- * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
- * task is submitted to the [Dispatchers.IO], so that the affected coroutine can cleanup its
- * resources and promptly complete.
+ * Note, that if the underlying executor throws [RejectedExecutionException] on
+ * attempt to submit a continuation task (it typically happens on executor shutdown or when it uses limited queues),
+ * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
+ * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
 public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher =
@@ -51,10 +51,10 @@ public fun ExecutorService.asCoroutineDispatcher(): ExecutorCoroutineDispatcher 
 /**
  * Converts an instance of [Executor] to an implementation of [CoroutineDispatcher].
  *
- * Note, that if the underlying executor uses limited queues and throws [RejectedExecutionException] on
- * attempt to submit a task, then the [Job] of the affected task is [cancelled][Job.cancel] and the
- * task is submitted to the [Dispatchers.IO], so that the affected coroutine can cleanup its
- * resources and promptly complete.
+ * Note, that if the underlying executor throws [RejectedExecutionException] on
+ * attempt to submit a continuation task (it typically happens on executor shutdown or when it uses limited queues),
+ * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
+ * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
  */
 @JvmName("from") // this is for a nice Java API, see issue #255
 public fun Executor.asCoroutineDispatcher(): CoroutineDispatcher =

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -139,7 +139,7 @@ internal abstract class ExecutorCoroutineDispatcherBase : ExecutorCoroutineDispa
     }
 
     private fun cancelJobOnRejection(context: CoroutineContext, exception: RejectedExecutionException) {
-        context[Job]?.cancel(CancellationException("The task was rejected", exception))
+        context.cancel(CancellationException("The task was rejected", exception))
     }
 
     override fun close() {

--- a/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
@@ -14,6 +14,11 @@ import kotlin.coroutines.*
  * **NOTE: The resulting [ExecutorCoroutineDispatcher] owns native resources (its thread).
  * Resources are reclaimed by [ExecutorCoroutineDispatcher.close].**
  *
+ * If the resulting dispatcher is [closed][ExecutorCoroutineDispatcher.close] and
+ * attempt to submit a continuation task is made,
+ * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
+ * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
+ *
  * **NOTE: This API will be replaced in the future**. A different API to create thread-limited thread pools
  * that is based on a shared thread-pool and does not require the resulting dispatcher to be explicitly closed
  * will be provided, thus avoiding potential thread leaks and also significantly improving performance, due
@@ -34,6 +39,11 @@ public fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher =
  * Creates a coroutine execution context with the fixed-size thread-pool and built-in [yield] support.
  * **NOTE: The resulting [ExecutorCoroutineDispatcher] owns native resources (its threads).
  * Resources are reclaimed by [ExecutorCoroutineDispatcher.close].**
+ *
+ * If the resulting dispatcher is [closed][ExecutorCoroutineDispatcher.close] and
+ * attempt to submit a continuation task is made,
+ * then the [Job] of the affected task is [cancelled][Job.cancel] and the task is submitted to the
+ * [Dispatchers.IO], so that the affected coroutine can cleanup its resources and promptly complete.
  *
  * **NOTE: This API will be replaced in the future**. A different API to create thread-limited thread pools
  * that is based on a shared thread-pool and does not require the resulting dispatcher to be explicitly closed

--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -87,17 +87,14 @@ private class MissingMainCoroutineDispatcher(
 
     override val immediate: MainCoroutineDispatcher get() = this
 
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean =
         missing()
-    }
 
-    override suspend fun delay(time: Long) {
+    override suspend fun delay(time: Long) =
         missing()
-    }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
         missing()
-    }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) =
         missing()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -65,6 +65,8 @@ public open class ExperimentalCoroutineDispatcher(
         try {
             coroutineScheduler.dispatch(block)
         } catch (e: RejectedExecutionException) {
+            // CoroutineScheduler only rejects execution when it is being closed and this behavior is reserved
+            // for testing purposes, so we don't have to worry about cancelling the affected Job here.
             DefaultExecutor.dispatch(context, block)
         }
 
@@ -72,6 +74,8 @@ public open class ExperimentalCoroutineDispatcher(
         try {
             coroutineScheduler.dispatch(block, tailDispatch = true)
         } catch (e: RejectedExecutionException) {
+            // CoroutineScheduler only rejects execution when it is being closed and this behavior is reserved
+            // for testing purposes, so we don't have to worry about cancelling the affected Job here.
             DefaultExecutor.dispatchYield(context, block)
         }
 
@@ -110,7 +114,9 @@ public open class ExperimentalCoroutineDispatcher(
         try {
             coroutineScheduler.dispatch(block, context, tailDispatch)
         } catch (e: RejectedExecutionException) {
-            // Context shouldn't be lost here to properly invoke before/after task
+            // CoroutineScheduler only rejects execution when it is being closed and this behavior is reserved
+            // for testing purposes, so we don't have to worry about cancelling the affected Job here.
+            // TaskContext shouldn't be lost here to properly invoke before/after task
             DefaultExecutor.enqueue(coroutineScheduler.createTask(block, context))
         }
     }

--- a/kotlinx-coroutines-core/jvm/src/test_/TestCoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/test_/TestCoroutineContext.kt
@@ -230,7 +230,7 @@ public class TestCoroutineContext(private val name: String? = null) : CoroutineC
             }, timeMillis)
         }
 
-        override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+        override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
             val node = postDelayed(block, timeMillis)
             return object : DisposableHandle {
                 override fun dispose() {

--- a/kotlinx-coroutines-core/jvm/test/ExecutorsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ExecutorsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines
@@ -29,6 +29,8 @@ class ExecutorsTest : TestBase() {
         val context = newFixedThreadPoolContext(2, "TestPool")
         runBlocking(context) {
             checkThreadName("TestPool")
+            delay(10)
+            checkThreadName("TestPool") // should dispatch on the right thread
         }
         context.close()
     }
@@ -38,6 +40,8 @@ class ExecutorsTest : TestBase() {
         val executor = Executors.newSingleThreadExecutor { r -> Thread(r, "TestExecutor") }
         runBlocking(executor.asCoroutineDispatcher()) {
             checkThreadName("TestExecutor")
+            delay(10)
+            checkThreadName("TestExecutor") // should dispatch on the right thread
         }
         executor.shutdown()
     }

--- a/kotlinx-coroutines-core/jvm/test/RejectedExecutionTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/RejectedExecutionTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import org.junit.*
+import org.junit.Test
+import java.util.concurrent.*
+import kotlin.test.*
+
+class RejectedExecutionTest : TestBase() {
+    private val threadName = "RejectedExecutionTest"
+    private val executor = RejectingExecutor()
+
+    @After
+    fun tearDown() {
+        executor.shutdown()
+        executor.awaitTermination(10, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun testRejectOnLaunch() = runTest {
+        expect(1)
+        val job = launch(executor.asCoroutineDispatcher()) {
+            expectUnreached()
+        }
+        assertEquals(1, executor.submittedTasks)
+        assertTrue(job.isCancelled)
+        finish(2)
+    }
+
+    @Test
+    fun testRejectOnLaunchAtomic() = runTest {
+        expect(1)
+        val job = launch(executor.asCoroutineDispatcher(), start = CoroutineStart.ATOMIC) {
+            expect(2)
+            assertEquals(true, coroutineContext[Job]?.isCancelled)
+            assertNotSame(threadName, Thread.currentThread().name) // should have got dispatched on the DefaultExecutor
+        }
+        assertEquals(1, executor.submittedTasks)
+        job.join()
+        finish(3)
+    }
+
+    @Test
+    fun testRejectOnWithContext() = runTest {
+        expect(1)
+        assertFailsWith<CancellationException> {
+            withContext(executor.asCoroutineDispatcher()) {
+                expectUnreached()
+            }
+        }
+        assertEquals(1, executor.submittedTasks)
+        finish(2)
+    }
+
+    @Test
+    fun testRejectOnResumeInContext() = runTest {
+        expect(1)
+        executor.acceptTasks = 1 // accept one task
+        assertFailsWith<CancellationException> {
+            withContext(executor.asCoroutineDispatcher()) {
+                expect(2)
+                withContext(Dispatchers.Default) {
+                    expect(3)
+                }
+                // cancelled on resume back
+                expectUnreached()
+            }
+        }
+        assertEquals(2, executor.submittedTasks)
+        finish(4)
+    }
+
+    @Test
+    fun testRejectOnDelay() = runTest {
+        expect(1)
+        executor.acceptTasks = 1 // accept one task
+        assertFailsWith<CancellationException> {
+            withContext(executor.asCoroutineDispatcher()) {
+                expect(2)
+                delay(10) // cancelled
+                expectUnreached()
+            }
+        }
+        assertEquals(2, executor.submittedTasks)
+        finish(3)
+    }
+
+    @Test
+    fun testRejectWithTimeout() = runTest {
+        expect(1)
+        executor.acceptTasks = 1 // accept one task
+        assertFailsWith<CancellationException> {
+            withContext(executor.asCoroutineDispatcher()) {
+                expect(2)
+                withTimeout(1000) {
+                    expect(3) // atomic entry into the block (legacy behavior, it seem to be Ok with way)
+                    assertEquals(true, coroutineContext[Job]?.isCancelled) // but the job is already cancelled
+                }
+                expectUnreached()
+            }
+        }
+        assertEquals(2, executor.submittedTasks)
+        finish(4)
+    }
+
+    private inner class RejectingExecutor : ScheduledThreadPoolExecutor(1, { r -> Thread(r, threadName) }) {
+        var acceptTasks = 0
+        var submittedTasks = 0
+
+        override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
+            submittedTasks++
+            if (submittedTasks > acceptTasks) throw RejectedExecutionException()
+            return super.schedule(command, delay, unit)
+        }
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/RejectedExecutionTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/RejectedExecutionTest.kt
@@ -67,16 +67,18 @@ class RejectedExecutionTest : TestBase() {
                     try {
                         withContext(Dispatchers.Default) {
                             expect(3)
+                            assertDefaultDispatcherThread()
                         }
                         // cancelled on resume back
                     } finally {
+                        expect(4)
                         assertIoThread()
                     }
                     expectUnreached()
                 }
         }
         assertEquals(2, executor.submittedTasks)
-        finish(4)
+        finish(5)
     }
 
     @Test
@@ -133,6 +135,12 @@ class RejectedExecutionTest : TestBase() {
     private fun assertExecutorThread() {
         val thread = Thread.currentThread()
         if (!thread.name.startsWith(threadName)) error("Not an executor thread: $thread")
+    }
+
+    private fun assertDefaultDispatcherThread() {
+        val thread = Thread.currentThread()
+        if (thread !is CoroutineScheduler.Worker) error("Not a thread from Dispatchers.Default: $thread")
+        assertEquals(CoroutineScheduler.WorkerState.CPU_ACQUIRED, thread.state)
     }
 
     private fun assertIoThread() {

--- a/kotlinx-coroutines-core/native/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/native/src/CoroutineContext.kt
@@ -16,8 +16,8 @@ internal actual object DefaultExecutor : CoroutineDispatcher(), Delay {
         takeEventLoop().dispatch(context, block)
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) =
         takeEventLoop().scheduleResumeAfterDelay(timeMillis, continuation)
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle =
-        takeEventLoop().invokeOnTimeout(timeMillis, block)
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
+        takeEventLoop().invokeOnTimeout(timeMillis, block, context)
 
     actual fun enqueue(task: Runnable): Unit = loopWasShutDown()
 }

--- a/kotlinx-coroutines-core/native/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/native/src/EventLoop.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines
 
+import kotlin.coroutines.*
 import kotlin.system.*
 
 internal actual abstract class EventLoopImplPlatform: EventLoop() {
@@ -13,7 +14,7 @@ internal actual abstract class EventLoopImplPlatform: EventLoop() {
 }
 
 internal class EventLoopImpl: EventLoopImplBase() {
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle =
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
         scheduleInvokeOnTimeout(timeMillis, block)
 }
 

--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
@@ -25,7 +25,7 @@ public final class kotlinx/coroutines/test/TestCoroutineDispatcher : kotlinx/cor
 	public fun dispatch (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
 	public fun dispatchYield (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
 	public fun getCurrentTime ()J
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun pauseDispatcher ()V
 	public fun pauseDispatcher (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun resumeDispatcher ()V

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -65,7 +65,7 @@ public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayControl
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val node = postDelayed(block, timeMillis)
         return object : DisposableHandle {
             override fun dispose() {

--- a/kotlinx-coroutines-test/src/internal/MainTestDispatcher.kt
+++ b/kotlinx-coroutines-test/src/internal/MainTestDispatcher.kt
@@ -46,8 +46,8 @@ internal class TestMainDispatcher(private val mainFactory: MainDispatcherFactory
         delay.delay(time)
     }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
-        return delay.invokeOnTimeout(timeMillis, block)
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
+        return delay.invokeOnTimeout(timeMillis, block, context)
     }
 
     public fun setDispatcher(dispatcher: CoroutineDispatcher) {

--- a/reactive/kotlinx-coroutines-reactor/api/kotlinx-coroutines-reactor.api
+++ b/reactive/kotlinx-coroutines-reactor/api/kotlinx-coroutines-reactor.api
@@ -49,7 +49,7 @@ public final class kotlinx/coroutines/reactor/SchedulerCoroutineDispatcher : kot
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getScheduler ()Lreactor/core/scheduler/Scheduler;
 	public fun hashCode ()I
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/reactive/kotlinx-coroutines-reactor/src/Scheduler.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Scheduler.kt
@@ -39,7 +39,7 @@ public class SchedulerCoroutineDispatcher(
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle =
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
         scheduler.schedule(block, timeMillis, TimeUnit.MILLISECONDS).asDisposableHandle()
 
     /** @suppress */

--- a/reactive/kotlinx-coroutines-rx2/api/kotlinx-coroutines-rx2.api
+++ b/reactive/kotlinx-coroutines-rx2/api/kotlinx-coroutines-rx2.api
@@ -80,7 +80,7 @@ public final class kotlinx/coroutines/rx2/SchedulerCoroutineDispatcher : kotlinx
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getScheduler ()Lio/reactivex/Scheduler;
 	public fun hashCode ()I
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/reactive/kotlinx-coroutines-rx2/src/RxScheduler.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxScheduler.kt
@@ -38,7 +38,7 @@ public class SchedulerCoroutineDispatcher(
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val disposable = scheduler.scheduleDirect(block, timeMillis, TimeUnit.MILLISECONDS)
         return DisposableHandle { disposable.dispose() }
     }

--- a/reactive/kotlinx-coroutines-rx3/api/kotlinx-coroutines-rx3.api
+++ b/reactive/kotlinx-coroutines-rx3/api/kotlinx-coroutines-rx3.api
@@ -67,7 +67,7 @@ public final class kotlinx/coroutines/rx3/SchedulerCoroutineDispatcher : kotlinx
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getScheduler ()Lio/reactivex/rxjava3/core/Scheduler;
 	public fun hashCode ()I
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/reactive/kotlinx-coroutines-rx3/src/RxScheduler.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxScheduler.kt
@@ -38,7 +38,7 @@ public class SchedulerCoroutineDispatcher(
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val disposable = scheduler.scheduleDirect(block, timeMillis, TimeUnit.MILLISECONDS)
         return DisposableHandle { disposable.dispose() }
     }

--- a/ui/kotlinx-coroutines-android/api/kotlinx-coroutines-android.api
+++ b/ui/kotlinx-coroutines-android/api/kotlinx-coroutines-android.api
@@ -1,7 +1,7 @@
 public abstract class kotlinx/coroutines/android/HandlerDispatcher : kotlinx/coroutines/MainCoroutineDispatcher, kotlinx/coroutines/Delay {
 	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getImmediate ()Lkotlinx/coroutines/android/HandlerDispatcher;
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 }
 
 public final class kotlinx/coroutines/android/HandlerDispatcherKt {

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -140,7 +140,7 @@ internal class HandlerContext private constructor(
         continuation.invokeOnCancellation { handler.removeCallbacks(block) }
     }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         handler.postDelayed(block, timeMillis.coerceAtMost(MAX_DELAY))
         return object : DisposableHandle {
             override fun dispose() {

--- a/ui/kotlinx-coroutines-javafx/api/kotlinx-coroutines-javafx.api
+++ b/ui/kotlinx-coroutines-javafx/api/kotlinx-coroutines-javafx.api
@@ -5,7 +5,7 @@ public final class kotlinx/coroutines/javafx/JavaFxConvertKt {
 public abstract class kotlinx/coroutines/javafx/JavaFxDispatcher : kotlinx/coroutines/MainCoroutineDispatcher, kotlinx/coroutines/Delay {
 	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dispatch (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 }
 

--- a/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
+++ b/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
@@ -42,7 +42,7 @@ public sealed class JavaFxDispatcher : MainCoroutineDispatcher(), Delay {
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val timeline = schedule(timeMillis, TimeUnit.MILLISECONDS, EventHandler {
             block.run()
         })

--- a/ui/kotlinx-coroutines-swing/api/kotlinx-coroutines-swing.api
+++ b/ui/kotlinx-coroutines-swing/api/kotlinx-coroutines-swing.api
@@ -1,7 +1,7 @@
 public abstract class kotlinx/coroutines/swing/SwingDispatcher : kotlinx/coroutines/MainCoroutineDispatcher, kotlinx/coroutines/Delay {
 	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun dispatch (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
-	public fun invokeOnTimeout (JLjava/lang/Runnable;)Lkotlinx/coroutines/DisposableHandle;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
 }
 

--- a/ui/kotlinx-coroutines-swing/src/SwingDispatcher.kt
+++ b/ui/kotlinx-coroutines-swing/src/SwingDispatcher.kt
@@ -36,7 +36,7 @@ public sealed class SwingDispatcher : MainCoroutineDispatcher(), Delay {
     }
 
     /** @suppress */
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val timer = schedule(timeMillis, TimeUnit.MILLISECONDS, ActionListener {
             block.run()
         })


### PR DESCRIPTION
When the Executor that was used with Executor.asCoroutineDispatcher() extension rejects submitted task, it means that it had reached its capacity and so the executing current Job should be cancelled to terminate it as soon as possible. This way RejectedExecutionException works as a rate-limiter just like it serves this purpose in executor-based Java code.

**NOTE**: This PR changes internal coroutines API for `Delay` interface which some 3rd part code might be using, so it should be merged only in the major release.

Fixes #2003