### PR TITLE
Remove keep rules mentioning kotlinx.coroutines.android

### DIFF
--- a/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
@@ -1,8 +1,6 @@
 # ServiceLoader support
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
 -keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
--keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {}
--keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {}
 
 # Most of volatile fields are updated with AFU and should not be mangled
 -keepclassmembernames class kotlinx.** {
@@ -13,3 +11,4 @@
 -keepclassmembernames class kotlin.coroutines.SafeContinuation {
     volatile <fields>;
 }
+


### PR DESCRIPTION
The rule -keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {} is present in kotlinx.coroutines.android/META-INF/proguard/coroutines.pro and should therefore not be needed. If the -keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {} is needed, it should go into kotlinx.coroutines.android/META-INF/proguard/coroutines.pro