### PR TITLE
Clarify the env requirements in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ to Gradle (in Preferences -> Build, Execution, Deployment -> Build Tools -> Grad
 * JDK 1.6 referred to by the `JDK_16` environment variable. 
   It is OK to have `JDK_16` pointing to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
 * JDK 1.8 referred to by the `JDK_18` environment variable. Only used by nightly stress-tests. 
-  It is OK to have `JDK_18` to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
+  It is OK to have `JDK_18` to a non 8 JDK (e.g. `JAVA_HOME`) for external contributions.
   
 For external contributions you can for example add this to your shell startup scripts (e.g. `~/.zshrc`):
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ to Gradle (in Preferences -> Build, Execution, Deployment -> Build Tools -> Grad
 
 * JDK >= 11 referred to by the `JAVA_HOME` environment variable.
 * JDK 1.6 referred to by the `JDK_16` environment variable. 
-  It is OK to have `JDK_16` pointing to `JAVA_HOME` for external contributions.
+  It is OK to have `JDK_16` pointing to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
 * JDK 1.8 referred to by the `JDK_18` environment variable. Only used by nightly stress-tests. 
-  It is OK to have `JDK_18` pointing to `JAVA_HOME` for external contributions.
+  It is OK to have `JDK_18` to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
 
 ### Running the Knit tool
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,13 @@ to Gradle (in Preferences -> Build, Execution, Deployment -> Build Tools -> Grad
   It is OK to have `JDK_16` pointing to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
 * JDK 1.8 referred to by the `JDK_18` environment variable. Only used by nightly stress-tests. 
   It is OK to have `JDK_18` to a non 1.6 JDK (e.g. `JAVA_HOME`) for external contributions.
+  
+For external contributions you can for example add this to your shell startup scripts (e.g. `~/.zshrc`):
+```shell
+# This assumes JAVA_HOME is set already to a JDK >= 11 version
+export JDK_16="$JAVA_HOME"
+export JDK_18="$JAVA_HOME"
+```
 
 ### Running the Knit tool
 


### PR DESCRIPTION
The wording is a bit confusing and does not clearly indicate that you can set `JDK_XX` to whatever JDK version you want.