### PR TITLE
Improve grammar in docs/Basics

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -41,7 +41,7 @@ fun main() {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-01.kt).
 
 You will see the following result:
 
@@ -95,7 +95,7 @@ fun main() {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-02.kt).
 
 <!--- TEST
 Hello,
@@ -125,7 +125,7 @@ fun main() = runBlocking<Unit> { // start main coroutine
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-03.kt).
 
 <!--- TEST
 Hello,
@@ -180,7 +180,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-04.kt).
 
 <!--- TEST
 Hello,
@@ -225,7 +225,7 @@ fun main() = runBlocking { // this: CoroutineScope
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-05.kt).
 
 <!--- TEST
 Hello,
@@ -271,7 +271,7 @@ fun main() = runBlocking { // this: CoroutineScope
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt).
 
 <!--- TEST
 Task from coroutine scope
@@ -310,7 +310,7 @@ suspend fun doWorld() {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-07.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-07.kt).
 
 <!--- TEST
 Hello,
@@ -347,7 +347,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-08.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-08.kt).
 
 <!--- TEST lines.size == 1 && lines[0] == ".".repeat(100_000) -->
 
@@ -379,7 +379,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-09.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-basic-09.kt).
 
 You can run and see that it prints three lines and terminates:
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -57,24 +57,24 @@ They are launched with [launch] _coroutine builder_ in a context of some [Corout
 Here we are launching a new coroutine in the [GlobalScope], meaning that the lifetime of the new
 coroutine is limited only by the lifetime of the whole application.  
 
-You can achieve the same result replacing
-`GlobalScope.launch { ... }` with `thread { ... }` and `delay(...)` with `Thread.sleep(...)`. 
+You can achieve the same result by replacing
+`GlobalScope.launch { ... }` with `thread { ... }`, and `delay(...)` with `Thread.sleep(...)`. 
 Try it (don't forget to import `kotlin.concurrent.thread`).
 
-If you start by replacing `GlobalScope.launch` by `thread`, the compiler produces the following error:
+If you start by replacing `GlobalScope.launch` with `thread`, the compiler produces the following error:
 
 ```
 Error: Kotlin: Suspend functions are only allowed to be called from a coroutine or another suspend function
 ```
 
-That is because [delay] is a special _suspending function_ that does not block a thread, but _suspends_
-coroutine and it can be only used from a coroutine.
+That is because [delay] is a special _suspending function_ that does not block a thread, but _suspends_ the
+coroutine, and it can be only used from a coroutine.
 
 ### Bridging blocking and non-blocking worlds
 
 The first example mixes _non-blocking_ `delay(...)` and _blocking_ `Thread.sleep(...)` in the same code. 
 It is easy to lose track of which one is blocking and which one is not. 
-Let's be explicit about blocking using [runBlocking] coroutine builder:
+Let's be explicit about blocking using the [runBlocking] coroutine builder:
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
 
@@ -195,7 +195,7 @@ the background job in any way. Much better.
 There is still something to be desired for practical usage of coroutines. 
 When we use `GlobalScope.launch`, we create a top-level coroutine. Even though it is light-weight, it still 
 consumes some memory resources while it runs. If we forget to keep a reference to the newly launched 
-coroutine it still runs. What if the code in the coroutine hangs (for example, we erroneously
+coroutine, it still runs. What if the code in the coroutine hangs (for example, we erroneously
 delay for too long), what if we launched too many coroutines and ran out of memory? 
 Having to manually keep references to all the launched coroutines and [join][Job.join] them is error-prone. 
 
@@ -203,7 +203,7 @@ There is a better solution. We can use structured concurrency in our code.
 Instead of launching coroutines in the [GlobalScope], just like we usually do with threads (threads are always global), 
 we can launch coroutines in the specific scope of the operation we are performing. 
 
-In our example, we have `main` function that is turned into a coroutine using [runBlocking] coroutine builder.
+In our example, we have a `main` function that is turned into a coroutine using a [runBlocking] coroutine builder.
 Every coroutine builder, including `runBlocking`, adds an instance of [CoroutineScope] to the scope of its code block. 
 We can launch coroutines in this scope without having to `join` them explicitly, because
 an outer coroutine (`runBlocking` in our example) does not complete until all the coroutines launched
@@ -233,12 +233,12 @@ World!
 -->
 
 ### Scope builder
-In addition to the coroutine scope provided by different builders, it is possible to declare your own scope using
-[coroutineScope] builder. It creates a coroutine scope and does not complete until all launched children
-complete. 
 
-[runBlocking] and [coroutineScope] may look similar because they both wait for its body and all its children to complete.
-The main difference between these two is that the [runBlocking] method _blocks_ the current thread for waiting,
+In addition to the coroutine scope provided by different builders, it is possible to declare your own scope using the
+[coroutineScope] builder. It creates a coroutine scope and does not complete until all launched children complete. 
+
+[runBlocking] and [coroutineScope] may look similar because they both wait for their body and all its children to complete.
+The main difference is that the [runBlocking] method _blocks_ the current thread for waiting,
 while [coroutineScope] just suspends, releasing the underlying thread for other usages.
 Because of that difference, [runBlocking] is a regular function and [coroutineScope] is a suspending function.
 
@@ -280,16 +280,16 @@ Task from nested launch
 Coroutine scope is over
 -->
 
-Note that right after "Task from coroutine scope" message, while waiting for nested launch,
- "Task from runBlocking" is executed and printed, though coroutineScope is not completed yet. 
+Note that right after the "Task from coroutine scope" message (while waiting for nested launch)
+ "Task from runBlocking" is executed and printed — even though the coroutineScope is not completed yet. 
 
 ### Extract function refactoring
 
 Let's extract the block of code inside `launch { ... }` into a separate function. When you 
-perform "Extract function" refactoring on this code you get a new function with `suspend` modifier.
-That is your first _suspending function_. Suspending functions can be used inside coroutines
+perform "Extract function" refactoring on this code, you get a new function with the `suspend` modifier.
+This is your first _suspending function_. Suspending functions can be used inside coroutines
 just like regular functions, but their additional feature is that they can, in turn, 
-use other suspending functions, like `delay` in this example, to _suspend_ execution of a coroutine.
+use other suspending functions (like `delay` in this example) to _suspend_ execution of a coroutine.
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
 
@@ -319,11 +319,11 @@ World!
 
 
 But what if the extracted function contains a coroutine builder which is invoked on the current scope?
-In this case `suspend` modifier on the extracted function is not enough. Making `doWorld` an extension
-method on `CoroutineScope` is one of the solutions, but it may not always be applicable as it does not make API clearer.
+In this case, the `suspend` modifier on the extracted function is not enough. Making `doWorld` an extension
+method on `CoroutineScope` is one of the solutions, but it may not always be applicable as it does not make the API clearer.
 The idiomatic solution is to have either an explicit `CoroutineScope` as a field in a class containing the target function
 or an implicit one when the outer class implements `CoroutineScope`.
-As a last resort, [CoroutineScope(coroutineContext)][CoroutineScope()] can be used, but such approach is structurally unsafe 
+As a last resort, [CoroutineScope(coroutineContext)][CoroutineScope()] can be used, but such an approach is structurally unsafe 
 because you no longer have control on the scope of execution of this method. Only private APIs can use this builder.
 
 ### Coroutines ARE light-weight
@@ -352,6 +352,7 @@ fun main() = runBlocking {
 <!--- TEST lines.size == 1 && lines[0] == ".".repeat(100_000) -->
 
 It launches 100K coroutines and, after a second, each coroutine prints a dot. 
+
 Now, try that with threads. What would happen? (Most likely your code will produce some sort of out-of-memory error)
 
 ### Global coroutines are like daemon threads

--- a/docs/cancellation-and-timeouts.md
+++ b/docs/cancellation-and-timeouts.md
@@ -49,7 +49,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-01.kt).
 
 It produces the following output:
 
@@ -104,7 +104,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-02.kt).
 
 Run it to see that it continues to print "I'm sleeping" even after cancellation
 until the job completes by itself after five iterations.
@@ -156,7 +156,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-03.kt).
 
 As you can see, now this loop is cancelled. [isActive] is an extension property 
 available inside the coroutine via the [CoroutineScope] object.
@@ -203,7 +203,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-04.kt).
 
 Both [join][Job.join] and [cancelAndJoin] wait for all finalization actions to complete, 
 so the example above produces the following output:
