### PR TITLE
Cleanup core module after update to Kotlin 1.4

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineStart.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineStart.kt
@@ -1,7 +1,6 @@
 /*
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("NO_EXPLICIT_VISIBILITY_IN_API_MODE")
 package kotlinx.coroutines
 
 import kotlinx.coroutines.CoroutineStart.*

--- a/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
@@ -89,6 +89,19 @@ public suspend inline fun <E> BroadcastChannel<E>.consumeEach(action: (E) -> Uni
 // -------- Operations on ReceiveChannel --------
 
 /**
+ * Returns a [List] containing all elements.
+ *
+ * The operation is _terminal_.
+ * This function [consumes][ReceiveChannel.consume] all elements of the original [ReceiveChannel].
+ */
+@OptIn(ExperimentalStdlibApi::class)
+public suspend fun <E> ReceiveChannel<E>.toList(): List<E> = buildList {
+    consumeEach {
+        add(it)
+    }
+}
+
+/**
  * Returns a [CompletionHandler] that invokes [cancel][ReceiveChannel.cancel] on the [ReceiveChannel]
  * with the corresponding cause. See also [ReceiveChannel.consume].
  *
@@ -1188,15 +1201,6 @@ public suspend fun <E, C : MutableCollection<in E>> ReceiveChannel<E>.toCollecti
     }
     return destination
 }
-
-/**
- * Returns a [List] containing all elements.
- *
- * The operation is _terminal_.
- * This function [consumes][ReceiveChannel.consume] all elements of the original [ReceiveChannel].
- */
-public suspend fun <E> ReceiveChannel<E>.toList(): List<E> =
-    this.toMutableList()
 
 /**
  * Returns a [Map] filled with all elements of this channel.

--- a/kotlinx-coroutines-core/jvm/src/CommonPool.kt
+++ b/kotlinx-coroutines-core/jvm/src/CommonPool.kt
@@ -28,7 +28,7 @@ internal object CommonPool : ExecutorCoroutineDispatcher() {
      * Note that until Java 10, if an application is run within a container,
      * `Runtime.getRuntime().availableProcessors()` is not aware of container constraints and will return the real number of cores.
      */
-    public const val DEFAULT_PARALLELISM_PROPERTY_NAME = "kotlinx.coroutines.default.parallelism"
+    private const val DEFAULT_PARALLELISM_PROPERTY_NAME = "kotlinx.coroutines.default.parallelism"
 
     override val executor: Executor
         get() = pool ?: getOrCreatePoolSync()
