### PR TITLE
Bug fix and better LockFreeLinkedList verification with Lincheck

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/LockFreeLinkedList.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/LockFreeLinkedList.common.kt
@@ -74,7 +74,7 @@ public expect abstract class AbstractAtomicDesc : AtomicDesc {
     public abstract fun finishPrepare(prepareOp: PrepareOp) // non-null on failure
     public open fun onPrepare(prepareOp: PrepareOp): Any? // non-null on failure
     public open fun onRemoved(affected: LockFreeLinkedListNode) // non-null on failure
-    protected abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
+    public abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
 }
 
 /** @suppress **This is unstable API and it is subject to change.** */

--- a/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
@@ -134,10 +134,10 @@ public actual abstract class AbstractAtomicDesc : AtomicDesc() {
         return onPrepare(PrepareOp(affected, this, op))
     }
 
-    actual final override fun complete(op: AtomicOp<*>, failure: Any?) = onComplete()
+    public actual final override fun complete(op: AtomicOp<*>, failure: Any?) = onComplete()
     protected actual open fun failure(affected: LockFreeLinkedListNode): Any? = null // Never fails by default
     protected actual open fun retry(affected: LockFreeLinkedListNode, next: Any): Boolean = false // Always succeeds
-    protected actual abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
+    public actual abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
 }
 
 /** @suppress **This is unstable API and it is subject to change.** */

