### PR TITLE
Gradle stewardship

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ import org.gradle.util.VersionNumber
 apply plugin: 'jdk-convention'
 apply from: rootProject.file("gradle/experimental.gradle")
 
-def rootModule = "kotlinx.coroutines"
 def coreModule = "kotlinx-coroutines-core"
 // Not applicable for Kotlin plugin
 def sourceless = ['kotlinx.coroutines', 'site', 'kotlinx-coroutines-bom', 'integration-testing']
@@ -187,7 +186,7 @@ configure(subprojects.findAll { !sourceless.contains(it.name) && it.name != core
     apply from: rootProject.file("gradle/compile-${platform}.gradle")
     dependencies {
         // See comment below for rationale, it will be replaced with "project" dependency
-        compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
+        compile project(":$coreModule")
         // the only way IDEA can resolve test classes
         testCompile project(":$coreModule").kotlin.targets.jvm.compilations.test.output.allOutputs
     }
@@ -239,22 +238,6 @@ if (build_snapshot_train) {
                     println it
                 }
             }
-        }
-    }
-}
-
-/*
- * Hack to trick nmpp plugin: we are renaming artifacts in order to provide backward compatibility for dependencies,
- * but publishing plugin does not re-read artifact names for kotlin-jvm projects, so renaming is not applied in pom files
- * for JVM-only projects.
- *
- * We artificially replace "project" dependency with "module" one to have proper names in pom files, but then substitute it
- * to have out "project" dependency back.
- */
-configure(subprojects.findAll { it.name != coreModule && it.name != rootModule }) {
-    configurations.all {
-        resolutionStrategy.dependencySubstitution {
-            substitute module("org.jetbrains.kotlinx:kotlinx-coroutines-core:$version") with project(':kotlinx-coroutines-core')
         }
     }
 }

--- a/gradle/publish-bintray.gradle
+++ b/gradle/publish-bintray.gradle
@@ -13,7 +13,6 @@ apply plugin: 'maven-publish'
 
 def isMultiplatform = project.name == "kotlinx-coroutines-core"
 def isBom = project.name == "kotlinx-coroutines-bom"
-def isKotlin137x = VersionNumber.parse(kotlin_version) <= VersionNumber.parse("1.3.79")
 
 if (!isBom) {
     apply plugin: "com.github.johnrengelman.shadow"
@@ -78,33 +77,23 @@ publishing {
             case 'kotlinMultiplatform':
                 // With Kotlin 1.4 & HMPP, the root module should have no suffix in the ID, but for compatibility with
                 // the consumers who can't read Gradle module metadata, we publish the JVM artifacts in it, too
-                it.artifactId = isKotlin137x ? "$project.name-native" : project.name
-                if (!isKotlin137x) {
-                    apply from: "$rootDir/gradle/publish-mpp-root-module-in-platform.gradle"
-                    publishPlatformArtifactsInRootModule(publications["jvm"])
-                }
+                it.artifactId =  project.name
+                apply from: "$rootDir/gradle/publish-mpp-root-module-in-platform.gradle"
+                publishPlatformArtifactsInRootModule(publications["jvm"])
                 break
             case 'metadata':
                 // As the old -common dependencies will fail to resolve with Gradle module metadata, rename the module
                 // to '*-metadata' so that the resolution failure are more clear
-                it.artifactId = isKotlin137x ? "$project.name-common" : "$project.name-metadata"
+                it.artifactId = "$project.name-metadata"
                 break
             case 'jvm':
-                it.artifactId = isKotlin137x ? project.name : "$project.name-jvm"
+                it.artifactId = "$project.name-jvm"
                 break
             case 'js':
             case 'native':
                 it.artifactId = "$project.name-$type"
                 break
         }
-        // Hierarchical project structures are not fully supported in 1.3.7x MPP
-        if (isKotlin137x) {
-            // disable metadata everywhere, but in native and js modules
-            if (type == 'maven' || type == 'metadata' || type == 'jvm') {
-                moduleDescriptorGenerator = null
-            }
-        }
-
     }
 }
 

--- a/gradle/publish-bintray.gradle
+++ b/gradle/publish-bintray.gradle
@@ -71,7 +71,6 @@ publishing {
             it.artifact(javadocJar)
         }
 
-        // Rename MPP artifacts for backward compatibility
         def type = it.name
         switch (type) {
             case 'kotlinMultiplatform':
@@ -82,13 +81,7 @@ publishing {
                 publishPlatformArtifactsInRootModule(publications["jvm"])
                 break
             case 'metadata':
-                // As the old -common dependencies will fail to resolve with Gradle module metadata, rename the module
-                // to '*-metadata' so that the resolution failure are more clear
-                it.artifactId = "$project.name-metadata"
-                break
             case 'jvm':
-                it.artifactId = "$project.name-jvm"
-                break
             case 'js':
             case 'native':
                 it.artifactId = "$project.name-$type"


### PR DESCRIPTION
    * Remove conditional publication that is compatible with Kotlin 1.3.70 plugin
    * Get rid of workaround in old MPP plugin with dependency renaming