### PR TITLE
Fix forever lock of main thread in runBlocking

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
@@ -68,6 +68,15 @@ import kotlin.native.concurrent.*
  * the `onBufferOverflow` parameter, which is equal to one of the entries of the [BufferOverflow] enum. When a strategy other
  * than [SUSPENDED][BufferOverflow.SUSPEND] is configured, emissions to the shared flow never suspend.
  *
+ * ### Unbuffered shared flow
+ *
+ * A default implementation of a shared flow that is created with `MutableSharedFlow()` constructor function
+ * without parameters has no replay cache nor additional buffer.
+ * [emit][MutableSharedFlow.emit] call to such a shared flow suspends until all subscribers receive the emitted value
+ * and returns immediately if there are no subscribers.
+ * Thus, [tryEmit][MutableSharedFlow.tryEmit] call succeeds and returns `true` only if
+ * there are no subscribers (in which case the emitted value is immediately lost).
+ *
  * ### SharedFlow vs BroadcastChannel
  *
  * Conceptually shared flow is similar to [BroadcastChannel][BroadcastChannel]

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -69,7 +69,7 @@ private class BlockingCoroutine<T>(
     override fun afterCompletion(state: Any?) {
         // wake up blocked thread
         if (Thread.currentThread() != blockedThread)
-            LockSupport.unpark(blockedThread)
+            unpark(blockedThread)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -84,7 +84,9 @@ private class BlockingCoroutine<T>(
                     val parkNanos = eventLoop?.processNextEvent() ?: Long.MAX_VALUE
                     // note: process next even may loose unpark flag, so check if completed before parking
                     if (isCompleted) break
-                    parkNanos(this, parkNanos)
+                    if (0 < parkNanos && parkNanos < Long.MAX_VALUE) {
+                        parkNanos(this, parkNanos)
+                    }
                 }
             } finally { // paranoia
                 eventLoop?.decrementUseCount()

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -84,7 +84,7 @@ private class BlockingCoroutine<T>(
                     val parkNanos = eventLoop?.processNextEvent() ?: Long.MAX_VALUE
                     // note: process next even may loose unpark flag, so check if completed before parking
                     if (isCompleted) break
-                    if (parkNanos < 0 || parkNanos >= Long.MAX_VALUE) {
+                    if (parkNanos <= 0 || parkNanos >= Long.MAX_VALUE) {
                         0L
                     } else {
                         if (parkNanos > 10_000_000L && isMainThread) {

--- a/kotlinx-coroutines-core/jvm/src/TimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/src/TimeSource.kt
@@ -60,7 +60,7 @@ internal inline fun unregisterTimeLoopThread() {
 
 @InlineOnly
 internal inline fun parkNanos(blocker: Any, nanos: Long) {
-    if (0 < nanos && nanos < Long.MAX_VALUE) {
+    if (0L <= nanos && nanos < Long.MAX_VALUE) {
         timeSource?.parkNanos(blocker, nanos) ?: LockSupport.parkNanos(blocker, nanos)
     }
 }

--- a/kotlinx-coroutines-core/jvm/src/TimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/src/TimeSource.kt
@@ -60,10 +60,13 @@ internal inline fun unregisterTimeLoopThread() {
 
 @InlineOnly
 internal inline fun parkNanos(blocker: Any, nanos: Long) {
-    timeSource?.parkNanos(blocker, nanos) ?: LockSupport.parkNanos(blocker, nanos)
+    if (0 < nanos && nanos < Long.MAX_VALUE) {
+        timeSource?.parkNanos(blocker, nanos) ?: LockSupport.parkNanos(blocker, nanos)
+    }
 }
 
 @InlineOnly
 internal inline fun unpark(thread: Thread) {
-    timeSource?.unpark(thread) ?: LockSupport.unpark(thread)
+    timeSource?.unpark(thread)
+    LockSupport.unpark(thread)
 }


### PR DESCRIPTION
In havy concurect UI load where in views have many small runBlocking (and withContext) blocks some time we can get parkNanos == Long.MAX_VALUE. 