### PR TITLE
[native-mt] Fix ObjC autorelease object leaks with native-mt dispatchers

### DIFF
--- a/kotlinx-coroutines-core/common/src/EventLoop.common.kt
+++ b/kotlinx-coroutines-core/common/src/EventLoop.common.kt
@@ -530,6 +530,15 @@ internal abstract class EventLoopImplBase: EventLoopImplPlatform(), Delay {
 
 internal expect fun createEventLoop(): EventLoop
 
+/**
+ * Used by Darwin targets to wrap a [Runnable.run] call in an Objective-C Autorelease Pool. It is a no-op on JVM, JS and
+ * non-Darwin native targets.
+ *
+ * Coroutines on Darwin targets can call into the Objective-C world, where a callee may push a to-be-returned object to
+ * the Autorelease Pool, so as to avoid a premature ARC release before it reaches the caller. This means the pool must
+ * be eventually drained to avoid leaks. Since Kotlin Coroutines does not use [NSRunLoop], which provides automatic
+ * pool management, it must manage the pool creation and pool drainage manually.
+ */
 internal expect inline fun platformAutoreleasePool(crossinline block: () -> Unit)
 
 internal expect fun nanoTime(): Long

--- a/kotlinx-coroutines-core/common/src/EventLoop.common.kt
+++ b/kotlinx-coroutines-core/common/src/EventLoop.common.kt
@@ -66,7 +66,9 @@ internal abstract class EventLoop : CoroutineDispatcher() {
     public fun processUnconfinedEvent(): Boolean {
         val queue = unconfinedQueue ?: return false
         val task = queue.removeFirstOrNull() ?: return false
-        task.run()
+        platformAutoreleasePool {
+            task.run()
+        }
         return true
     }
     /**
@@ -271,7 +273,9 @@ internal abstract class EventLoopImplBase: EventLoopImplPlatform(), Delay {
         // then process one event from queue
         val task = dequeue()
         if (task != null) {
-            task.run()
+            platformAutoreleasePool {
+                task.run()
+            }
             return 0
         }
         return nextTime
@@ -525,6 +529,8 @@ internal abstract class EventLoopImplBase: EventLoopImplPlatform(), Delay {
 }
 
 internal expect fun createEventLoop(): EventLoop
+
+internal expect inline fun platformAutoreleasePool(crossinline block: () -> Unit)
 
 internal expect fun nanoTime(): Long
 

--- a/kotlinx-coroutines-core/js/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/js/src/EventLoop.kt
@@ -8,6 +8,8 @@ import kotlin.coroutines.*
 
 internal actual fun createEventLoop(): EventLoop = UnconfinedEventLoop()
 
+internal actual inline fun platformAutoreleasePool(crossinline block: () -> Unit) = block()
+
 internal actual fun nanoTime(): Long = unsupported()
 
 internal class UnconfinedEventLoop : EventLoop() {

--- a/kotlinx-coroutines-core/jvm/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/jvm/src/EventLoop.kt
@@ -25,6 +25,8 @@ internal class BlockingEventLoop(
 
 internal actual fun createEventLoop(): EventLoop = BlockingEventLoop(Thread.currentThread())
 
+internal actual inline fun platformAutoreleasePool(crossinline block: () -> Unit) = block()
+
 /**
  * Processes next event in the current thread's event loop.
  *

--- a/kotlinx-coroutines-core/nativeDarwin/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/EventLoop.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.cinterop.*
+
+internal actual inline fun platformAutoreleasePool(crossinline block: () -> Unit): Unit = autoreleasepool { block() }

--- a/kotlinx-coroutines-core/nativeDarwin/test/AutoreleaseLeakTest.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/test/AutoreleaseLeakTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.native.ref.*
+import kotlin.native.concurrent.*
+import kotlin.native.internal.*
+import platform.Foundation.*
+import platform.darwin.NSObject
+import kotlinx.cinterop.*
+import kotlin.test.*
+
+class AutoreleaseLeakTest : TestBase() {
+    private val testThread = currentThread()
+
+    @Test
+    fun testObjCAutorelease() {
+        val weakRef = AtomicReference<WeakReference<NSObject>?>(null)
+
+        runTest {
+            withContext(Dispatchers.Default) {
+                val job = launch {
+                    assertNotEquals(testThread, currentThread())
+                    val objcObj = NSObject()
+                    weakRef.value = WeakReference(objcObj).freeze()
+
+                    // Emulate an autorelease return value in native code.
+                    objc_retainAutoreleaseReturnValue(objcObj.objcPtr())
+                }
+                job.join()
+                GC.collect()
+            }
+
+            assertNotNull(weakRef.value)
+            assertNull(weakRef.value?.value)
+        }
+    }
+}

--- a/kotlinx-coroutines-core/nativeOther/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/nativeOther/src/EventLoop.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+internal actual inline fun platformAutoreleasePool(crossinline block: () -> Unit): Unit = block()


### PR DESCRIPTION
Resolves #2322

While 1.4.30-M1 fixed `Worker.execute()` leaking ObjC autoreleasing objects when running native code on a K/N Worker thread ([KT-42822](https://youtrack.jetbrains.com/issue/KT-42822)), it does not address the issue at KoltinX Coroutines framework level.

More specifically, when tasks on an EventLoop call into native code, any autoreleasing object — especially many ObjC method return values — is effectively leaked <sup>[1]</sup>. This is because [the first available autoreleasepool in the call stack is in `workerMain()`, and it wraps around a most likely never-returning <sup>[2]</sup> `runEventLoop()`](https://github.com/Kotlin/kotlinx.coroutines/blob/89a9f7d53c7add3492d0846b5dbd623ab5b5d81d/kotlinx-coroutines-core/native/src/Workers.kt#L46-L52). 

This PR introduced a failing test case of this bug, and fixed it by wrapping all `Runnable.run()` calls in `EventLoopImplBase` with an autoreleasepool (or nothing for non-Darwin targets). This is equivalent to the [DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM](https://developer.apple.com/documentation/dispatch/dispatch_autorelease_frequency_t/dispatch_autorelease_frequency_work_item)<sup>[3]</sup> in GCD.

An alternative to the per-item wrapping is integrating pool push/pop into `runEventLoop()`, with heruistics based on the park time returned by `processNextEvent()`. Not familiar enough about the particulars to try this out though.

_<sup>[1]</sup> ... unless an autoreleasepool is declared in user code explicitly, which is a rare practice except for memory optimization._
_<sup>[2]</sup> `Dispatchers.Default`, for example._
_<sup>[3]</sup> ... which is not the default behaviour. GCD threads inherit autorelease pool management from `NSRunLoop`, which recreates pools for each runloop iteration._