### PR TITLE
Add bi-directional cancellation for Task.await and Task.asDeferred

### DIFF
--- a/integration/kotlinx-coroutines-play-services/README.md
+++ b/integration/kotlinx-coroutines-play-services/README.md
@@ -6,7 +6,7 @@ Extension functions:
 
 | **Name** | **Description**
 | -------- | ---------------
-| [awaitTask][awaitTask] | Awaits for completion of a Task constructed with a CancellationToken
+| [Task.asDeferred][asDeferred] | Converts a Task into a Deferred
 | [Task.await][await] | Awaits for completion of the Task (cancellable)
 | [Deferred.asTask][asTask] | Converts a deferred value to a Task
 
@@ -26,6 +26,14 @@ val snapshot = try {
 // Do stuff
 ```
 
-[awaitTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/awaitTask.html
+If the `Task` supports cancellation via passing a `CancellationToken`, pass the corresponding `CancellationTokenSource` to `asDeferred` or `await` to support bi-directional cancellation:
+
+```kotlin
+val cancellationTokenSource = CancellationTokenSource()
+val currentLocationTask = fusedLocationProviderClient.getCurrentLocation(PRIORITY_HIGH_ACCURACY, cancellationTokenSource.token)
+val currentLocation = currentLocationTask.await(cancellationTokenSource)
+```
+
+[asDeferred]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/as-deferred.html
 [await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
 [asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html

--- a/integration/kotlinx-coroutines-play-services/README.md
+++ b/integration/kotlinx-coroutines-play-services/README.md
@@ -6,7 +6,7 @@ Extension functions:
 
 | **Name** | **Description**
 | -------- | ---------------
-| [((CancellationToken) -> Task).await][((CancellationToken) -> Task).await] | Awaits for completion of a Task constructed with a CancellationToken
+| [awaitTask][awaitTask] | Awaits for completion of a Task constructed with a CancellationToken
 | [Task.await][await] | Awaits for completion of the Task (cancellable)
 | [Deferred.asTask][asTask] | Converts a deferred value to a Task
 
@@ -26,6 +26,6 @@ val snapshot = try {
 // Do stuff
 ```
 
-[((CancellationToken) -> Task).await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/awaitConstructedTask.html
+[awaitTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/awaitTask.html
 [await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
 [asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html

--- a/integration/kotlinx-coroutines-play-services/README.md
+++ b/integration/kotlinx-coroutines-play-services/README.md
@@ -6,6 +6,7 @@ Extension functions:
 
 | **Name** | **Description**
 | -------- | ---------------
+| [((CancellationToken) -> Task).await][((CancellationToken) -> Task).await] | Awaits for completion of a Task constructed with a CancellationToken
 | [Task.await][await] | Awaits for completion of the Task (cancellable)
 | [Deferred.asTask][asTask] | Converts a deferred value to a Task
 
@@ -25,5 +26,6 @@ val snapshot = try {
 // Do stuff
 ```
 
+[((CancellationToken) -> Task).await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/awaitConstructedTask.html
 [await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
 [asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html

--- a/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
+++ b/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
@@ -1,7 +1,8 @@
 public final class kotlinx/coroutines/tasks/TasksKt {
 	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;)Lkotlinx/coroutines/Deferred;
+	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;Lcom/google/android/gms/tasks/CancellationTokenSource;)Lkotlinx/coroutines/Deferred;
 	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
+	public static final fun await (Lcom/google/android/gms/tasks/Task;Lcom/google/android/gms/tasks/CancellationTokenSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun awaitTask (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
+++ b/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
@@ -2,5 +2,6 @@ public final class kotlinx/coroutines/tasks/TasksKt {
 	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;)Lkotlinx/coroutines/Deferred;
 	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
 	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun await (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
+++ b/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
@@ -2,6 +2,6 @@ public final class kotlinx/coroutines/tasks/TasksKt {
 	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;)Lkotlinx/coroutines/Deferred;
 	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
 	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun await (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun awaitTask (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/integration/kotlinx-coroutines-play-services/src/Tasks.kt
+++ b/integration/kotlinx-coroutines-play-services/src/Tasks.kt
@@ -49,7 +49,7 @@ public fun <T> Task<T>.asDeferred(): Deferred<T> = asDeferred(CancellationTokenS
  * Converts this task to an instance of [Deferred] with a [CancellationTokenSource] to control cancellation.
  *
  * If the task is cancelled, then the resulting deferred will be cancelled.
- * If the deferred is cancelled, then the [cancellationTokenSource] will be cancelled.
+ * When the deferred is completed, the [cancellationTokenSource] will be cancelled.
  *
  * Providing a [CancellationTokenSource] that is unrelated to the receiving [Task] is not supported, as this function
  * won't listen for the token being cancelled directly. Instead, prefer to just cancel the corresponding [Job].
@@ -83,9 +83,7 @@ public fun <T> Task<T>.asDeferred(cancellationTokenSource: CancellationTokenSour
     }
 
     deferred.invokeOnCompletion {
-        if (it is CancellationException) {
-            cancellationTokenSource.cancel()
-        }
+        cancellationTokenSource.cancel()
     }
 
     return object : Deferred<T> by deferred {}

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -154,11 +154,10 @@ class TaskTest : TestBase() {
         var taskCompletionSource: TaskCompletionSource<Int>? = null
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            val taskCreator: suspend (CancellationToken) -> Task<Int> = { cancellationToken ->
+            awaitTask { cancellationToken ->
                 taskCompletionSource = TaskCompletionSource<Int>(cancellationToken)
                 taskCompletionSource!!.task
             }
-            taskCreator.await()
         }
 
         assertFalse(deferred.isCompleted)
@@ -173,11 +172,10 @@ class TaskTest : TestBase() {
         var taskCompletionSource: TaskCompletionSource<Int>? = null
 
         val deferred: Deferred<Int> = GlobalScope.async(start = CoroutineStart.UNDISPATCHED) {
-            val taskCreator: suspend (CancellationToken) -> Task<Int> = { cancellationToken ->
+            awaitTask { cancellationToken ->
                 taskCompletionSource = TaskCompletionSource<Int>(cancellationToken)
                 taskCompletionSource!!.task
             }
-            taskCreator.await()
         }
 
         assertFalse(deferred.isCompleted)
@@ -193,11 +191,10 @@ class TaskTest : TestBase() {
         var task: Task<Int>? = null
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            val taskCreator: suspend (CancellationToken) -> Task<Int> = { cancellationToken ->
+            awaitTask { cancellationToken ->
                 task = TaskCompletionSource<Int>(cancellationToken).task
                 task!!
             }
-            taskCreator.await()
         }
 
         assertFalse(deferred.isCompleted)

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -328,7 +328,6 @@ class TaskTest : TestBase() {
             assertTrue(e is CancellationException)
         }
 
-        assertTrue(taskCompletionSource.task.isCanceled)
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
@@ -352,7 +351,6 @@ class TaskTest : TestBase() {
             assertTrue(e is CancellationException)
         }
 
-        assertTrue(taskCompletionSource.task.isCanceled)
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
@@ -371,7 +369,6 @@ class TaskTest : TestBase() {
 
         // Cancelling the token doesn't cancel the deferred
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
-        assertFalse(taskCompletionSource.task.isCanceled)
         assertFalse(deferred.isCompleted)
 
         // Cleanup
@@ -393,7 +390,6 @@ class TaskTest : TestBase() {
 
         // Cancelling the token doesn't cancel the deferred
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
-        assertFalse(taskCompletionSource.task.isCanceled)
         assertFalse(deferred.isCompleted)
 
         // Cleanup

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -154,14 +154,14 @@ class TaskTest : TestBase() {
         val cancellationTokenSource = CancellationTokenSource()
         val deferred = Tasks.forResult(42).asDeferred(cancellationTokenSource)
         assertEquals(42, deferred.await())
-        assertFalse(cancellationTokenSource.token.isCancellationRequested)
+        assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
     @Test
     fun testNullResultCancellableTaskAsDeferred() = runTest {
         val cancellationTokenSource = CancellationTokenSource()
         assertNull(Tasks.forResult(null).asDeferred(cancellationTokenSource).await())
-        assertFalse(cancellationTokenSource.token.isCancellationRequested)
+        assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
     @Test
@@ -243,7 +243,7 @@ class TaskTest : TestBase() {
             assertTrue(e is TestException)
             assertEquals("something went wrong", e.message)
         }
-        assertFalse(cancellationTokenSource.token.isCancellationRequested)
+        assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
     @Test
@@ -266,7 +266,7 @@ class TaskTest : TestBase() {
             assertEquals("something went wrong", e.message)
             assertSame(e.cause, deferred.getCompletionExceptionOrNull()) // debug mode stack augmentation
         }
-        assertFalse(cancellationTokenSource.token.isCancellationRequested)
+        assertTrue(cancellationTokenSource.token.isCancellationRequested)
     }
 
     @Test

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -218,7 +218,7 @@ class TaskTest : TestBase() {
     fun testSeparatelyCancelledCancellableTaskAsDeferred() = runTest {
         val cancellationTokenSource = CancellationTokenSource()
         val task = TaskCompletionSource<Int>().task
-        val deferred = task.asDeferred(cancellationTokenSource)
+        task.asDeferred(cancellationTokenSource)
 
         cancellationTokenSource.cancel()
 
@@ -318,7 +318,7 @@ class TaskTest : TestBase() {
         }
 
         assertFalse(deferred.isCompleted)
-        // Cancel the deferred token source
+        // Cancel the deferred
         deferred.cancel()
 
         try {

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -193,7 +193,6 @@ class TaskTest : TestBase() {
             assertTrue(e is CancellationException)
         }
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
-        assertTrue(task.isCanceled)
     }
 
     @Test
@@ -211,7 +210,6 @@ class TaskTest : TestBase() {
             assertTrue(e is CancellationException)
         }
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
-        assertTrue(task.isCanceled)
     }
 
     @Test
@@ -223,7 +221,6 @@ class TaskTest : TestBase() {
         cancellationTokenSource.cancel()
 
         assertTrue(cancellationTokenSource.token.isCancellationRequested)
-        assertFalse(task.isCanceled)
     }
 
     @Test


### PR DESCRIPTION
This PR includes my proposed addition to the `play-services` integration to allow bi-directional cancellation for `Task.await` and `Task.asDeferred`, which in particular provides the hook to cancel a task via a `CancellationToken` (which fixes #2527)

Both `Task.asDeferred` and `Task.await` now each have a new overload that takes a passed in `CancellationTokenSource`. If the `Deferred`/`await` is cancelled, or if the receiving `Task` is cancelled, then the `CancellationTokenSource` will also be cancelled. In particular, this means that if the `Task` will be cancelled when the `CancellationTokenSource` is cancelled, cancelling the `Deferred`/`await` will cancel the underlying `Task`.

The existing implementations of `Task.asDeferred` and `Task.await` call into the new implementations, with a newly constructed `CancellationTokenSource` that will result in a no-op upon being cancelled.