### PR TITLE
Allow extra suspension in Lincheck tests for `Semaphore.acquire()`

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/lincheck/SemaphoreLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/lincheck/SemaphoreLincheckTest.kt
@@ -16,7 +16,7 @@ abstract class SemaphoreLincheckTestBase(permits: Int) : AbstractLincheckTest() 
     @Operation
     fun tryAcquire() = semaphore.tryAcquire()
 
-    @Operation(promptCancellation = true)
+    @Operation(promptCancellation = true, allowExtraSuspension = true)
     suspend fun acquire() = semaphore.acquire()
 
     @Operation(handleExceptionsAsResult = [IllegalStateException::class])


### PR DESCRIPTION
Fixes the Lincheck test for Semaphore, see
https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_KotlinxTrain_Kotlin140_LibrariesBranchesFor150Release/3383227
https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_KotlinxTrain_Kotlin140_LibrariesBranchesFor150Release/3388024