@@ -259,7 +259,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-05.kt).
 
 <!--- TEST
 job: I'm sleeping 0 ...
@@ -298,7 +298,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-06.kt).
 
 It produces the following output:
 
@@ -342,7 +342,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-07.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-cancel-07.kt).
 
 There is no longer an exception when running this code:
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -52,7 +52,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-01.kt).
 
 The output of this code is:
 
@@ -99,7 +99,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-02.kt).
 
 <!--- TEST 
 1
@@ -141,7 +141,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-03.kt).
 
 <!--- TEST 
 1
@@ -214,7 +214,7 @@ fun CoroutineScope.square(numbers: ReceiveChannel<Int>): ReceiveChannel<Int> = p
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-04.kt).
 
 <!--- TEST 
 1
@@ -305,7 +305,7 @@ fun CoroutineScope.filter(numbers: ReceiveChannel<Int>, prime: Int) = produce<In
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-05.kt).
 
 The output of this code is:
 
@@ -408,7 +408,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-06.kt).
 
 The output will be similar to the the following one, albeit the processor ids that receive
 each specific integer may be different:
@@ -488,7 +488,7 @@ suspend fun sendString(channel: SendChannel<String>, s: String, time: Long) {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-07.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-07.kt).
 
 The output is:
 
@@ -540,7 +540,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-08.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-08.kt).
 
 It prints "sending" _five_ times using a buffered channel with capacity of _four_:
 
