### PR TITLE
Add timeout operator to Flow

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -1035,6 +1035,10 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun switchMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun take (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static final fun takeWhile (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun timeout (Lkotlinx/coroutines/flow/Flow;JLkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun timeout$default (Lkotlinx/coroutines/flow/Flow;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun timeout-8Mi8wO0 (Lkotlinx/coroutines/flow/Flow;DLkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun timeout-8Mi8wO0$default (Lkotlinx/coroutines/flow/Flow;DLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun toCollection (Lkotlinx/coroutines/flow/Flow;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toList (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun toList$default (Lkotlinx/coroutines/flow/Flow;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -1046,6 +1050,11 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun unsafeTransform (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun withIndex (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun zip (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class kotlinx/coroutines/flow/FlowTimeoutException : java/util/concurrent/CancellationException, kotlinx/coroutines/CopyableThrowable {
+	public synthetic fun createCopy ()Ljava/lang/Throwable;
+	public fun createCopy ()Lkotlinx/coroutines/flow/FlowTimeoutException;
 }
 
 public final class kotlinx/coroutines/flow/LintKt {

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -432,7 +432,6 @@ public fun <T> Flow<T>.timeout(
 ): Flow<T> = timeoutInternal(timeoutMillis, action)
 
 @ExperimentalTime
-@OptIn(kotlin.experimental.ExperimentalTypeInference::class)
 private fun <T> Flow<T>.timeoutInternal(
     timeoutMillis: Long,
     action: suspend FlowCollector<T>.() -> Unit

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -469,7 +469,7 @@ private fun <T> Flow<T>.timeoutInternal(
         values.onReceiveOrNull { value ->
             if (value !== DONE) {
                 if (value === TIMEOUT) {
-                    action(downStream)
+                    downStream.action()
                     values.cancel(ChildCancelledException())
                     return@onReceiveOrNull false // Just end the loop here. Nothing more to be done.
                 }

--- a/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow.operators
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlin.test.*
+import kotlin.time.*
+
+class TimeoutTest : TestBase() {
+    @ExperimentalTime
+    @Test
+    fun testBasic() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(100)
+            emit("B")
+            delay(100)
+            emit("C")
+            expect(4)
+            delay(400)
+            expectUnreached()
+        }
+
+        expect(2)
+        val list = mutableListOf<String>()
+        assertFailsWith<FlowTimeoutException>(flow.timeout(300).onEach { list.add(it) })
+        assertEquals(listOf("A", "B", "C"), list)
+        finish(5)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testBasicCustomAction() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            delay(100)
+            emit("B")
+            delay(100)
+            emit("C")
+            expect(4)
+            delay(400)
+            expectUnreached()
+        }
+
+        expect(2)
+        val list = mutableListOf<String>()
+        flow.timeout(300) { emit("-1") }.collect { list.add(it) }
+        assertEquals(listOf("A", "B", "C", "-1"), list)
+        finish(5)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testDelayedFirst() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            delay(100)
+            emit(1)
+            expect(4)
+        }.timeout(250)
+        expect(2)
+        assertEquals(1, flow.singleOrNull())
+        finish(5)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testEmpty() = runTest {
+        val flow = emptyFlow<Any?>().timeout(1)
+        assertNull(flow.singleOrNull())
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testScalar() = runTest {
+        val flow = flowOf(1, 2, 3).timeout(1)
+        assertEquals(listOf(1, 2, 3), flow.toList())
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testUpstreamError() = testUpstreamError(TestException())
+
+    @ExperimentalTime
+    @Test
+    fun testUpstreamErrorTimeoutException() = testUpstreamError(FlowTimeoutException(0))
+
+    @ExperimentalTime
+    private inline fun <reified T: Throwable> testUpstreamError(cause: T) = runTest {
+        val flow = flow {
+            emit(1)
+            throw cause
+        }.timeout(1)
+
+        assertFailsWith<T>(flow)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testDownstreamError() = runTest {
+        val flow = flow {
+            expect(1)
+            emit(1)
+            hang { expect(3) }
+            expectUnreached()
+        }.timeout(100).map {
+            expect(2)
+            yield()
+            throw TestException()
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testUpstreamTimeoutIsolatedContext() = runTest {
+        val flow = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            expect(2)
+            delay(300)
+            expectUnreached()
+        }.flowOn(NamedDispatchers("upstream")).timeout(100)
+
+        assertFailsWith<FlowTimeoutException>(flow)
+        finish(3)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testUpstreamTimeoutActionIsolatedContext() = runTest {
+        val flow = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            expect(2)
+            delay(300)
+            expectUnreached()
+        }.flowOn(NamedDispatchers("upstream")).timeout(100) {
+            expect(3)
+            emit(2)
+        }
+
+        assertEquals(listOf(1, 2), flow.toList())
+        finish(4)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testUpstreamNoTimeoutIsolatedContext() = runTest {
+        val flow = flow {
+            assertEquals("upstream", NamedDispatchers.name())
+            expect(1)
+            emit(1)
+            expect(2)
+            delay(10)
+        }.flowOn(NamedDispatchers("upstream")).timeout(100)
+
+        assertEquals(listOf(1), flow.toList())
+        finish(3)
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testSharedFlowTimeout() = runTest {
+        assertFailsWith<FlowTimeoutException>(MutableSharedFlow<Int>().asSharedFlow().timeout(100))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun testSharedFlowCancelledNoTimeout() = runTest {
+        val mutableSharedFlow = MutableSharedFlow<Int>()
+        val list = arrayListOf<Int>()
+
+        expect(1)
+        val consumerJob = launch {
+            expect(3)
+            mutableSharedFlow.asSharedFlow().timeout(100).collect { list.add(it) }
+            expectUnreached()
+        }
+        val producerJob = launch {
+            expect(4)
+            repeat(10) {
+                delay(50)
+                mutableSharedFlow.emit(it)
+            }
+            yield()
+            consumerJob.cancel()
+            expect(5)
+        }
+
+        expect(2)
+
+        producerJob.join()
+        consumerJob.join()
+
+        assertEquals((0 until 10).toList(), list)
+        finish(6)
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
+++ b/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
@@ -1,0 +1,28 @@
+@file:OptIn(ExperimentalTime::class)
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// This file was automatically generated from Delay.kt by Knit tool. Do not edit.
+package kotlinx.coroutines.examples.exampleTimeoutDuration01
+
+import kotlin.time.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+
+fun main() = runBlocking {
+
+flow {
+    emit(1)
+    delay(100)
+    emit(2)
+    delay(100)
+    emit(3)
+    delay(1000)
+    emit(4)
+}.timeout(100.milliseconds) {
+    emit(-1) // Item to emit on timeout
+}.onEach {
+    delay(300) // This will not cause a timeout
+}
+.toList().joinToString().let { println(it) } }

--- a/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-02.kt
+++ b/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-02.kt
@@ -1,0 +1,28 @@
+@file:OptIn(ExperimentalTime::class)
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// This file was automatically generated from Delay.kt by Knit tool. Do not edit.
+package kotlinx.coroutines.examples.exampleTimeoutDuration02
+
+import kotlin.time.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+
+fun main() = runBlocking {
+
+flow {
+    emit(1)
+    delay(100)
+    emit(2)
+    delay(100)
+    emit(3)
+    delay(1000)
+    emit(4)
+}.timeout(100) {
+    emit(-1) // Item to emit on timeout
+}.onEach {
+    delay(300) // This will not cause a timeout
+}
+.toList().joinToString().let { println(it) } }

--- a/kotlinx-coroutines-core/jvm/test/examples/test/FlowDelayTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/examples/test/FlowDelayTest.kt
@@ -50,4 +50,18 @@ class FlowDelayTest {
             "1, 3, 5, 7, 9"
         )
     }
+
+    @Test
+    fun testExampleTimeoutDuration01() {
+        test("ExampleTimeoutDuration01") { kotlinx.coroutines.examples.exampleTimeoutDuration01.main() }.verifyLines(
+            "1, 2, 3, -1"
+        )
+    }
+
+    @Test
+    fun testExampleTimeoutDuration02() {
+        test("ExampleTimeoutDuration02") { kotlinx.coroutines.examples.exampleTimeoutDuration02.main() }.verifyLines(
+            "1, 2, 3, -1"
+        )
+    }
 }


### PR DESCRIPTION
This adds functionality similar to the [`timeout()`](http://reactivex.io/documentation/operators/timeout.html) in Rx. This invokes a timeout if the upstream flow doesn't emit after the set period of time, with the option to perform a custom action on timeout.