### PR TITLE
Add lint warnings on SharedFlow operations that never complete

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Lint.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Lint.kt
@@ -2,12 +2,13 @@
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("unused")
+@file:Suppress("unused", "INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 
 package kotlinx.coroutines.flow
 
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
+import kotlin.internal.InlineOnly
 
 /**
  * Applying [cancellable][Flow.cancellable] to a [SharedFlow] has no effect.
@@ -80,3 +81,60 @@ public fun FlowCollector<*>.cancel(cause: CancellationException? = null): Unit =
 )
 public val FlowCollector<*>.coroutineContext: CoroutineContext
     get() = noImpl()
+
+@Deprecated(
+    message = "SharedFlow never completes, so this operator has no effect.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("this")
+)
+@InlineOnly
+public inline fun <T> SharedFlow<T>.catch(noinline action: suspend FlowCollector<T>.(cause: Throwable) -> Unit): Flow<T> =
+    (this as Flow<T>).catch(action)
+
+@Deprecated(
+    message = "SharedFlow never completes, so this operator has no effect.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("this")
+)
+@InlineOnly
+public inline fun <T> SharedFlow<T>.retry(
+    retries: Long = Long.MAX_VALUE,
+    noinline predicate: suspend (cause: Throwable) -> Boolean = { true }
+): Flow<T> =
+    (this as Flow<T>).retry(retries, predicate)
+
+@Deprecated(
+    message = "SharedFlow never completes, so this operator has no effect.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("this")
+)
+@InlineOnly
+public inline fun <T> SharedFlow<T>.retryWhen(noinline predicate: suspend FlowCollector<T>.(cause: Throwable, attempt: Long) -> Boolean): Flow<T> =
+    (this as Flow<T>).retryWhen(predicate)
+
+@Deprecated(
+    message = "SharedFlow never completes, so this terminal operation never completes.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("awaitCancellation()")
+)
+@InlineOnly
+public suspend inline fun <T> SharedFlow<T>.toList(): List<T> =
+    (this as Flow<T>).toList()
+
+@Deprecated(
+    message = "SharedFlow never completes, so this terminal operation never completes.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("awaitCancellation()")
+)
+@InlineOnly
+public suspend inline fun <T> SharedFlow<T>.toSet(): Set<T> =
+    (this as Flow<T>).toSet()
+
+@Deprecated(
+    message = "SharedFlow never completes, so this terminal operation never completes.",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("awaitCancellation()")
+)
+@InlineOnly
+public suspend inline fun <T> SharedFlow<T>.count(): Int =
+    (this as Flow<T>).count()

--- a/kotlinx-coroutines-core/common/src/flow/operators/Lint.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Lint.kt
@@ -112,28 +112,28 @@ public inline fun <T> SharedFlow<T>.retry(
 public inline fun <T> SharedFlow<T>.retryWhen(noinline predicate: suspend FlowCollector<T>.(cause: Throwable, attempt: Long) -> Boolean): Flow<T> =
     (this as Flow<T>).retryWhen(predicate)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
     message = "SharedFlow never completes, so this terminal operation never completes.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("awaitCancellation()")
+    level = DeprecationLevel.WARNING
 )
 @InlineOnly
 public suspend inline fun <T> SharedFlow<T>.toList(): List<T> =
     (this as Flow<T>).toList()
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
     message = "SharedFlow never completes, so this terminal operation never completes.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("awaitCancellation()")
+    level = DeprecationLevel.WARNING
 )
 @InlineOnly
 public suspend inline fun <T> SharedFlow<T>.toSet(): Set<T> =
     (this as Flow<T>).toSet()
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
     message = "SharedFlow never completes, so this terminal operation never completes.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("awaitCancellation()")
+    level = DeprecationLevel.WARNING
 )
 @InlineOnly
 public suspend inline fun <T> SharedFlow<T>.count(): Int =


### PR DESCRIPTION
Fixes #2340
Fixes #2368