### PR TITLE
Fix docs for CancellableContinuation

### DIFF
--- a/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
@@ -28,10 +28,8 @@ import kotlin.coroutines.intrinsics.*
  *
  * A [cancelled][isCancelled] continuation implies that it is [completed][isCompleted].
  *
- * Invocation of [resume] or [resumeWithException] in _resumed_ state produces an [IllegalStateException].
- * Invocation of [resume] in _cancelled_ state is ignored (it is a trivial race between resume from the continuation owner and
- * outer job's cancellation, and the cancellation wins).
- * Invocation of [resumeWithException] in _cancelled_ state triggers exception handling of the passed exception.
+ * Invocation of [resume] or [resumeWithException] in _resumed_ state produces an [IllegalStateException],
+ * but is ignored in _cancelled_ state.
  *
  * ```
  *    +-----------+   resume    +---------+


### PR DESCRIPTION
Basically reverts the documentation update in #800 due to the changes in #896