### PR TITLE
Make SharingStarted a fun interface

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/SharingStarted.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharingStarted.kt
@@ -38,7 +38,7 @@ public enum class SharingCommand {
 /**
  * A strategy for starting and stopping the sharing coroutine in [shareIn] and [stateIn] operators.
  *
- * This interface provides a set of built-in strategies: [Eagerly], [Lazily], [WhileSubscribed], and
+ * This functional interface provides a set of built-in strategies: [Eagerly], [Lazily], [WhileSubscribed], and
  * supports custom strategies by implementing this interface's [command] function.
  *
  * For example, it is possible to define a custom strategy that starts the upstream only when the number
@@ -46,11 +46,9 @@ public enum class SharingCommand {
  * that it looks like a built-in strategy on the use-site:
  *
  * ```
- * fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int): SharingStarted =
- *     object : SharingStarted {
- *         override fun command(subscriptionCount: StateFlow<Int>): Flow<SharingCommand> =
- *             subscriptionCount
- *                 .map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP }
+ * fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int) =
+ *     SharingStarted { subscriptionCount: StateFlow<Int> ->
+ *         subscriptionCount.map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP }
  *     }
  * ```
  *
@@ -74,7 +72,7 @@ public enum class SharingCommand {
  * The completion of the `command` flow normally has no effect (the upstream flow keeps running if it was running).
  * The failure of the `command` flow cancels the sharing coroutine and the upstream flow.
  */
-public interface SharingStarted {
+public fun interface SharingStarted {
     public companion object {
         /**
          * Sharing is started immediately and never stops.

--- a/kotlinx-coroutines-core/common/test/flow/sharing/ShareInTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/sharing/ShareInTest.kt
@@ -187,11 +187,9 @@ class ShareInTest : TestBase() {
     }
 
     @Suppress("TestFunctionName")
-    private fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int): SharingStarted =
-        object : SharingStarted {
-            override fun command(subscriptionCount: StateFlow<Int>): Flow<SharingCommand> =
-                subscriptionCount
-                    .map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP }
+    private fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int) =
+        SharingStarted { subscriptionCount ->
+            subscriptionCount.map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP }
         }
 
     private class FlowState {


### PR DESCRIPTION
It was a part of the original design, but was forgotten because prototype was developer before Kotlin 1.4.0.
It makes implementing custom SharingStarted strategies more concise.