--- a/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
@@ -439,7 +439,7 @@ public actual open class LockFreeLinkedListNode {
             affected._next.compareAndSet(this, update)
             if (consensus == null) {
                 // If the consensus was on a successful completion of operation the above CAS could have reinstalled
-                // the node that was already removed into the list. This call to finishOnSuccess properly completes
+                // the node that was already removed from the list. This call to finishOnSuccess properly completes
                 // the ongoing operation.
                 desc.finishOnSuccess(affected, next)
             }

--- a/kotlinx-coroutines-core/jvm/test/lincheck/LockFreeListMultiLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/lincheck/LockFreeListMultiLincheckTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:Suppress("unused")
+
+package kotlinx.coroutines.lincheck
+
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.internal.*
+import org.jetbrains.kotlinx.lincheck.annotations.*
+import org.jetbrains.kotlinx.lincheck.paramgen.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
+import kotlin.test.*
+
+@Param.Params(
+    Param(name = "id", gen = IntGen::class, conf = "0:1"),
+    Param(name = "value", gen = IntGen::class, conf = "1:5")
+)
+class LockFreeList2LincheckTest : LockFreeListMultiLincheckTest(2)
+
+@Param.Params(
+    Param(name = "id", gen = IntGen::class, conf = "0:2"),
+    Param(name = "value", gen = IntGen::class, conf = "1:5")
+)
+class LockFreeList3LincheckTest : LockFreeListMultiLincheckTest(3)
+
+/**
+ * Test atomic operations across multiple instances of `LockFreeLinkedList`.
+ */
+abstract class LockFreeListMultiLincheckTest(val n: Int) : AbstractLincheckTest() {
+    private val _opSequence = atomic(0L)
+
+    class Node(val value: Int): LockFreeLinkedListNode() {
+        override fun toString(): String = "N$value"
+    }
+    private val q = Array(n) { index ->
+        object : LockFreeLinkedListHead() {
+            override fun toString(): String = "H$index"
+        }
+    }
+
+    @Operation
+    fun addLast(@Param(name = "id") id: Int, @Param(name = "value") value: Int) {
+        q[id].addLast(Node(value))
+    }
+
+    @Operation
+    fun addTwo(@Param(name = "id") id: Int, @Param(name = "value") value: Int) {
+        var result: Any?
+        do {
+            val add1 = q[id].describeAddLast(Node(value))
+            val add2 = q[(id + 1) % n].describeAddLast(Node(value))
+            val op = object : AtomicOp<Any?>() {
+                override val opSequence = _opSequence.incrementAndGet()
+                init {
+                    add1.atomicOp = this
+                    add2.atomicOp = this
+                }
+                override fun prepare(affected: Any?): Any? =
+                    add1.prepare(this) ?:
+                    add2.prepare(this)
+
+                override fun complete(affected: Any?, failure: Any?) {
+                    add1.complete(this, failure)
+                    add2.complete(this, failure)
+                }
+                override fun toString(): String = "AddTwoOp($id, $value)"
+            }
+            result = op.perform(null)
+        } while (result === RETRY_ATOMIC)
+        assertNull(result)
+    }
+
+    @Operation
+    fun removeFirst(@Param(name = "id") id: Int): Int? {
+        val node = q[id].removeFirstOrNull() ?: return null
+        return (node as Node).value
+    }
+
+    fun removeTwo(@Param(name = "id") id: Int): Pair<Int, Int>? {
+        var remove1: LockFreeLinkedListNode.RemoveFirstDesc<*>
+        var remove2: LockFreeLinkedListNode.RemoveFirstDesc<*>
+        var result: Any?
+        do {
+            remove1 = q[id].describeRemoveFirst()
+            remove2 = q[(id + 1) % n].describeRemoveFirst()
+            val op = object : AtomicOp<Any?>() {
+                override val opSequence = _opSequence.incrementAndGet()
+                init {
+                    remove1.atomicOp = this
+                    remove2.atomicOp = this
+                }
+                override fun prepare(affected: Any?): Any? =
+                    remove1.prepare(this) ?:
+                    remove2.prepare(this)
+
+                override fun complete(affected: Any?, failure: Any?) {
+                    remove1.complete(this, failure)
+                    remove2.complete(this, failure)
+                }
+                override fun toString(): String = "RemoveTwoOp($id)"
+            }
+            result = op.perform(null)
+        } while (result === RETRY_ATOMIC)
+        if (result != null) return null
+        return (remove1.result as Node).value to (remove2.result as Node).value
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun extractState(): List<List<Int>> = q.map {
+        buildList { it.forEach<Node> { add(it.value) } }
+    }
+
+    @Validate
+    fun validate() = q.forEach { it.validate() }
+
+    @StateRepresentation
+    fun stateRepresentation() = q.joinToString("; ") { it.stateRepresentation() }
+
+    override fun ModelCheckingOptions.customize(isStressTest: Boolean) =
+        checkObstructionFreedom()
+}

--- a/kotlinx-coroutines-core/native/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/native/src/internal/LinkedList.kt
@@ -134,10 +134,10 @@ public actual abstract class AbstractAtomicDesc : AtomicDesc() {
         return onPrepare(PrepareOp(affected, this, op))
     }
 
-    actual final override fun complete(op: AtomicOp<*>, failure: Any?) = onComplete()
+    public actual final override fun complete(op: AtomicOp<*>, failure: Any?) = onComplete()
     protected actual open fun failure(affected: LockFreeLinkedListNode): Any? = null // Never fails by default
     protected actual open fun retry(affected: LockFreeLinkedListNode, next: Any): Boolean = false // Always succeeds
-    protected actual abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
+    public actual abstract fun finishOnSuccess(affected: LockFreeLinkedListNode, next: LockFreeLinkedListNode)
 }
 
 /** @suppress **This is unstable API and it is subject to change.** */


### PR DESCRIPTION
Fixes a rare crash of LockFreeLinkedListAtomicLFStressTest, e.g:
https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_KotlinxCoroutines_NightlyStressWindows/3215239
with AssertionError at kotlinx.coroutines.internal.LockFreeLinkedListNode.validateNode

This was happening because during concurrent execution of a complex atomic operation a thread that adds a node to the list could be helped to complete by other threads and the newly added node could be already removed. Now, the original adder thread will execute its add operation too, adding the removed element back to the list, leaving the list in the state that is logically correct, but which is not correct physically (with a removed node still in the list).

The Lincheck test that consistently reproduces this problem is added and the fix is introduced.