### PR TITLE
Add Log4J2 MDC integration for coroutines

### DIFF
--- a/integration/kotlinx-coroutines-log4j2/README.md
+++ b/integration/kotlinx-coroutines-log4j2/README.md
@@ -1,0 +1,26 @@
+# Module kotlinx-coroutines-log4j2
+
+Integration with Log4J2 [Thread Context Map](https://logging.apache.org/log4j/2.x/manual/thread-context.html) (aka MDC).
+
+## Example
+
+Add [MDCContext] to the coroutine context so that the Log4J2 Thread Context Map is captured and passed into the coroutine.
+
+```kotlin
+ThreadContext.put("kotlin", "rocks") // put a value into the Thread Context Map
+
+launch(MDCContext()) {
+   logger.info { "..." }   // the Thread Context will contain the mapping here
+}
+```
+
+# Package kotlinx.coroutines.log4j2
+
+Integration with Log4J2 [Thread Context Map](https://logging.apache.org/log4j/2.x/manual/thread-context.html) (aka MDC).
+
+<!--- MODULE kotlinx-coroutines-log4j2 -->
+<!--- INDEX kotlinx.coroutines.log4j2 -->
+
+[MDCContext]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-log4j2/kotlinx.coroutines.log4j2/-m-d-c-context/index.html
+
+<!--- END -->

--- a/integration/kotlinx-coroutines-log4j2/api/kotlinx-coroutines-log4j2.api
+++ b/integration/kotlinx-coroutines-log4j2/api/kotlinx-coroutines-log4j2.api
@@ -1,0 +1,19 @@
+public final class kotlinx/coroutines/log4j2/MDCContext : kotlin/coroutines/AbstractCoroutineContextElement, kotlinx/coroutines/ThreadContextElement {
+	public static final field Key Lkotlinx/coroutines/log4j2/MDCContext$Key;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public final fun getContextMap ()Ljava/util/Map;
+	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+	public synthetic fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Object;)V
+	public fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;)V
+	public synthetic fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
+	public fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Ljava/util/Map;
+}
+
+public final class kotlinx/coroutines/log4j2/MDCContext$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+

--- a/integration/kotlinx-coroutines-log4j2/build.gradle.kts
+++ b/integration/kotlinx-coroutines-log4j2/build.gradle.kts
@@ -1,0 +1,9 @@
+dependencies {
+    implementation("org.apache.logging.log4j:log4j-api:2.14.0")
+    testImplementation("io.github.microutils:kotlin-logging:1.5.4")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.14.0")
+}
+
+externalDocumentationLink(
+    url = "https://logging.apache.org/log4j/2.x/javadoc.html"
+)

--- a/integration/kotlinx-coroutines-log4j2/package.list
+++ b/integration/kotlinx-coroutines-log4j2/package.list
@@ -1,0 +1,1 @@
+org.apache.logging.log4j

--- a/integration/kotlinx-coroutines-log4j2/src/MDCContext.kt
+++ b/integration/kotlinx-coroutines-log4j2/src/MDCContext.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.log4j2
+
+import kotlinx.coroutines.*
+import org.apache.logging.log4j.ThreadContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * The value of [ThreadContext] context map.
+ * See [ThreadContext.getContext].
+ */
+public typealias MDCContextMap = Map<String, String>?
+
+/**
+ * [ThreadContext] context element for [CoroutineContext].
+ *
+ * Example:
+ *
+ * ```
+ * ThreadContext.put("kotlin", "rocks") // Put a value into the MDC context
+ *
+ * launch(MDCContext()) {
+ *     logger.info { "..." }   // The MDC context contains the mapping here
+ * }
+ * ```
+ *
+ * Note that you cannot update MDC context from inside of the coroutine simply
+ * using [ThreadContext.put]. These updates are going to be lost on the next suspension and
+ * reinstalled to the ThreadContext that was captured or explicitly specified in
+ * [contextMap] when this object was created on the next resumption.
+ * Use `withContext(MDCContext()) { ... }` to capture updated map of MDC keys and values
+ * for the specified block of code.
+ *
+ * @param contextMap the value of [ThreadContext] context map.
+ * Default value is the copy of the current thread's context map that is acquired via
+ * [ThreadContext.getContext].
+ */
+public class MDCContext(
+    /**
+     * The value of [ThreadContext] context map.
+     */
+    public val contextMap: MDCContextMap = ThreadContext.getContext()
+) : ThreadContextElement<MDCContextMap>, AbstractCoroutineContextElement(Key) {
+    /**
+     * Key of [MDCContext] in [CoroutineContext].
+     */
+    public companion object Key : CoroutineContext.Key<MDCContext>
+
+    override fun updateThreadContext(context: CoroutineContext): MDCContextMap {
+        val oldState = ThreadContext.getImmutableContext()
+        setCurrent(contextMap)
+        return oldState
+    }
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: MDCContextMap) {
+        setCurrent(oldState)
+    }
+
+    private fun setCurrent(contextMap: MDCContextMap) {
+        ThreadContext.clearMap()
+        if (contextMap != null) {
+            ThreadContext.putAll(contextMap)
+        }
+    }
+}

