### PR TITLE
Release coroutine block after lazy start

### DIFF
--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -108,10 +108,11 @@ private class LazyDeferredCoroutine<T>(
     parentContext: CoroutineContext,
     block: suspend CoroutineScope.() -> T
 ) : DeferredCoroutine<T>(parentContext, active = false) {
-    private val continuation = block.createCoroutineUnintercepted(this, this)
+    private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
     }
 }
 
@@ -195,10 +196,11 @@ private class LazyStandaloneCoroutine(
     parentContext: CoroutineContext,
     block: suspend CoroutineScope.() -> Unit
 ) : StandaloneCoroutine(parentContext, active = false) {
-    private val continuation = block.createCoroutineUnintercepted(this, this)
+    private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -111,8 +111,9 @@ private class LazyDeferredCoroutine<T>(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation!!.startCoroutineCancellable(this)
-        continuation = null
+        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        this.continuation = null
+        continuation.startCoroutineCancellable(this)
     }
 }
 
@@ -199,8 +200,9 @@ private class LazyStandaloneCoroutine(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation!!.startCoroutineCancellable(this)
-        continuation = null
+        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        this.continuation = null
+        continuation.startCoroutineCancellable(this)
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -111,7 +111,7 @@ private class LazyDeferredCoroutine<T>(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        val continuation = checkNotNull(this.continuation) { "Already started" }
         this.continuation = null
         continuation.startCoroutineCancellable(this)
     }
@@ -200,7 +200,7 @@ private class LazyStandaloneCoroutine(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        val continuation = checkNotNull(this.continuation) { "Already started" }
         this.continuation = null
         continuation.startCoroutineCancellable(this)
     }


### PR DESCRIPTION
When starting a coroutine lazily by using `CoroutineStart.LAZY`, it creates a `Continuation` that would launch the coroutine block, which is stored in the returned `Job` or `Deferred` to be invoked lazily. However, this reference is never cleared, even after the coroutine ends.

This prevents the coroutine block and it's enclosing class instance from being garbage collected if the `Job` or `Deferred` is retained in another class, or while child coroutines are running (as they also hold a reference to the `Job`).

Fixed by clearing the reference to the `Continuation` after invoking it.