### PR TITLE
Add Publisher.awaitSingleOrDefault|Null|Else extensions

### DIFF
--- a/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
+++ b/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
@@ -5,6 +5,9 @@ public final class kotlinx/coroutines/reactive/AwaitKt {
 	public static final fun awaitFirstOrNull (Lorg/reactivestreams/Publisher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun awaitLast (Lorg/reactivestreams/Publisher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun awaitSingle (Lorg/reactivestreams/Publisher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun awaitSingleOrDefault (Lorg/reactivestreams/Publisher;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun awaitSingleOrElse (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun awaitSingleOrNull (Lorg/reactivestreams/Publisher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class kotlinx/coroutines/reactive/ChannelKt {

--- a/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
@@ -48,6 +48,9 @@ class IntegrationTest(
         assertEquals("ELSE", pub.awaitFirstOrElse { "ELSE" })
         assertFailsWith<NoSuchElementException> { pub.awaitLast() }
         assertFailsWith<NoSuchElementException> { pub.awaitSingle() }
+        assertEquals("OK", pub.awaitSingleOrDefault("OK"))
+        assertNull(pub.awaitSingleOrNull())
+        assertEquals("ELSE", pub.awaitSingleOrElse { "ELSE" })
         var cnt = 0
         pub.collect { cnt++ }
         assertEquals(0, cnt)
@@ -65,6 +68,9 @@ class IntegrationTest(
         assertEquals("OK", pub.awaitFirstOrElse { "ELSE" })
         assertEquals("OK", pub.awaitLast())
         assertEquals("OK", pub.awaitSingle())
+        assertEquals("OK", pub.awaitSingleOrDefault("!"))
+        assertEquals("OK", pub.awaitSingleOrNull())
+        assertEquals("OK", pub.awaitSingleOrElse { "ELSE" })
         var cnt = 0
         pub.collect {
             assertEquals("OK", it)
@@ -84,10 +90,13 @@ class IntegrationTest(
         }
         assertEquals(1, pub.awaitFirst())
         assertEquals(1, pub.awaitFirstOrDefault(0))
-        assertEquals(n, pub.awaitLast())
         assertEquals(1, pub.awaitFirstOrNull())
         assertEquals(1, pub.awaitFirstOrElse { 0 })
+        assertEquals(n, pub.awaitLast())
         assertFailsWith<IllegalArgumentException> { pub.awaitSingle() }
+        assertFailsWith<IllegalArgumentException> { pub.awaitSingleOrDefault(0) }
+        assertFailsWith<IllegalArgumentException> { pub.awaitSingleOrNull() }
+        assertFailsWith<IllegalArgumentException> { pub.awaitSingleOrElse { 0 } }
         checkNumbers(n, pub)
         val channel = pub.openSubscription()
         checkNumbers(n, channel.asPublisher(ctx(coroutineContext)))

--- a/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
+++ b/reactive/kotlinx-coroutines-reactor/test/FluxSingleTest.kt
@@ -69,6 +69,72 @@ class FluxSingleTest : TestBase() {
     }
 
     @Test
+    fun testAwaitSingleOrDefault() {
+        val flux = flux {
+            send(Flux.empty<String>().awaitSingleOrDefault("O") + "K")
+        }
+
+        checkSingleValue(flux) {
+            assertEquals("OK", it)
+        }
+    }
+
+    @Test
+    fun testAwaitSingleOrDefaultException() {
+        val flux = flux {
+            send(Flux.just("O", "#").awaitSingleOrDefault("!") + "K")
+        }
+
+        checkErroneous(flux) {
+            assert(it is IllegalArgumentException)
+        }
+    }
+
+    @Test
+    fun testAwaitSingleOrNull() {
+        val flux = flux<String?> {
+            send(Flux.empty<String>().awaitSingleOrNull() ?: "OK")
+        }
+
+        checkSingleValue(flux) {
+            assertEquals("OK", it)
+        }
+    }
+
+    @Test
+    fun testAwaitSingleOrNullException() {
+        val flux = flux {
+            send((Flux.just("O", "#").awaitSingleOrNull() ?: "!") + "K")
+        }
+
+        checkErroneous(flux) {
+            assert(it is IllegalArgumentException)
+        }
+    }
+
+    @Test
+    fun testAwaitSingleOrElse() {
+        val flux = flux {
+            send(Flux.empty<String>().awaitSingleOrElse { "O" } + "K")
+        }
+
+        checkSingleValue(flux) {
+            assertEquals("OK", it)
+        }
+    }
+
+    @Test
+    fun testAwaitSingleOrElseException() {
+        val flux = flux {
+            send(Flux.just("O", "#").awaitSingleOrElse { "!" } + "K")
+        }
+
+        checkErroneous(flux) {
+            assert(it is IllegalArgumentException)
+        }
+    }
+
+    @Test
     fun testAwaitFirst() {
         val flux = flux {
             send(Flux.just("O", "#").awaitFirst() + "K")


### PR DESCRIPTION
This commit adds `awaitSingle` variants similar to `awaitFirst` ones, but always emitting the value during `onComplete()`.

Fixes #1993