### PR TITLE
Make the subscriber in awaitOne less permissive

### DIFF
--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -161,7 +161,8 @@ private suspend fun <T> Publisher<T>.awaitOne(
             val sub = subscription.let {
                 if (it == null) {
                     /** Enforce rule 1.9: expect [Subscriber.onSubscribe] before any other signals. */
-                    handleCoroutineException(cont.context, IllegalStateException(checkInitializedString("onNext")))
+                    handleCoroutineException(cont.context,
+                        IllegalStateException("'onNext' was called before 'onSubscribe'"))
                     return
                 } else {
                     it
@@ -236,19 +237,12 @@ private suspend fun <T> Publisher<T>.awaitOne(
  * state was reached.
  */
 private fun gotSignalInTerminalStateException(context: CoroutineContext, signalName: String) =
-    handleCoroutineException(context, IllegalStateException(signalInTerminalStateExceptionString(signalName)))
-
-internal fun signalInTerminalStateExceptionString(signalName: String) =
-    "'$signalName' was called after the publisher already signalled being in a terminal state"
+    handleCoroutineException(context,
+        IllegalStateException("'$signalName' was called after the publisher already signalled being in a terminal state"))
 
 /**
  * Enforce rule 1.1: it is invalid for a publisher to provide more values than requested.
  */
 private fun moreThanOneValueProvidedException(context: CoroutineContext, mode: Mode) =
-    handleCoroutineException(context, IllegalStateException(moreThanOneValueProvidedExceptionString(mode.toString())))
-
-internal fun moreThanOneValueProvidedExceptionString(mode: String) =
-    "Only a single value were requested in $mode, but the publisher provided more"
-
-internal fun checkInitializedString(signalName: String) =
-    "'$signalName' was called before 'onSubscribe'"
+    handleCoroutineException(context,
+        IllegalStateException("Only a single value was requested in '$mode', but the publisher provided more"))

--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -184,8 +184,9 @@ private suspend fun <T> Publisher<T>.awaitOne(
                     if ((mode == Mode.SINGLE || mode == Mode.SINGLE_OR_DEFAULT) && seenValue) {
                         sub.cancel()
                         // the check for `cont.isActive` is just a slight optimization and doesn't affect correctness
-                        if (cont.isActive)
+                        if (cont.isActive) {
                             cont.resumeWithException(IllegalArgumentException("More than one onNext value for $mode"))
+                        }
                     } else {
                         value = t
                         seenValue = true
@@ -200,8 +201,9 @@ private suspend fun <T> Publisher<T>.awaitOne(
                 return
             if (seenValue) {
                 // the check for `cont.isActive` is just a slight optimization and doesn't affect correctness
-                if (mode != Mode.FIRST_OR_DEFAULT && mode != Mode.FIRST && cont.isActive)
+                if (mode != Mode.FIRST_OR_DEFAULT && mode != Mode.FIRST && cont.isActive) {
                     cont.resume(value as T)
+                }
                 return
             }
             when {
@@ -216,8 +218,9 @@ private suspend fun <T> Publisher<T>.awaitOne(
         }
 
         override fun onError(e: Throwable) {
-            if (tryEnterTerminalState("onError"))
+            if (tryEnterTerminalState("onError")) {
                 cont.resumeWithException(e)
+            }
         }
 
         /**

--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -202,9 +202,9 @@ private suspend fun <T> Publisher<T>.awaitOne(
                 return
             }
             if (seenValue) {
-                /* the check for `cont.isActive` is needed because otherwise, if the publisher doesn't acknowledge the
+                /* the check for `cont.isActive` is needed because, otherwise, if the publisher doesn't acknowledge the
                 call to `cancel` for modes `SINGLE*` when more than one value was seen, it may call `onComplete`, and
-                here it `cont.resume` would fail. */
+                here `cont.resume` would fail. */
                 if (mode != Mode.FIRST_OR_DEFAULT && mode != Mode.FIRST && cont.isActive) {
                     cont.resume(value as T)
                 }

--- a/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
@@ -216,17 +216,17 @@ class IntegrationTest(
     private suspend inline fun <reified E: Throwable> assertCallsExceptionHandlerWith(
         crossinline operation: suspend () -> Unit): E
     {
-        var caughtException: Throwable? = null
+        val caughtExceptions = mutableListOf<Throwable>()
         val exceptionHandler = object: AbstractCoroutineContextElement(CoroutineExceptionHandler),
             CoroutineExceptionHandler
         {
             override fun handleException(context: CoroutineContext, exception: Throwable) {
-                caughtException = exception
+                caughtExceptions += exception
             }
         }
         return withContext(exceptionHandler) {
             operation()
-            caughtException.let {
+            caughtExceptions.single().let {
                 assertTrue(it is E)
                 it
             }

--- a/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/IntegrationTest.kt
@@ -133,6 +133,35 @@ class IntegrationTest(
     }
 
     /**
+     * Test that the continuation is not being resumed after it has already failed due to there having been too many
+     * values passed.
+     */
+    @Test
+    fun testNotCompletingFailedAwait() = runTest {
+        try {
+            expect(1)
+            Publisher<Int> { sub ->
+                sub.onSubscribe(object: Subscription {
+                    override fun request(n: Long) {
+                        expect(2)
+                        sub.onNext(1)
+                        sub.onNext(2)
+                        expect(4)
+                        sub.onComplete()
+                    }
+
+                    override fun cancel() {
+                        expect(3)
+                    }
+                })
+            }.awaitSingle()
+        } catch (e: java.lang.IllegalArgumentException) {
+            expect(5)
+        }
+        finish(6)
+    }
+
+    /**
      * Test the behavior of [awaitOne] on unconforming publishers.
      */
     @Test


### PR DESCRIPTION
Reactive Streams' Subscriber's implementation for `await*` operations was assuming that the publisher is correct. Now, the implementation detects some instances of problematic behavior for publishers and reports them.

Fixes https://github.com/Kotlin/kotlinx.coroutines/issues/2079