@@ -595,7 +595,7 @@ suspend fun player(name: String, table: Channel<Ball>) {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-09.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-09.kt).
 
 The "ping" coroutine is started first, so it is the first one to receive the ball. Even though "ping"
 coroutine immediately starts receiving the ball again after sending it back to the table, the ball gets
@@ -658,7 +658,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-10.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-channel-10.kt).
 
 It prints following lines:
 

--- a/docs/composing-suspending-functions.md
+++ b/docs/composing-suspending-functions.md
@@ -81,7 +81,7 @@ suspend fun doSomethingUsefulTwo(): Int {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-01.kt).
 
 It produces something like this:
 
@@ -134,7 +134,7 @@ suspend fun doSomethingUsefulTwo(): Int {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-02.kt).
 
 It produces something like this:
 
@@ -188,7 +188,7 @@ suspend fun doSomethingUsefulTwo(): Int {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-03.kt).
 
 It produces something like this:
 
@@ -285,7 +285,7 @@ suspend fun doSomethingUsefulTwo(): Int {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-04.kt).
 
 <!--- TEST ARBITRARY_TIME
 The answer is 42
@@ -361,7 +361,7 @@ suspend fun doSomethingUsefulTwo(): Int {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-05.kt).
 
 We still have concurrent execution of both operations, as evident from the output of the above `main` function: 
 
@@ -408,7 +408,7 @@ suspend fun failedConcurrentSum(): Int = coroutineScope {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-compose-06.kt).
 
 Note how both the first `async` and the awaiting parent are cancelled on failure of one of the children
 (namely, `two`):

