### PR TITLE
Cleanup continuation field in lazily-started coroutines after the start to reduce potential memory pressure

### DIFF
--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -111,8 +111,9 @@ private class LazyDeferredCoroutine<T>(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation!!.startCoroutineCancellable(this)
-        continuation = null
+        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        this.continuation = null
+        continuation.startCoroutineCancellable(this)
     }
 }
 
@@ -203,8 +204,9 @@ private class LazyStandaloneCoroutine(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation!!.startCoroutineCancellable(this)
-        continuation = null
+        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        this.continuation = null
+        continuation.startCoroutineCancellable(this)
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -108,10 +108,11 @@ private class LazyDeferredCoroutine<T>(
     parentContext: CoroutineContext,
     block: suspend CoroutineScope.() -> T
 ) : DeferredCoroutine<T>(parentContext, active = false) {
-    private val continuation = block.createCoroutineUnintercepted(this, this)
+    private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
     }
 }
 
@@ -199,10 +200,11 @@ private class LazyStandaloneCoroutine(
     parentContext: CoroutineContext,
     block: suspend CoroutineScope.() -> Unit
 ) : StandaloneCoroutine(parentContext, active = false) {
-    private val continuation = block.createCoroutineUnintercepted(this, this)
+    private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:JvmMultifileClass
@@ -111,9 +111,12 @@ private class LazyDeferredCoroutine<T>(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started" }
-        this.continuation = null
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
+    }
+
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        continuation = null
     }
 }
 
@@ -204,9 +207,12 @@ private class LazyStandaloneCoroutine(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started" }
-        this.continuation = null
-        continuation.startCoroutineCancellable(this)
+        continuation!!.startCoroutineCancellable(this)
+        continuation = null
+    }
+
+    override fun onCancelled(cause: Throwable, handled: Boolean) {
+        continuation = null
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -111,7 +111,7 @@ private class LazyDeferredCoroutine<T>(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        val continuation = checkNotNull(this.continuation) { "Already started" }
         this.continuation = null
         continuation.startCoroutineCancellable(this)
     }
@@ -204,7 +204,7 @@ private class LazyStandaloneCoroutine(
     private var continuation: Continuation<Unit>? = block.createCoroutineUnintercepted(this, this)
 
     override fun onStart() {
-        val continuation = checkNotNull(this.continuation) { "Already started!" }
+        val continuation = checkNotNull(this.continuation) { "Already started" }
         this.continuation = null
         continuation.startCoroutineCancellable(this)
     }

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -129,6 +129,7 @@ internal fun <E> CoroutineScope.produce(
     onCompletion: CompletionHandler? = null,
     @BuilderInference block: suspend ProducerScope<E>.() -> Unit
 ): ReceiveChannel<E> {
+    require(!start.isLazy) { "$start start is not supported" }
     val channel = Channel<E>(capacity, onBufferOverflow)
     val newContext = newCoroutineContext(context)
     val coroutine = ProducerCoroutine(newContext, channel)

--- a/kotlinx-coroutines-core/jvm/test/LazyCoroutineLeakTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/LazyCoroutineLeakTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.coroutines.channels.*
+import org.junit.*
+
+class LazyCoroutineLeakTest : TestBase() {
+
+    private object NonReachable
+
+    private fun capturingBlock(victim: Any): suspend CoroutineScope.() -> Unit = { victim.hashCode() }
+
+    private suspend fun Job.testStartAndJoin() {
+        FieldWalker.assertReachableCount(1, this) { it === NonReachable }
+        start()
+        join()
+        FieldWalker.assertReachableCount(0, this) { it === NonReachable }
+    }
+
+    suspend fun Job.testCancelAndJoin() {
+        FieldWalker.assertReachableCount(1, this) { it === NonReachable }
+        cancelAndJoin()
+        FieldWalker.assertReachableCount(0, this) { it === NonReachable }
+    }
+
+    @Test
+    fun testLazyLaunch() = runTest {
+        launch(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)).testStartAndJoin()
+    }
+
+    @Test
+    fun testLazyLaunchCancel() = runTest {
+        launch(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)).testCancelAndJoin()
+
+    }
+
+    @Test
+    fun testLazyAsync() = runTest {
+        async(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)).testStartAndJoin()
+    }
+
+    @Test
+    fun testLazyLaunchAsync() = runTest {
+        async(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)).testCancelAndJoin()
+    }
+
+    @Test
+    fun testLazyActor() = runTest {
+        (actor<Int>(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)) as Job).testStartAndJoin()
+    }
+
+    @Test
+    fun testLazyActorCancel() = runTest {
+        (actor<Int>(start = CoroutineStart.LAZY, block = capturingBlock(NonReachable)) as Job).testCancelAndJoin()
+    }
+
+    // Lazy produce & future are not supported, broadcast is obsolete
+}


### PR DESCRIPTION

Also, as long as onStart is our own private API, replace checkNotNull with !! operator to save few bytecodes