### PR TITLE
Remove parent.start() from CancellableContinuationImpl.kt

### DIFF
--- a/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
@@ -114,7 +114,6 @@ internal open class CancellableContinuationImpl<in T>(
         if (checkCompleted()) return
         if (parentHandle !== null) return // fast path 2 -- was already initialized
         val parent = delegate.context[Job] ?: return // fast path 3 -- don't do anything without parent
-        parent.start() // make sure the parent is started
         val handle = parent.invokeOnCompletion(
             onCancelling = true,
             handler = ChildContinuation(parent, this).asHandler


### PR DESCRIPTION
It seems to be the legacy from times when CC was a Job, in order to observe behaviour change, a specific example should be accurately made.

Note that this changes the behaviour of the following (weird, but still) test:

```
@Test
fun suspendCancellableContinuationParentStart() = runTest {
    val job = launch(start = CoroutineStart.LAZY) { println("Aha!") }
    ::suspendCancellable.startCoroutine(Continuation(job) {})
}

suspend fun suspendCancellable() = suspendCancellableCoroutine<Int> { 
    it.resumeWith(Result.success(42))
}
```