### PR TITLE
Flow ThrottleFirst and ThrottleLatest operators

### DIFF
--- a/integration/kotlinx-coroutines-jdk8/api/kotlinx-coroutines-jdk8.api
+++ b/integration/kotlinx-coroutines-jdk8/api/kotlinx-coroutines-jdk8.api
@@ -17,6 +17,7 @@ public final class kotlinx/coroutines/time/TimeKt {
 	public static final fun onTimeout (Lkotlinx/coroutines/selects/SelectBuilder;Ljava/time/Duration;Lkotlin/jvm/functions/Function1;)V
 	public static final fun sample (Lkotlinx/coroutines/flow/Flow;Ljava/time/Duration;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun throttleFirst (Lkotlinx/coroutines/flow/Flow;Ljava/time/Duration;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleLatest (Lkotlinx/coroutines/flow/Flow;Ljava/time/Duration;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun withTimeout (Ljava/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun withTimeoutOrNull (Ljava/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/integration/kotlinx-coroutines-jdk8/api/kotlinx-coroutines-jdk8.api
+++ b/integration/kotlinx-coroutines-jdk8/api/kotlinx-coroutines-jdk8.api
@@ -16,6 +16,7 @@ public final class kotlinx/coroutines/time/TimeKt {
 	public static final fun delay (Ljava/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun onTimeout (Lkotlinx/coroutines/selects/SelectBuilder;Ljava/time/Duration;Lkotlin/jvm/functions/Function1;)V
 	public static final fun sample (Lkotlinx/coroutines/flow/Flow;Ljava/time/Duration;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleFirst (Lkotlinx/coroutines/flow/Flow;Ljava/time/Duration;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun withTimeout (Ljava/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun withTimeoutOrNull (Ljava/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
@@ -30,6 +30,12 @@ public fun <T> Flow<T>.debounce(timeout: Duration): Flow<T> = debounce(timeout.c
 public fun <T> Flow<T>.sample(period: Duration): Flow<T> = sample(period.coerceToMillis())
 
 /**
+ * "java.time" adapter method for [kotlinx.coroutines.flow.throttleFirst].
+ */
+@FlowPreview
+public fun <T> Flow<T>.throttleFirst(timeout: Duration): Flow<T> = throttleFirst(timeout.coerceToMillis())
+
+/**
  * "java.time" adapter method for [SelectBuilder.onTimeout].
  */
 public fun <R> SelectBuilder<R>.onTimeout(duration: Duration, block: suspend () -> R): Unit =

--- a/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
+++ b/integration/kotlinx-coroutines-jdk8/src/time/Time.kt
@@ -36,6 +36,12 @@ public fun <T> Flow<T>.sample(period: Duration): Flow<T> = sample(period.coerceT
 public fun <T> Flow<T>.throttleFirst(timeout: Duration): Flow<T> = throttleFirst(timeout.coerceToMillis())
 
 /**
+ * "java.time" adapter method for [kotlinx.coroutines.flow.throttleLatest].
+ */
+@FlowPreview
+public fun <T> Flow<T>.throttleLatest(window: Duration): Flow<T> = throttleLatest(window.coerceToMillis())
+
+/**
  * "java.time" adapter method for [SelectBuilder.onTimeout].
  */
 public fun <R> SelectBuilder<R>.onTimeout(duration: Duration, block: suspend () -> R): Unit =

--- a/integration/kotlinx-coroutines-jdk8/test/time/FlowThrottleFirstTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/FlowThrottleFirstTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.time.*
+import java.time.*
+import kotlin.test.*
+
+class FlowThrottleFirstTest : TestBase() {
+
+    @Test
+    fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(Duration.ofMillis(1500))
+            emit("B")
+            delay(Duration.ofMillis(500))
+            emit("C")
+            delay(Duration.ofMillis(250))
+            emit("D")
+            delay(Duration.ofMillis(2000))
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleFirst(Duration.ofMillis(1000)).toList()
+        assertEquals(listOf("A", "B", "E"), result)
+        finish(5)
+    }
+}

--- a/integration/kotlinx-coroutines-jdk8/test/time/FlowThrottleLatestTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/FlowThrottleLatestTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.time.*
+import java.time.*
+import kotlin.test.*
+
+class FlowThrottleLatestTest : TestBase() {
+
+    @Test
+    fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(Duration.ofMillis(1500))
+            emit("B")
+            delay(Duration.ofMillis(500))
+            emit("C")
+            delay(Duration.ofMillis(250))
+            emit("D")
+            delay(Duration.ofMillis(2000))
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleLatest(Duration.ofMillis(1000)).toList()
+        assertEquals(listOf("A", "B", "D", "E"), result)
+        finish(5)
+    }
+}

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -990,6 +990,8 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun takeWhile (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun throttleFirst (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun throttleFirst-8GFy2Ro (Lkotlinx/coroutines/flow/Flow;D)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleLatest (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleLatest-8GFy2Ro (Lkotlinx/coroutines/flow/Flow;D)Lkotlinx/coroutines/flow/Flow;
 	public static final fun toCollection (Lkotlinx/coroutines/flow/Flow;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toList (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun toList$default (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -988,6 +988,8 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun switchMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun take (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static final fun takeWhile (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleFirst (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throttleFirst-8GFy2Ro (Lkotlinx/coroutines/flow/Flow;D)Lkotlinx/coroutines/flow/Flow;
 	public static final fun toCollection (Lkotlinx/coroutines/flow/Flow;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toList (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun toList$default (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/kotlinx-coroutines-core/common/test/flow/operators/ThrottleFirstTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/ThrottleFirstTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+import kotlin.time.*
+
+class ThrottleFirstTest : TestBase() {
+
+    @Test
+    fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500)
+            emit("B")
+            delay(500)
+            emit("C")
+            delay(250)
+            emit("D")
+            delay(2000)
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleFirst(1000).toList()
+        assertEquals(listOf("A", "B", "E"), result)
+        finish(5)
+    }
+
+    @Test
+    fun testSingleNull() = runTest {
+        val flow = flowOf<Int?>(null).throttleFirst(Long.MAX_VALUE)
+        assertNull(flow.single())
+    }
+
+    @Test
+    fun testBasicWithNulls() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500)
+            emit("B")
+            delay(500)
+            emit("C")
+            delay(250)
+            emit(null)
+            delay(2000)
+            emit(null)
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleFirst(1000).toList()
+        assertEquals(listOf("A", "B", null), result)
+        finish(5)
+    }
+
+    @Test
+    fun testEmpty() = runTest {
+        val flow = emptyFlow<Int>().throttleFirst(Long.MAX_VALUE)
+        assertNull(flow.singleOrNull())
+    }
+
+    @Test
+    fun testScalar() = withVirtualTime {
+        val flow = flowOf(1, 2, 3).throttleFirst(1000)
+        assertEquals(1, flow.single())
+        finish(1)
+    }
+
+    @Test
+    fun testPeriodic() = withVirtualTime {
+        val flow = flow {
+            expect(1)
+            repeat(10) {
+                emit(it)
+                delay(50)
+            }
+            expect(2)
+        }
+
+        val result = flow.throttleFirst(100).toList()
+        assertEquals(listOf(0, 2, 4, 6, 8), result)
+        finish(3)
+    }
+
+    @Test
+    fun testUpstreamError() = testUpstreamError(TimeoutCancellationException(""))
+
+    @Test
+    fun testUpstreamErrorCancellation() = testUpstreamError(TimeoutCancellationException(""))
+
+    private inline fun <reified T: Throwable> testUpstreamError(cause: T) = runTest {
+        val latch = Channel<Unit>()
+        val flow = flow {
+            expect(1)
+            emit(1)
+            expect(2)
+            latch.receive()
+            throw cause
+        }.throttleFirst(1).map {
+            latch.send(Unit)
+            hang { expect(3) }
+        }
+
+        assertFailsWith<T>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testUpstreamErrorIsolatedContext() = runTest {
+        val latch = Channel<Unit>()
+        val flow = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            expect(2)
+            latch.receive()
+            throw TestException()
+        }.flowOn(NamedDispatchers("upstream")).throttleFirst(1).map {
+            latch.send(Unit)
+            hang { expect(3) }
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testDownstreamError() = runTest {
+        val flow: Flow<Int> = flow {
+            expect(1)
+            emit(1)
+            hang { expect(3) }
+        }.throttleFirst(100).map {
+            expect(2)
+            yield()
+            throw TestException()
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testDownstreamErrorIsolatedContext() = runTest {
+        val flow: Flow<Int> = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            hang { expect(3) }
+        }.flowOn(NamedDispatchers("upstream")).throttleFirst(100).map {
+            expect(2)
+            yield()
+            throw TestException()
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testDurationBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500.milliseconds)
+            emit("B")
+            delay(500.milliseconds)
+            emit("C")
+            delay(250.milliseconds)
+            emit("D")
+            delay(2000.milliseconds)
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleFirst(1000.milliseconds).toList()
+        assertEquals(listOf("A", "B", "E"), result)
+        finish(5)
+    }
+}

--- a/kotlinx-coroutines-core/common/test/flow/operators/ThrottleLatestTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/ThrottleLatestTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+import kotlin.time.*
+
+class ThrottleLatestTest : TestBase() {
+
+    @Test
+    fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500)
+            emit("B")
+            delay(500)
+            emit("C")
+            delay(250)
+            emit("D")
+            delay(2000)
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleLatest(1000).toList()
+        assertEquals(listOf("A", "B", "D", "E"), result)
+        finish(5)
+    }
+
+    @Test
+    fun testSingleNull() = runTest {
+        val flow = flowOf<Int?>(null).throttleLatest(Long.MAX_VALUE)
+        assertNull(flow.single())
+    }
+
+    @Test
+    fun testBasicWithNulls() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500)
+            emit("B")
+            delay(500)
+            emit("C")
+            delay(250)
+            emit(null)
+            delay(2000)
+            emit(null)
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleLatest(1000).toList()
+        assertEquals(listOf("A", "B", null, null), result)
+        finish(5)
+    }
+
+    @Test
+    fun testSlidingWindow() = withVirtualTime {
+        val flow = flow {
+            expect(1)
+            emit("A")
+            delay(500)
+            emit("B")
+            delay(750)
+            emit("C")
+            delay(250)
+            emit("D")
+            delay(1000)
+            emit("E")
+            delay(250)
+            emit("F")
+            delay(1500)
+            emit("G")
+            expect(2)
+        }
+
+        val result = flow.throttleLatest(1000).toList()
+        assertEquals(listOf("A", "B", "D", "F", "G"), result)
+        finish(3)
+    }
+
+    @Test
+    fun testDelayedSource() = withVirtualTime {
+        val flow = flow {
+            expect(1)
+            delay(500)
+            emit("A")
+            expect(2)
+        }
+
+        val result = flow.throttleLatest(1000).toList()
+        assertEquals(listOf("A"), result)
+        finish(3)
+    }
+
+    @Test
+    fun testCompletion() = withVirtualTime {
+        val flow = flow {
+            expect(1)
+            emit("A")
+            delay(500)
+            emit("B")
+            expect(2)
+        }
+
+        val result = flow.throttleLatest(1000).toList()
+        assertEquals(listOf("A"), result)
+        finish(3)
+    }
+
+    @Test
+    fun testEmpty() = runTest {
+        val flow = emptyFlow<Int>().throttleLatest(Long.MAX_VALUE)
+        assertNull(flow.singleOrNull())
+    }
+
+    @Test
+    fun testScalar() = withVirtualTime {
+        val flow = flowOf(1, 2, 3).throttleLatest(1000)
+        assertEquals(1, flow.single())
+        finish(1)
+    }
+
+    @Test
+    fun testUpstreamError() = testUpstreamError(TimeoutCancellationException(""))
+
+    @Test
+    fun testUpstreamErrorCancellation() = testUpstreamError(TimeoutCancellationException(""))
+
+    private inline fun <reified T: Throwable> testUpstreamError(cause: T) = runTest {
+        val latch = Channel<Unit>()
+        val flow = flow {
+            expect(1)
+            emit(1)
+            expect(2)
+            latch.receive()
+            throw cause
+        }.throttleLatest(1).map {
+            latch.send(Unit)
+            hang { expect(3) }
+        }
+
+        assertFailsWith<T>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testUpstreamErrorIsolatedContext() = runTest {
+        val latch = Channel<Unit>()
+        val flow = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            expect(2)
+            latch.receive()
+            throw TestException()
+        }.flowOn(NamedDispatchers("upstream")).throttleLatest(1).map {
+            latch.send(Unit)
+            hang { expect(3) }
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testDownstreamError() = runTest {
+        val flow: Flow<Int> = flow {
+            expect(1)
+            emit(1)
+            hang { expect(3) }
+        }.throttleLatest(100).map {
+            expect(2)
+            yield()
+            throw TestException()
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testDownstreamErrorIsolatedContext() = runTest {
+        val flow: Flow<Int> = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            hang { expect(3) }
+        }.flowOn(NamedDispatchers("upstream")).throttleLatest(100).map {
+            expect(2)
+            yield()
+            throw TestException()
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testDurationBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(1500.milliseconds)
+            emit("B")
+            delay(500.milliseconds)
+            emit("C")
+            delay(250.milliseconds)
+            emit("D")
+            delay(2000.milliseconds)
+            emit("E")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.throttleLatest(1000.milliseconds).toList()
+        assertEquals(listOf("A", "B", "D", "E"), result)
+        finish(5)
+    }
+}


### PR DESCRIPTION
This provides an implementation of  the `throttleFirst` Flow operator asked in #1446 and #1927.
This also adds an equivalent `throttleLatest` that conflates values until timeout is ellapsed.

The behavior of those operators is the same as their RxJava equivalents: [throttleFirst](http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/core/Flowable.html#throttleFirst-long-java.util.concurrent.TimeUnit-), [throttleLatest](http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/core/Flowable.html#throttleLatest-long-java.util.concurrent.TimeUnit-).

Both operators are used mostly for UI programming, for example:
- Reduce the pace at which a button is clicked,
- Reduce the rate a which display is updated (UI state, notifications, etc).

I feel like documentation of those operators and implementation of `throttleFirst` could be improved. Suggestions are more than welcome!

About the API, maybe we could rename `throttleLatest` to `throttleConflate` and `throttleFirst` to `throttle` or something like `throttleDrop`. I've found that `throttleLatest` works a bit like conflated channels, hence the name.

Also in RxJS, we have a single `throttle` operator that accepts 2 boolean parameters `leading` and `trailing`. We could follow the same approach by merging those 2 operators into a single `throttle(withTrailing: Boolean)` operator.
