### PR TITLE
Add a keep rule for AndroidDispatcherFactory for R8 version > 1.6.0

### DIFF
--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
@@ -9,6 +9,8 @@
     boolean ANDROID_DETECTED return true;
 }
 
+-keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
+
 # Disable support for "Missing Main Dispatcher", since we always have Android main dispatcher
 -assumenosideeffects class kotlinx.coroutines.internal.MainDispatchersKt {
     boolean SUPPORT_MISSING return false;


### PR DESCRIPTION
In commit #3a8a0ea this keep rule was removed from kotlinx-coroutines-core (which is good), but this caused `AndroidDispatcherFactory` to be minimized in newer R8 versions. Adding a rule explicitly fixes the problem.

I didn't succeed in making a sample project to reproduce the issue, as the project that faces this issue has a complex multi module setup (which might be the cause). I verified this change is working by including the local `kotlinx-coroutines-android` jar in the project and not getting the following error:
```
Fatal Exception: java.lang.IllegalStateException: Module with the Main dispatcher is missing. Add dependency providing the Main dispatcher, e.g. 'kotlinx-coroutines-android' and ensure it has the same version as 'kotlinx-coroutines-core'
       at kotlinx.coroutines.internal.MainDispatchersKt.throwMissingMainDispatcherException(MainDispatchersKt.java:76)
       at kotlinx.coroutines.internal.MissingMainCoroutineDispatcher.missing(MissingMainCoroutineDispatcher.java:110)
       at kotlinx.coroutines.internal.MissingMainCoroutineDispatcher.isDispatchNeeded(MissingMainCoroutineDispatcher.java:91)
       at kotlinx.coroutines.DispatchedContinuation.resumeCancellableWith(DispatchedContinuation.java:199)
       at kotlinx.coroutines.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuationKt.java:285)
       at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(CancellableKt.java:26)
       at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.java:109)
       at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.java:158)
       at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(BuildersKt__Builders_commonKt.java:56)
       at kotlinx.coroutines.BuildersKt.launch(BuildersKt.java:1)
       at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(BuildersKt__Builders_commonKt.java:49)
       at kotlinx.coroutines.BuildersKt.launch$default(BuildersKt.java:1)
```