### PR TITLE
Fix some sample outputs not being displayed in flow.md

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1471,6 +1471,8 @@ Exception in thread "main" java.lang.IllegalStateException: Collected 2
 	at ...
 ```
 
+<!--- TEST EXCEPTION -->
+
 #### Catching declaratively
 
 We can combine the declarative nature of the [catch] operator with a desire to handle all the exceptions, by moving the body
@@ -1516,6 +1518,8 @@ Emitting 1
 Emitting 2
 Caught java.lang.IllegalStateException: Collected 2
 ```
+
+<!--- TEST -->
 
 ### Flow completion
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1519,7 +1519,7 @@ Emitting 2
 Caught java.lang.IllegalStateException: Collected 2
 ```
 
-<!--- TEST -->
+<!--- TEST EXCEPTION -->
 
 ### Flow completion
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1463,13 +1463,13 @@ fun main() = runBlocking<Unit> {
  
 A "Caught ..." message is not printed despite there being a `catch` operator: 
 
-<!--- TEST EXCEPTION  
+```text  
 Emitting 1
 1
 Emitting 2
 Exception in thread "main" java.lang.IllegalStateException: Collected 2
 	at ...
--->
+```
 
 #### Catching declaratively
 
@@ -1510,12 +1510,12 @@ fun main() = runBlocking<Unit> {
 Now we can see that a "Caught ..." message is printed and so we can catch all the exceptions without explicitly
 using a `try/catch` block: 
 
-<!--- TEST EXCEPTION  
+```text 
 Emitting 1
 1
 Emitting 2
 Caught java.lang.IllegalStateException: Collected 2
--->
+```
 
 ### Flow completion
 


### PR DESCRIPTION
For some reason, some sample outputs in section `Flow Exceptions` are not displayed in the documentation. This commit fixes this issue.