### PR TITLE
Replace scanReduce with runningReduce to be consistent with Kotlin st…

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -971,6 +971,7 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static synthetic fun retry$default (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun retry$default (Lkotlinx/coroutines/flow/Flow;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun retryWhen (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function4;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun runningReduce (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun sample (Lkotlinx/coroutines/flow/Flow;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun sample-8GFy2Ro (Lkotlinx/coroutines/flow/Flow;D)Lkotlinx/coroutines/flow/Flow;
 	public static final fun scan (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -430,3 +430,11 @@ public fun <T> Flow<T>.delayEach(timeMillis: Long): Flow<T> = onEach { delay(tim
     replaceWith = ReplaceWith("this.flatMapLatest(transform)")
 )
 public fun <T, R> Flow<T>.switchMap(transform: suspend (value: T) -> Flow<R>): Flow<R> = flatMapLatest(transform)
+
+@Deprecated(
+    level = DeprecationLevel.WARNING, // Since 1.3.8, was experimental when deprecated
+    message = "'scanReduce' was renamed to 'runningReduce' to be consistent with Kotlin standard library",
+    replaceWith = ReplaceWith("runningReduce(operation)")
+)
+@ExperimentalCoroutinesApi
+public fun <T> Flow<T>.scanReduce(operation: suspend (accumulator: T, value: T) -> T): Flow<T> = runningReduce(operation)

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -100,12 +100,12 @@ public fun <T, R> Flow<T>.scan(initial: R, @BuilderInference operation: suspend 
  *
  * For example:
  * ```
- * flowOf(1, 2, 3, 4).scanReduce { (v1, v2) -> v1 + v2 }.toList()
+ * flowOf(1, 2, 3, 4).runningReduce { (v1, v2) -> v1 + v2 }.toList()
  * ```
  * will produce `[1, 3, 6, 10]`
  */
 @ExperimentalCoroutinesApi
-public fun <T> Flow<T>.scanReduce(operation: suspend (accumulator: T, value: T) -> T): Flow<T> = flow {
+public fun <T> Flow<T>.runningReduce(operation: suspend (accumulator: T, value: T) -> T): Flow<T> = flow {
     var accumulator: Any? = NULL
     collect { value ->
         accumulator = if (accumulator === NULL) {

--- a/kotlinx-coroutines-core/common/test/flow/operators/ScanTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/ScanTest.kt
@@ -12,7 +12,7 @@ class ScanTest : TestBase() {
     @Test
     fun testScan() = runTest {
         val flow = flowOf(1, 2, 3, 4, 5)
-        val result = flow.scanReduce { acc, v -> acc + v }.toList()
+        val result = flow.runningReduce { acc, v -> acc + v }.toList()
         assertEquals(listOf(1, 3, 6, 10, 15), result)
     }
 
@@ -26,13 +26,13 @@ class ScanTest : TestBase() {
     @Test
     fun testNulls() = runTest {
         val flow = flowOf(null, 2, null, null, null, 5)
-        val result = flow.scanReduce { acc, v ->  if (v == null) acc else (if (acc == null) v else acc + v) }.toList()
+        val result = flow.runningReduce { acc, v -> if (v == null) acc else (if (acc == null) v else acc + v) }.toList()
         assertEquals(listOf(null, 2, 2, 2, 2, 7), result)
     }
 
     @Test
     fun testEmptyFlow() = runTest {
-        val result = emptyFlow<Int>().scanReduce { _, _ -> 1 }.toList()
+        val result = emptyFlow<Int>().runningReduce { _, _ -> 1 }.toList()
         assertTrue(result.isEmpty())
     }
 
@@ -49,7 +49,7 @@ class ScanTest : TestBase() {
                 emit(1)
                 emit(2)
             }
-        }.scanReduce { _, value ->
+        }.runningReduce { _, value ->
             expect(value) // 2
             latch.receive()
             throw TestException()
@@ -59,7 +59,7 @@ class ScanTest : TestBase() {
         finish(4)
     }
 
-    public operator fun <T> Collection<T>.plus(element: T): List<T> {
+    private operator fun <T> Collection<T>.plus(element: T): List<T> {
         val result = ArrayList<T>(size + 1)
         result.addAll(this)
         result.add(element)


### PR DESCRIPTION
…andard library.

foldReduce is not introduced to see how it goes in the standard library first. For the full rationale of renaming, please refer to KT-38060