### PR TITLE
Fix SharedFlow with replay for subscribers working at different speed

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
@@ -326,7 +326,7 @@ private class SharedFlowImpl<T>(
         var resumes: Array<Continuation<Unit>?> = EMPTY_RESUMES
         val emitted = synchronized(this) {
             if (tryEmitLocked(value)) {
-                resumes = findSlotsToResumeLocked()
+                resumes = findSlotsToResumeLocked(resumes)
                 true
             } else {
                 false
@@ -422,7 +422,7 @@ private class SharedFlowImpl<T>(
             // recheck buffer under lock again (make sure it is really full)
             if (tryEmitLocked(value)) {
                 cont.resume(Unit)
-                resumes = findSlotsToResumeLocked()
+                resumes = findSlotsToResumeLocked(resumes)
                 return@lock null
             }
             // add suspended emitter to the buffer
@@ -430,7 +430,7 @@ private class SharedFlowImpl<T>(
                 enqueueLocked(it)
                 queueSize++ // added to queue of waiting emitters
                 // synchronous shared flow might rendezvous with waiting emitter
-                if (bufferCapacity == 0) resumes = findSlotsToResumeLocked()
+                if (bufferCapacity == 0) resumes = findSlotsToResumeLocked(resumes)
             }
         }
         // outside of the lock: register dispose on cancellation
@@ -512,6 +512,8 @@ private class SharedFlowImpl<T>(
         updateBufferLocked(newReplayIndex, newMinCollectorIndex, newBufferEndIndex, newQueueEndIndex)
         // just in case we've moved all buffered emitters and have NO_VALUE's at the tail now
         cleanupTailLocked()
+        // We need to waken up suspended collectors if any emitters were resumed here
+        if (resumes.isNotEmpty()) resumes = findSlotsToResumeLocked(resumes)
         return resumes
     }
 
@@ -598,9 +600,9 @@ private class SharedFlowImpl<T>(
         }
     }
 
-    private fun findSlotsToResumeLocked(): Array<Continuation<Unit>?> {
-        var resumes: Array<Continuation<Unit>?> = EMPTY_RESUMES
-        var resumeCount = 0
+    private fun findSlotsToResumeLocked(resumesIn: Array<Continuation<Unit>?>): Array<Continuation<Unit>?> {
+        var resumes: Array<Continuation<Unit>?> = resumesIn
+        var resumeCount = resumesIn.size
         forEachSlotLocked loop@{ slot ->
             val cont = slot.cont ?: return@loop // only waiting slots
             if (tryPeekLocked(slot) < 0) return@loop // only slots that can peek a value


### PR DESCRIPTION
Problematic scenario:
* Emitter suspends because there is a slow subscriber
* Fast subscriber collects all the values and suspend
* Slow subscriber resumes, collects value, causes emitter to be resume
* Fast subscribers must be resumed in this case, too

Fixes #2320