### PR TITLE
Do not throw from JobListenableFuture.isCancelled

### DIFF
--- a/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
+++ b/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
@@ -397,9 +397,7 @@ private class JobListenableFuture<T>(private val jobToCancel: Job): ListenableFu
             Uninterruptibles.getUninterruptibly(this) is Cancelled
         } catch (e: CancellationException) {
             true
-        } catch (t: Throwable) {
-            // In theory appart from CancellationException, getUninterruptibly can only
-            // throw ExecutionException, but to be safe we catch Throwable here.
+        } catch (e: ExecutionException) {
             false
         }
 


### PR DESCRIPTION
This pull request properly handles ExecutionException that can be thrown from getUninterruptibly.

Bug was introduced in #2222 and affects 1.4.2 release :(

Fixed #2421