### PR TITLE
Added a `mapIterable` operator

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -49,6 +49,20 @@ public inline fun <T, R> Flow<T>.map(crossinline transform: suspend (value: T) -
 }
 
 /**
+ * Returns a flow iterating the results of applying the given [transform] function to each value of the original flow.
+ * entityRepository.getAll() // List<Entity>
+ *  .mapIterable { it.toView() } // View
+ *  .toCollection(mutableListOf()) // List<View>
+ */
+public inline fun<T, R> Flow<Collection<T>>.mapIterable(mapBlock: (t: T) -> R): Flow<R> = flow<R> {
+    this@mapIterable.collect {
+        it.forEach { value ->
+            emit(mapBlock(value))
+        }
+    }
+}
+
+/**
  * Returns a flow that contains only non-null results of applying the given [transform] function to each value of the original flow.
  */
 public inline fun <T, R: Any> Flow<T>.mapNotNull(crossinline transform: suspend (value: T) -> R?): Flow<R> = transform { value ->


### PR DESCRIPTION
I suppose to add the new operator called `mapIterable`.  It's can flatten flow stream and give the ability to work with each entity of collection. I will be glad to hear any feedback. I'm ready to complete work on this operator by you code conducts. Best regards.