@@ -62,7 +62,7 @@ internal object CommonPool : ExecutorCoroutineDispatcher() {
             ?: return createPlainPool() // Fallback to plain thread pool
         // Try to use commonPool unless parallelism was explicitly specified or in debug privatePool mode
         if (!usePrivatePool && requestedParallelism < 0) {
-            Try { fjpClass.getMethod("commonPool")?.invoke(null) as? ExecutorService }
+            Try { fjpClass.getMethod("commonPool").invoke(null) as? ExecutorService }
                 ?.takeIf { isGoodCommonPool(fjpClass, it) }
                 ?.let { return it }
         }

--- a/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
@@ -6,7 +6,6 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.scheduling.*
-import java.util.concurrent.atomic.*
 import kotlin.coroutines.*
 
 internal const val COROUTINES_SCHEDULER_PROPERTY_NAME = "kotlinx.coroutines.scheduler"

--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -8,7 +8,6 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.scheduling.*
-import java.util.*
 import kotlin.coroutines.*
 
 /**

--- a/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
@@ -4,10 +4,8 @@
 
 package kotlinx.coroutines
 
-import kotlinx.coroutines.internal.*
 import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.coroutines.*
 
 /**
  * Creates a coroutine execution context using a single thread with built-in [yield] support.

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
@@ -72,7 +72,7 @@ internal class DebugCoroutineInfoImpl(
     private fun creationStackTrace(): List<StackTraceElement> {
         val bottom = creationStackBottom ?: return emptyList()
         // Skip "Coroutine creation stacktrace" frame
-        return sequence<StackTraceElement> { yieldFrames(bottom.callerFrame) }.toList()
+        return sequence { yieldFrames(bottom.callerFrame) }.toList()
     }
 
     private tailrec suspend fun SequenceScope<StackTraceElement>.yieldFrames(frame: CoroutineStackFrame?) {

--- a/kotlinx-coroutines-core/jvm/src/flow/internal/SafeCollector.kt
+++ b/kotlinx-coroutines-core/jvm/src/flow/internal/SafeCollector.kt
@@ -36,7 +36,7 @@ internal actual class SafeCollector<T> actual constructor(
     override val context: CoroutineContext
         get() = completion?.context ?: EmptyCoroutineContext
 
-    override fun invokeSuspend(result: Result<Any?>): Any? {
+    override fun invokeSuspend(result: Result<Any?>): Any {
         result.onFailure { lastEmissionContext = DownstreamExceptionElement(it) }
         completion?.resumeWith(result as Result<Unit>)
         return COROUTINE_SUSPENDED

--- a/kotlinx-coroutines-core/jvm/src/internal/Concurrent.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/Concurrent.kt
@@ -9,7 +9,7 @@ import java.util.*
 import java.util.concurrent.*
 import kotlin.concurrent.withLock as withLockJvm
 
-internal actual fun <E> subscriberList(): SubscribersList<E> = CopyOnWriteArrayList<E>()
+internal actual fun <E> subscriberList(): SubscribersList<E> = CopyOnWriteArrayList()
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 internal actual typealias ReentrantLock = java.util.concurrent.locks.ReentrantLock

--- a/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
@@ -322,7 +322,7 @@ public actual open class LockFreeLinkedListNode {
 
         private val _affectedNode = atomic<Node?>(null)
         final override val affectedNode: Node? get() = _affectedNode.value
-        final override val originalNext: Node? get() = queue
+        final override val originalNext: Node get() = queue
 
         override fun retry(affected: Node, next: Any): Boolean = next !== queue
 

--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -35,7 +35,7 @@ internal object MainDispatcherLoader {
                 ).iterator().asSequence().toList()
             }
             @Suppress("ConstantConditionIf")
-            factories.maxBy { it.loadPriority }?.tryCreateDispatcher(factories)
+            factories.maxByOrNull { it.loadPriority }?.tryCreateDispatcher(factories)
                 ?: createMissingDispatcher()
         } catch (e: Throwable) {
             // Service loader can throw an exception as well

--- a/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
@@ -2,7 +2,7 @@
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-@file:Suppress("UNCHECKED_CAST", "NO_EXPLICIT_VISIBILITY_IN_API_MODE")
+@file:Suppress("UNCHECKED_CAST")
 
 package kotlinx.coroutines.internal
 

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -169,7 +169,7 @@ internal class CoroutineScheduler(
      * It does nothing is this worker is already physically linked to the stack.
      * This method is invoked only from the worker thread itself.
      * This invocation always precedes [LockSupport.parkNanos].
-     * See [Worker.doPark].
+     * See [Worker.tryPark].
      *
      * Returns `true` if worker was added to the stack by this invocation, `false` if it was already
      * registered in the stack.

--- a/kotlinx-coroutines-debug/src/CoroutineInfo.kt
+++ b/kotlinx-coroutines-debug/src/CoroutineInfo.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("NO_EXPLICIT_VISIBILITY_IN_API_MODE", "INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "UNUSED")
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "UNUSED")
 package kotlinx.coroutines.debug
 
 import kotlinx.coroutines.*


### PR DESCRIPTION
    * Remove explicit API mode suppressions
    * Use list build in ReceiveChannel.toList to prevent casting to mutable list
    * Migrate to maxByOrNull
    * Remove redundant nullabilities