### PR TITLE
[native-mt] Fix the errornous isDispatchNeeded check in Dispatchers.Main.immediate on Darwin platforms.

### DIFF
--- a/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
@@ -28,7 +28,7 @@ private class DarwinMainDispatcher(
 
     init { freeze() }
 
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean = !invokeImmediately || isMainThread()
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean = !(invokeImmediately && isMainThread())
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         dispatch_async(dispatch_get_main_queue()) {

--- a/kotlinx-coroutines-core/nativeDarwin/test/MainDispatcherTest.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/test/MainDispatcherTest.kt
@@ -4,10 +4,20 @@
 
 package kotlinx.coroutines
 
+import kotlin.coroutines.*
 import kotlin.test.*
 
 class MainDispatcherTest : TestBase() {
     private val testThread = currentThread()
+
+    @Test
+    fun testDispatchNecessityCheckWithMainImmediateDispatcher() {
+        runTest {
+            val immediate = Dispatchers.Main.immediate
+            val needsDispatch = testThread != mainThread
+            assertEquals(needsDispatch, immediate.isDispatchNeeded(EmptyCoroutineContext))
+        }
+    }
 
     @Test
     fun testWithContext() {


### PR DESCRIPTION
Resolves https://github.com/Kotlin/kotlinx.coroutines/issues/2283

First commit includes a test case that fails in both macosx64 background & main tests.