### PR TITLE
Fix in Global coroutines are like daemon threads doc

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -373,7 +373,7 @@ fun main() = runBlocking {
             delay(500L)
         }
     }
-    delay(1300L) // just quit after delay
+    delay(1000L) // just quit after delay
 //sampleEnd    
 }
 ```


### PR DESCRIPTION
The `delay` with 1300 millisecond time print [following results](https://pl.kotl.in/tpgnfGR2f):

```
I'm sleeping 3 ... I'm sleeping 0 ...
I'm sleeping 1 ...
I'm sleeping 2 ...
``` 

When changing this to the 1000 millisecond it will show the [correct output](https://pl.kotl.in/dJ437pRYI) like the documentation:

```
I'm sleeping 0 ...
I'm sleeping 1 ...
I'm sleeping 2 ...
```