### PR TITLE
Do not print error message to the console when we've failed to instal…

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
@@ -69,7 +69,7 @@ internal object AgentPremain {
                 }
             }
         } catch (t: Throwable) {
-            System.err.println("Failed to install signal handler: $t")
+            // Do nothing, signal cannot be installed, e.g. because we are on Windows
         }
     }
 }


### PR DESCRIPTION
…l signal handler.

Otherwise, it may lead to obscure error messages in the console when users are on Windows and are not aware of signals.

This seems to be the easiest fix and (unreliably) detecting OS and printing exception conditionally is not reasonable