### PR TITLE
fixes ScopeCoroutine cast to internal CoroutineStackFrame (#2386)

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/Scopes.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Scopes.kt
@@ -16,7 +16,7 @@ internal open class ScopeCoroutine<in T>(
     context: CoroutineContext,
     @JvmField val uCont: Continuation<T> // unintercepted continuation
 ) : AbstractCoroutine<T>(context, true), CoroutineStackFrame {
-    final override val callerFrame: CoroutineStackFrame? get() = uCont as CoroutineStackFrame?
+    final override val callerFrame: CoroutineStackFrame? get() = uCont as? CoroutineStackFrame?
     final override fun getStackTraceElement(): StackTraceElement? = null
     final override val isScopedCoroutine: Boolean get() = true
 


### PR DESCRIPTION
I attempted (unsuccessfully) to orchestrate the proper conditions to reproduce the issue, but I am afraid my mastery of coroutineScope, job scheduling, interception and the like was such that I was unable to do so.

What I was trying was adding a second test to `DebugAgentTest` using a barebones custom continuation implementation, something like this:

```
class CustomContinuationImpl<T>(continuation: Continuation<T>): Continuation<T> {
    override val context = continuation.context
    override fun resumeWith(result: Result<T>) {
        println("CustomContinuationImpl for result $result")
        // no-op, this is just a sample class to reproduce issue #2386
    }
}
```

But figuring out how to stitch that into a test s.t. that it would own something that was a ScopeCoroutine s.t. it would attempt to be cast to `CoroutineStackFrame` within the `DebugProbesImpl` wasn't working out for me. I would certainly be open to guidance on how better to set up such a test, but perhaps this is a simple enough fix to just merge sans test replicating it? Feedback welcome!