--- a/docs/coroutine-context-and-dispatchers.md
+++ b/docs/coroutine-context-and-dispatchers.md
@@ -65,7 +65,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-01.kt).
 
 It produces the following output (maybe in different order):
 
@@ -129,7 +129,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-02.kt).
 
 Produces the output: 
  
@@ -186,7 +186,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-03.kt).
 
 There are three coroutines. The main coroutine (#1) inside `runBlocking` 
 and two coroutines computing the deferred values `a` (#2) and `b` (#3).
@@ -238,7 +238,7 @@ fun main() {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
 
 It demonstrates several new techniques. One is using [runBlocking] with an explicitly specified context, and
 the other one is using the [withContext] function to change the context of a coroutine while still staying in the
@@ -274,7 +274,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-05.kt).
 
 In the [debug mode](#debugging-coroutines-and-threads), it outputs something like this:
 
@@ -332,7 +332,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-06.kt).
 
 The output of this code is:
 
@@ -375,7 +375,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-07.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-07.kt).
 
 The result is going to be:
 
@@ -427,7 +427,7 @@ fun main() = runBlocking(CoroutineName("main")) {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-08.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-08.kt).
 
 The output it produces with `-Dkotlinx.coroutines.debug` JVM option is similar to:
  
@@ -462,7 +462,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-09.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-09.kt).
 
 The output of this code with the `-Dkotlinx.coroutines.debug` JVM option is: 
 
@@ -566,7 +566,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-10.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-10.kt).
 
 The output of this example is:
 
@@ -620,7 +620,7 @@ fun main() = runBlocking<Unit> {
 
 </div>                                                                                       
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-11.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-context-11.kt).
 
 In this example we launch a new coroutine in a background thread pool using [Dispatchers.Default], so
 it works on a different thread from the thread pool, but it still has the value of the thread local variable

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -62,7 +62,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-01.kt).
 
 The output of this code is (with [debug](https://github.com/Kotlin/kotlinx.coroutines/blob/master/docs/coroutine-context-and-dispatchers.md#debugging-coroutines-and-threads)):
 
@@ -126,7 +126,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-02.kt).
 
 The output of this code is:
 
@@ -172,7 +172,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-03.kt).
 
 The output of this code is:
 
@@ -232,7 +232,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-04.kt).
 
 The output of this code is:
 
@@ -284,7 +284,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-05.kt).
 
 > Note: This above code will work properly only on JDK7+ that supports `suppressed` exceptions
 
@@ -334,7 +334,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-exceptions-06.kt).
 
 The output of this code is:
 
@@ -398,7 +398,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-01.kt).
 
 The output of this code is:
 
@@ -447,7 +447,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-02.kt).
 
 The output of this code is:
 
@@ -491,7 +491,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-supervision-03.kt).
 
 The output of this code is:
 

--- a/docs/select-expression.md
+++ b/docs/select-expression.md
@@ -125,7 +125,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-01.kt).
 
 The result of this code is: 
 
@@ -220,7 +220,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-02.kt).
 
 The result of this code is quite interesting, so we'll analyze it in mode detail:
 
@@ -310,7 +310,7 @@ fun main() = runBlocking<Unit> {
 
 </div> 
  
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-03.kt).
   
 So let us see what happens:
  
@@ -403,7 +403,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-04.kt).
 
 The output is:
 
@@ -522,7 +522,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-select-05.kt).
 
 The result of this code:
 

--- a/docs/shared-mutable-state-and-concurrency.md
+++ b/docs/shared-mutable-state-and-concurrency.md
@@ -90,7 +90,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-01.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-01.kt).
 
 <!--- TEST LINES_START
 Completed 100000 actions in
@@ -144,7 +144,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-02.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-02.kt).
 
 <!--- TEST LINES_START
 Completed 100000 actions in
@@ -202,7 +202,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-03.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-03.kt).
 
 <!--- TEST ARBITRARY_TIME
 Completed 100000 actions in xxx ms