--- a/integration/kotlinx-coroutines-log4j2/test-resources/log4j2-test.xml
+++ b/integration/kotlinx-coroutines-log4j2/test-resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%X{first, last} - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</configuration>

--- a/integration/kotlinx-coroutines-log4j2/test/MDCContextTest.kt
+++ b/integration/kotlinx-coroutines-log4j2/test/MDCContextTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.log4j2
+
+import kotlinx.coroutines.*
+import org.apache.logging.log4j.ThreadContext
+import org.junit.*
+import org.junit.Test
+import kotlin.coroutines.*
+import kotlin.test.*
+
+class MDCContextTest : TestBase() {
+    @Before
+    fun setUp() {
+        ThreadContext.clearMap()
+    }
+
+    @After
+    fun tearDown() {
+        ThreadContext.clearMap()
+    }
+
+    @Test
+    fun testContextIsNotPassedByDefaultBetweenCoroutines() = runTest {
+        expect(1)
+        ThreadContext.put("myKey", "myValue")
+        // Standalone launch
+        GlobalScope.launch {
+            assertNull(ThreadContext.get("myKey"))
+            expect(2)
+        }.join()
+        finish(3)
+    }
+
+    @Test
+    fun testContextCanBePassedBetweenCoroutines() = runTest {
+        expect(1)
+        ThreadContext.put("myKey", "myValue")
+        // Scoped launch with MDCContext element
+        launch(MDCContext()) {
+            assertEquals("myValue", ThreadContext.get("myKey"))
+            expect(2)
+        }.join()
+
+        finish(3)
+    }
+
+    @Test
+    fun testContextInheritance() = runTest {
+        expect(1)
+        ThreadContext.put("myKey", "myValue")
+        withContext(MDCContext()) {
+            ThreadContext.put("myKey", "myValue2")
+            // Scoped launch with inherited MDCContext element
+            launch(Dispatchers.Default) {
+                assertEquals("myValue", ThreadContext.get("myKey"))
+                expect(2)
+            }.join()
+
+            finish(3)
+        }
+        assertEquals("myValue", ThreadContext.get("myKey"))
+    }
+
+    @Test
+    fun testContextPassedWhileOnMainThread() {
+        ThreadContext.put("myKey", "myValue")
+        // No MDCContext element
+        runBlocking {
+            assertEquals("myValue", ThreadContext.get("myKey"))
+        }
+    }
+
+    @Test
+    fun testContextCanBePassedWhileOnMainThread() {
+        ThreadContext.put("myKey", "myValue")
+        runBlocking(MDCContext()) {
+            assertEquals("myValue", ThreadContext.get("myKey"))
+        }
+    }
+
+    @Test
+    fun testContextNeededWithOtherContext() {
+        ThreadContext.put("myKey", "myValue")
+        runBlocking(MDCContext()) {
+            assertEquals("myValue", ThreadContext.get("myKey"))
+        }
+    }
+
+    @Test
+    fun testContextMayBeEmpty() {
+        runBlocking(MDCContext()) {
+            assertNull(ThreadContext.get("myKey"))
+        }
+    }
+
+    @Test
+    fun testContextWithContext() = runTest {
+        ThreadContext.put("myKey", "myValue")
+        val mainDispatcher = kotlin.coroutines.coroutineContext[ContinuationInterceptor]!!
+        withContext(Dispatchers.Default + MDCContext()) {
+            assertEquals("myValue", ThreadContext.get("myKey"))
+            withContext(mainDispatcher) {
+                assertEquals("myValue", ThreadContext.get("myKey"))
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,6 +39,7 @@ module('integration/kotlinx-coroutines-guava')
 module('integration/kotlinx-coroutines-jdk8')
 module('integration/kotlinx-coroutines-slf4j')
 module('integration/kotlinx-coroutines-play-services')
+module('integration/kotlinx-coroutines-log4j2')
 
 module('reactive/kotlinx-coroutines-reactive')
 module('reactive/kotlinx-coroutines-reactor')


### PR DESCRIPTION
As Log4J2 is superior 😉 I thought it would be nice to start having Kotlin play nicer with it, particularly with coroutines.

This patch is a copy of the SLF4J integration, with adjustments to Log4J2 API. It only considers `ThreadContext` map (aka MDC) at the moment. The `ThreadContext` stack (aka NDC) is for later consideration.

Another future consideration includes Log4J2's [asynchronous logger](https://logging.apache.org/log4j/log4j-2.3/manual/async.html) capability in the context of coroutines or other non-blocking code.

NB: I did _not_ test against a JDK 1.6, sorry.