### PR TITLE
Fix a test that was flaky because of BlockHound

### DIFF
--- a/kotlinx-coroutines-debug/src/CoroutinesBlockHoundIntegration.kt
+++ b/kotlinx-coroutines-debug/src/CoroutinesBlockHoundIntegration.kt
@@ -18,6 +18,7 @@ public class CoroutinesBlockHoundIntegration : BlockHoundIntegration {
         allowBlockingWhenEnqueuingTasks()
         allowServiceLoaderInvocationsOnInit()
         allowBlockingCallsInReflectionImpl()
+        allowBlockingCallsInDebugProbes()
         /* The predicates that define that BlockHound should only report blocking calls from threads that are part of
         the coroutine thread pool and currently execute a CPU-bound coroutine computation. */
         addDynamicThreadPredicate { isSchedulerWorker(it) }
@@ -45,6 +46,17 @@ public class CoroutinesBlockHoundIntegration : BlockHoundIntegration {
             "tryMakeCompleting"))
         {
             allowBlockingCallsInside("kotlinx.coroutines.JobSupport", method)
+        }
+    }
+
+    /**
+     * Allow blocking calls inside [kotlinx.coroutines.debug.internal.DebugProbesImpl].
+     */
+    private fun BlockHound.Builder.allowBlockingCallsInDebugProbes() {
+        for (method in listOf("install", "uninstall", "hierarchyToString", "dumpCoroutinesInfo", "dumpDebuggerInfo",
+            "dumpCoroutinesSynchronized", "updateRunningState", "updateState"))
+        {
+            allowBlockingCallsInside("kotlinx.coroutines.debug.internal.DebugProbesImpl", method)
         }
     }
 


### PR DESCRIPTION
`RunningThreadStackMergeTest.testStackMergeWithContext` was failing:
https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_KotlinxTrain_Kotlin140_LibrariesBranchesFor150Release/3329282?buildTab=tests&status=failed&expandedTest=4424896350783031328

`kotlinx.coroutines.debug.internal.DebugProbesImpl.updateState`
sometimes parks in order to acquire a lock, which leads BlockHound
to detect an illegal blocking call. Now, blocking calls inside
`DebugProbesImpl` are permitted. Though allowing `updateState`
would suffice, the other users of the lock seem safe, too, and are
allowed even when it doesn't make much sense to call them from
coroutines.