### PR TITLE
Remove workaround for KT-42671 that triggers test failures from IDEA …

### DIFF
--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -177,9 +177,7 @@ jvmTest {
     minHeapSize = '1g'
     maxHeapSize = '1g'
     enableAssertions = true
-    if (!Idea.active) { // Workaround for KT-42671
-        systemProperty 'java.security.manager', 'kotlinx.coroutines.TestSecurityManager'
-    }
+    systemProperty 'java.security.manager', 'kotlinx.coroutines.TestSecurityManager'
     // 'stress' is required to be able to run all subpackage tests like ":jvmTests --tests "*channels*" -Pstress=true"
     if (!Idea.active && rootProject.properties['stress'] == null) {
         exclude '**/*StressTest.*'

--- a/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
@@ -21,9 +21,9 @@ internal object AgentPremain {
 
     public var isInstalledStatically = false
 
-    private val enableCreationStackTraces =
+    private val enableCreationStackTraces = runCatching {
         System.getProperty("kotlinx.coroutines.debug.enable.creation.stack.trace")?.toBoolean()
-            ?: DebugProbesImpl.enableCreationStackTraces
+    }.getOrNull() ?: DebugProbesImpl.enableCreationStackTraces
 
     @JvmStatic
     public fun premain(args: String?, instrumentation: Instrumentation) {


### PR DESCRIPTION
…and access properties in a safe manner from agent premain instead