@@ -263,7 +263,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-04.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-04.kt).
 
 <!--- TEST ARBITRARY_TIME
 Completed 100000 actions in xxx ms
@@ -321,7 +321,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-05.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-05.kt).
 
 <!--- TEST ARBITRARY_TIME
 Completed 100000 actions in xxx ms
@@ -384,7 +384,7 @@ fun main() = runBlocking {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-06.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-06.kt).
 
 <!--- TEST ARBITRARY_TIME
 Completed 100000 actions in xxx ms
@@ -504,7 +504,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> You can get full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-07.kt).
+> You can get the full code [here](../kotlinx-coroutines-core/jvm/test/guide/example-sync-07.kt).
 
 <!--- TEST ARBITRARY_TIME
 Completed 100000 actions in xxx ms

--- a/ui/coroutines-guide-ui.md
+++ b/ui/coroutines-guide-ui.md
@@ -70,7 +70,7 @@ fun setup(hello: Text, fab: Circle) {
 }
 ```
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-01.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-01.kt).
 
 You can clone [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) project from GitHub onto your 
 workstation and open the project in IDE. All the examples from this guide are in the test folder of 
@@ -152,7 +152,7 @@ fun setup(hello: Text, fab: Circle) {
 }
 ```
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-02.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-02.kt).
 
 So, what happens here? Because we are launching coroutine in the main UI context, we can freely update UI from 
 inside this coroutine and invoke _suspending functions_ like [delay] at the same time. UI is not frozen
@@ -179,7 +179,7 @@ fun setup(hello: Text, fab: Circle) {
 }
 ```
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-03.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-basic-03.kt).
 
 Now, if the circle is clicked while countdown is still running, the countdown stops. 
 Note that [Job.cancel] is completely thread-safe and non-blocking. It just signals the coroutine to cancel 
@@ -231,7 +231,7 @@ fun Node.onClick(action: suspend (MouseEvent) -> Unit) {
 }
 ```  
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-actor-01.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-actor-01.kt).
 
 Note that each time the circle is clicked, it starts a new coroutine and they all compete to 
 update the text. Try it. It does not look very good. We'll fix it later.
@@ -273,7 +273,7 @@ fun Node.onClick(action: suspend (MouseEvent) -> Unit) {
 }
 ```  
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-actor-02.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-actor-02.kt).
   
 The key idea that underlies an integration of an actor coroutine and a regular event handler is that 
 there is an [offer][SendChannel.offer] function on [SendChannel] that does not wait. It sends an element to the actor immediately,
@@ -496,7 +496,7 @@ suspend fun fib(x: Int): Int = withContext(Dispatchers.Default) {
 }
 ```
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-blocking-02.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-blocking-02.kt).
 
 You can run this code and verify that UI is not frozen while large Fibonacci numbers are being computed. 
 However, this code computes `fib` somewhat slower, because every recursive call to `fib` goes via `withContext`. This is 
@@ -518,7 +518,7 @@ fun fibBlocking(x: Int): Int =
     if (x <= 1) x else fibBlocking(x - 1) + fibBlocking(x - 2)
 ```
 
-> You can get full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-blocking-03.kt).
+> You can get the full code [here](kotlinx-coroutines-javafx/test/guide/example-ui-blocking-03.kt).
 
 You can now enjoy full-speed naive Fibonacci computation without blocking the main UI thread. 
 All we need is `withContext(Dispatchers.Default)`.


### PR DESCRIPTION
This is just a few small corrections to some minor second-language grammar mistakes; also improving readability and punctuation in a few places.

I've also replaced the phrase 'get full code here' with 'get the full code here', because that sounds more natural to me. But Englishes do differ, and is a very minor thing anyway. I understand this is a pretty ubiquitous phrase, and I've only changed it in this one document, so I've kept those changes in a separate commit so you can reject them (and keep the others) if you don't think that's a worthwhile change.