### PR TITLE
Conditionally create an instance of CancellationException in Channel.…

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
@@ -635,6 +635,7 @@ internal abstract class AbstractChannel<E>(
         cancelInternal(cause)
 
     final override fun cancel(cause: CancellationException?) {
+        if (isClosedForReceive) return // Do not create an exception if channel is already cancelled
         cancelInternal(cause ?: CancellationException("$classSimpleName was cancelled"))
     }
 

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -26,6 +26,7 @@ internal open class ChannelCoroutine<E>(
     }
 
     final override fun cancel(cause: CancellationException?) {
+        if (isClosedForReceive) return // Do not create an exception if channel is already cancelled
         cancelInternal(cause ?: defaultCancellationException())
     }
 

--- a/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
@@ -137,7 +137,7 @@ internal fun <T1, T2, R> zipImpl(flow: Flow<T1>, flow2: Flow<T2>, transform: sus
             } catch (e: AbortFlowException) {
                 e.checkOwnership(owner = this@unsafeFlow)
             } finally {
-                if (!second.isClosedForReceive) second.cancel()
+                second.cancel()
             }
         }
     }


### PR DESCRIPTION
…cancel()

Avoid creating costly exception when the channel is cancelled to save a few cycles when it's not necessary. Cancellation is heavy-enough when the channel is open, so the single check won't worsen it.