### PR TITLE
Deprecation and migration of receiveOrNull and onReceiveOrNull.

### DIFF
--- a/integration/kotlinx-coroutines-jdk8/test/time/FlowSampleTest.kt
+++ b/integration/kotlinx-coroutines-jdk8/test/time/FlowSampleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.time
@@ -12,8 +12,7 @@ import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
 
-
-class SampleTest : TestBase() {
+class FlowSampleTest : TestBase() {
     @Test
     public fun testBasic() = withVirtualTime {
         expect(1)

--- a/kotlinx-coroutines-core/README.md
+++ b/kotlinx-coroutines-core/README.md
@@ -54,9 +54,9 @@ helper function. [NonCancellable] job object is provided to suppress cancellatio
 | ---------------- | --------------------------------------------- | ------------------------------------------------ | --------------------------
 | [Job]            | [join][Job.join]                              | [onJoin][Job.onJoin]                   | [isCompleted][Job.isCompleted]
 | [Deferred]       | [await][Deferred.await]                       | [onAwait][Deferred.onAwait]                 | [isCompleted][Job.isCompleted]
-| [SendChannel][kotlinx.coroutines.channels.SendChannel]    | [send][kotlinx.coroutines.channels.SendChannel.send]                      | [onSend][kotlinx.coroutines.channels.SendChannel.onSend]                   | [offer][kotlinx.coroutines.channels.SendChannel.offer]
-| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receive][kotlinx.coroutines.channels.ReceiveChannel.receive]             | [onReceive][kotlinx.coroutines.channels.ReceiveChannel.onReceive]             | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
-| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveOrNull][kotlinx.coroutines.channels.receiveOrNull] | [onReceiveOrNull][kotlinx.coroutines.channels.onReceiveOrNull] | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
+| [SendChannel][kotlinx.coroutines.channels.SendChannel]    | [send][kotlinx.coroutines.channels.SendChannel.send]                      | [onSend][kotlinx.coroutines.channels.SendChannel.onSend]                   | [trySend][kotlinx.coroutines.channels.SendChannel.trySend]
+| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receive][kotlinx.coroutines.channels.ReceiveChannel.receive]             | [onReceive][kotlinx.coroutines.channels.ReceiveChannel.onReceive]             | [tryReceive][kotlinx.coroutines.channels.ReceiveChannel.tryReceive]
+| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveCatching][kotlinx.coroutines.channels.ReceiveChannel.receiveCatching] | [onReceiveCatching][kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching] | [tryReceive][kotlinx.coroutines.channels.ReceiveChannel.tryReceive]
 | [Mutex][kotlinx.coroutines.sync.Mutex]          | [lock][kotlinx.coroutines.sync.Mutex.lock]                            | [onLock][kotlinx.coroutines.sync.Mutex.onLock]                   | [tryLock][kotlinx.coroutines.sync.Mutex.tryLock]
 | none            | [delay]                                        | [onTimeout][kotlinx.coroutines.selects.SelectBuilder.onTimeout]                   | none
 
@@ -133,11 +133,11 @@ Obsolete and deprecated module to test coroutines. Replaced with `kotlinx-corout
 [kotlinx.coroutines.channels.ReceiveChannel.receive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/receive.html
 [kotlinx.coroutines.channels.SendChannel]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/index.html
 [kotlinx.coroutines.channels.SendChannel.onSend]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/on-send.html
-[kotlinx.coroutines.channels.SendChannel.offer]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/offer.html
+[kotlinx.coroutines.channels.SendChannel.trySend]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/try-send.html
 [kotlinx.coroutines.channels.ReceiveChannel.onReceive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive.html
-[kotlinx.coroutines.channels.ReceiveChannel.poll]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/poll.html
-[kotlinx.coroutines.channels.receiveOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/receive-or-null.html
-[kotlinx.coroutines.channels.onReceiveOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/on-receive-or-null.html
+[kotlinx.coroutines.channels.ReceiveChannel.tryReceive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/try-receive.html
+[kotlinx.coroutines.channels.ReceiveChannel.receiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/receive-catching.html
+[kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive-catching.html
 
 <!--- INDEX kotlinx.coroutines.selects -->
 

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -555,7 +555,9 @@ public abstract interface class kotlinx/coroutines/channels/ActorScope : kotlinx
 
 public final class kotlinx/coroutines/channels/ActorScope$DefaultImpls {
 	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ActorScope;)V
+	public static fun getOnReceiveOrNull (Lkotlinx/coroutines/channels/ActorScope;)Lkotlinx/coroutines/selects/SelectClause1;
 	public static fun poll (Lkotlinx/coroutines/channels/ActorScope;)Ljava/lang/Object;
+	public static fun receiveOrNull (Lkotlinx/coroutines/channels/ActorScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : kotlinx/coroutines/channels/SendChannel {
@@ -600,8 +602,10 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 
 public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
 	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)V
+	public static fun getOnReceiveOrNull (Lkotlinx/coroutines/channels/Channel;)Lkotlinx/coroutines/selects/SelectClause1;
 	public static fun offer (Lkotlinx/coroutines/channels/Channel;Ljava/lang/Object;)Z
 	public static fun poll (Lkotlinx/coroutines/channels/Channel;)Ljava/lang/Object;
+	public static fun receiveOrNull (Lkotlinx/coroutines/channels/Channel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class kotlinx/coroutines/channels/Channel$Factory {
@@ -627,6 +631,9 @@ public final class kotlinx/coroutines/channels/ChannelKt {
 	public static final fun Channel (ILkotlinx/coroutines/channels/BufferOverflow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/channels/Channel;
 	public static synthetic fun Channel$default (IILjava/lang/Object;)Lkotlinx/coroutines/channels/Channel;
 	public static synthetic fun Channel$default (ILkotlinx/coroutines/channels/BufferOverflow;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/channels/Channel;
+	public static final fun getOrElse-WpGqRn0 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun onFailure-WpGqRn0 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun onSuccess-WpGqRn0 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class kotlinx/coroutines/channels/ChannelResult {
@@ -840,7 +847,9 @@ public final class kotlinx/coroutines/channels/ReceiveChannel$DefaultImpls {
 	public static synthetic fun cancel (Lkotlinx/coroutines/channels/ReceiveChannel;)V
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
+	public static fun getOnReceiveOrNull (Lkotlinx/coroutines/channels/ReceiveChannel;)Lkotlinx/coroutines/selects/SelectClause1;
 	public static fun poll (Lkotlinx/coroutines/channels/ReceiveChannel;)Ljava/lang/Object;
+	public static fun receiveOrNull (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class kotlinx/coroutines/channels/SendChannel {

--- a/kotlinx-coroutines-core/common/README.md
+++ b/kotlinx-coroutines-core/common/README.md
@@ -59,7 +59,7 @@ helper function. [NonCancellable] job object is provided to suppress cancellatio
 | [Deferred]       | [await][Deferred.await]                       | [onAwait][Deferred.onAwait]                 | [isCompleted][Job.isCompleted]
 | [SendChannel][kotlinx.coroutines.channels.SendChannel]    | [send][kotlinx.coroutines.channels.SendChannel.send]                      | [onSend][kotlinx.coroutines.channels.SendChannel.onSend]                   | [offer][kotlinx.coroutines.channels.SendChannel.offer]
 | [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receive][kotlinx.coroutines.channels.ReceiveChannel.receive]             | [onReceive][kotlinx.coroutines.channels.ReceiveChannel.onReceive]             | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
-| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveOrNull][kotlinx.coroutines.channels.receiveOrNull] | [onReceiveOrNull][kotlinx.coroutines.channels.onReceiveOrNull] | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
+| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveCatching][kotlinx.coroutines.channels.ReceiveChannel.receiveCatching] | [onReceiveCatching][kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching] | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
 | [Mutex][kotlinx.coroutines.sync.Mutex]          | [lock][kotlinx.coroutines.sync.Mutex.lock]                            | [onLock][kotlinx.coroutines.sync.Mutex.onLock]                   | [tryLock][kotlinx.coroutines.sync.Mutex.tryLock]
 | none            | [delay]                                        | [onTimeout][kotlinx.coroutines.selects.SelectBuilder.onTimeout]                   | none
 
@@ -149,8 +149,8 @@ Low-level primitives for finer-grained control of coroutines.
 [kotlinx.coroutines.channels.SendChannel.offer]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/offer.html
 [kotlinx.coroutines.channels.ReceiveChannel.onReceive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive.html
 [kotlinx.coroutines.channels.ReceiveChannel.poll]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/poll.html
-[kotlinx.coroutines.channels.receiveOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/receive-or-null.html
-[kotlinx.coroutines.channels.onReceiveOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/on-receive-or-null.html
+[kotlinx.coroutines.channels.ReceiveChannel.receiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/receive-catching.html
+[kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive-catching.html
 
 <!--- INDEX kotlinx.coroutines.selects -->
 

--- a/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
@@ -37,40 +37,34 @@ public inline fun <E, R> BroadcastChannel<E>.consume(block: ReceiveChannel<E>.()
 }
 
 /**
- * Retrieves and removes the element from this channel suspending the caller while this channel [isEmpty]
- * or returns `null` if the channel is [closed][Channel.isClosedForReceive].
+ * This function is deprecated in the favour of [ReceiveChannel.receiveCatching].
  *
- * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
- * function is suspended, this function immediately resumes with [CancellationException].
- * There is a **prompt cancellation guarantee**. If the job was cancelled while this function was
- * suspended, it will not resume successfully. If the `receiveOrNull` call threw [CancellationException] there is no way
- * to tell if some element was already received from the channel or not. See [Channel] documentation for details.
+ * This function is considered error-prone for the following reasons;
+ * * Is throwing if the channel has failed even though its signature may suggest it returns 'null'
+ * * It is easy to forget that exception handling still have to be explicit
+ * * During code reviews and code reading, intentions of the code are frequently unclear:
+ *   are potential exceptions ignored deliberately or not?
  *
- * Note, that this function does not check for cancellation when it is not suspended.
- * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
- *
- * This extension is defined only for channels on non-null types, so that generic functions defined using
- * these extensions do not accidentally confuse `null` value and a normally closed channel, leading to hard
- * to find bugs.
+ * @suppress doc
  */
+@Deprecated(
+    "Deprecated in the favour of 'receiveCatching'",
+    ReplaceWith("receiveCatching().getOrNull()"),
+    DeprecationLevel.WARNING
+) // Warning since 1.5.0, ERROR in 1.6.0, HIDDEN in 1.7.0
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-@ExperimentalCoroutinesApi // since 1.3.0, tentatively stable in 1.4.x
 public suspend fun <E : Any> ReceiveChannel<E>.receiveOrNull(): E? {
     @Suppress("DEPRECATION", "UNCHECKED_CAST")
     return (this as ReceiveChannel<E?>).receiveOrNull()
 }
 
 /**
- * Clause for [select] expression of [receiveOrNull] suspending function that selects with the element that
- * is received from the channel or selects with `null` if the channel
- * [isClosedForReceive][ReceiveChannel.isClosedForReceive] without cause. The [select] invocation fails with
- * the original [close][SendChannel.close] cause exception if the channel has _failed_.
- *
- * This extension is defined only for channels on non-null types, so that generic functions defined using
- * these extensions do not accidentally confuse `null` value and a normally closed channel, leading to hard
- * to find bugs.
- **/
-@ExperimentalCoroutinesApi // since 1.3.0, tentatively stable in 1.4.x
+ * This function is deprecated in the favour of [ReceiveChannel.onReceiveCatching]
+ */
+@Deprecated(
+    "Deprecated in the favour of 'onReceiveCatching'",
+    level = DeprecationLevel.WARNING
+)  // Warning since 1.5.0, ERROR in 1.6.0, HIDDEN in 1.7.0
 public fun <E : Any> ReceiveChannel<E>.onReceiveOrNull(): SelectClause1<E?> {
     @Suppress("DEPRECATION", "UNCHECKED_CAST")
     return (this as ReceiveChannel<E?>).onReceiveOrNull

--- a/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
@@ -54,7 +54,8 @@ internal suspend fun <R, T> FlowCollector<R>.combineInternal(
         ++currentEpoch
         // Start batch
         // The very first receive in epoch should be suspending
-        var element = resultChannel.receiveOrNull() ?: break // Channel is closed, nothing to do here
+        // TODO closed with an exception ?
+        var element = resultChannel.receiveCatching().getOrNull() ?: break // Channel is closed, nothing to do here
         while (true) {
             val index = element.index
             // Update values
@@ -129,7 +130,9 @@ internal fun <T1, T2, R> zipImpl(flow: Flow<T1>, flow2: Flow<T2>, transform: sus
                 withContextUndispatched(coroutineContext + collectJob, Unit) {
                     flow.collect { value ->
                         withContextUndispatched(scopeContext, Unit, cnt) {
-                            val otherValue = second.receiveOrNull() ?: throw AbortFlowException(this@unsafeFlow)
+                            val otherValue = second.receiveCatching().getOrElse {
+                                throw it ?:AbortFlowException(this@unsafeFlow)
+                            }
                             emit(transform(value, NULL.unbox(otherValue)))
                         }
                     }

--- a/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/Combine.kt
@@ -54,7 +54,6 @@ internal suspend fun <R, T> FlowCollector<R>.combineInternal(
         ++currentEpoch
         // Start batch
         // The very first receive in epoch should be suspending
-        // TODO closed with an exception ?
         var element = resultChannel.receiveCatching().getOrNull() ?: break // Channel is closed, nothing to do here
         while (true) {
             val index = element.index

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -177,16 +177,6 @@ public interface SelectInstance<in R> {
  * corresponding non-suspending version that can be used with a regular `when` expression to select one
  * of the alternatives or to perform the default (`else`) action if none of them can be immediately selected.
  *
- * | **Receiver**     | **Suspending function**                       | **Select clause**                                | **Non-suspending version**
- * | ---------------- | --------------------------------------------- | ------------------------------------------------ | --------------------------
- * | [Job]            | [join][Job.join]                              | [onJoin][Job.onJoin]                             | [isCompleted][Job.isCompleted]
- * | [Deferred]       | [await][Deferred.await]                       | [onAwait][Deferred.onAwait]                      | [isCompleted][Job.isCompleted]
- * | [SendChannel]    | [send][SendChannel.send]                      | [onSend][SendChannel.onSend]                     | [offer][SendChannel.offer]
- * | [ReceiveChannel] | [receive][ReceiveChannel.receive]             | [onReceive][ReceiveChannel.onReceive]            | [poll][ReceiveChannel.poll]
- * | [ReceiveChannel] | [receiveOrNull][ReceiveChannel.receiveOrNull] | [onReceiveOrNull][ReceiveChannel.onReceiveOrNull]| [poll][ReceiveChannel.poll]
- * | [Mutex]          | [lock][Mutex.lock]                            | [onLock][Mutex.onLock]                           | [tryLock][Mutex.tryLock]
- * | none             | [delay]                                       | [onTimeout][SelectBuilder.onTimeout]             | none
- *
  * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
  * function is suspended, this function immediately resumes with [CancellationException].
  * There is a **prompt cancellation guarantee**. If the job was cancelled while this function was

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -177,6 +177,18 @@ public interface SelectInstance<in R> {
  * corresponding non-suspending version that can be used with a regular `when` expression to select one
  * of the alternatives or to perform the default (`else`) action if none of them can be immediately selected.
  *
+ * ### List of supported select methods
+ *
+ * | **Receiver**     | **Suspending function**                           | **Select clause**
+ * | ---------------- | ---------------------------------------------     | -----------------------------------------------------
+ * | [Job]            | [join][Job.join]                                  | [onJoin][Job.onJoin]
+ * | [Deferred]       | [await][Deferred.await]                           | [onAwait][Deferred.onAwait]
+ * | [SendChannel]    | [send][SendChannel.send]                          | [onSend][SendChannel.onSend]
+ * | [ReceiveChannel] | [receive][ReceiveChannel.receive]                 | [onReceive][ReceiveChannel.onReceive]
+ * | [ReceiveChannel] | [receiveCatching][ReceiveChannel.receiveCatching] | [onReceiveCatching][ReceiveChannel.onReceiveCatching]
+ * | [Mutex]          | [lock][Mutex.lock]                                | [onLock][Mutex.onLock]
+ * | none             | [delay]                                           | [onTimeout][SelectBuilder.onTimeout]
+ *
  * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
  * function is suspended, this function immediately resumes with [CancellationException].
  * There is a **prompt cancellation guarantee**. If the job was cancelled while this function was

--- a/kotlinx-coroutines-core/common/test/channels/ArrayBroadcastChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ArrayBroadcastChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -46,7 +46,7 @@ class ArrayBroadcastChannelTest : TestBase() {
             assertEquals(2, first.receive()) // suspends
             assertFalse(first.isClosedForReceive)
             expect(10)
-            assertNull(first.receiveOrNull()) // suspends
+            assertTrue(first.receiveCatching().isClosed) // suspends
             assertTrue(first.isClosedForReceive)
             expect(14)
         }
@@ -62,7 +62,7 @@ class ArrayBroadcastChannelTest : TestBase() {
             assertEquals(2, second.receive()) // suspends
             assertFalse(second.isClosedForReceive)
             expect(11)
-            assertNull(second.receiveOrNull()) // suspends
+            assertNull(second.receiveCatching().getOrNull()) // suspends
             assertTrue(second.isClosedForReceive)
             expect(15)
         }
@@ -116,9 +116,9 @@ class ArrayBroadcastChannelTest : TestBase() {
         expect(6)
         assertFalse(sub.isClosedForReceive)
         for (x in 1..3)
-            assertEquals(x, sub.receiveOrNull())
+            assertEquals(x, sub.receiveCatching().getOrNull())
         // and receive close signal
-        assertNull(sub.receiveOrNull())
+        assertNull(sub.receiveCatching().getOrNull())
         assertTrue(sub.isClosedForReceive)
         finish(7)
     }
@@ -153,7 +153,7 @@ class ArrayBroadcastChannelTest : TestBase() {
         // make sure all of them are consumed
         check(!sub.isClosedForReceive)
         for (x in 1..5) check(sub.receive() == x)
-        check(sub.receiveOrNull() == null)
+        check(sub.receiveCatching().getOrNull() == null)
         check(sub.isClosedForReceive)
     }
 
@@ -196,7 +196,7 @@ class ArrayBroadcastChannelTest : TestBase() {
         val channel = BroadcastChannel<Int>(1)
         val subscription = channel.openSubscription()
         subscription.cancel(TestCancellationException())
-        subscription.receiveOrNull()
+        subscription.receive()
     }
 
     @Test
@@ -208,6 +208,6 @@ class ArrayBroadcastChannelTest : TestBase() {
         channel.cancel()
         assertTrue(channel.isClosedForSend)
         assertTrue(sub.isClosedForReceive)
-        check(sub.receiveOrNull() == null)
+        check(sub.receiveCatching().getOrNull() == null)
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ArrayChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -38,17 +38,17 @@ class ArrayChannelTest : TestBase() {
     }
 
     @Test
-    fun testClosedBufferedReceiveOrNull() = runTest {
+    fun testClosedBufferedReceiveCatching() = runTest {
         val q = Channel<Int>(1)
         check(q.isEmpty && !q.isClosedForSend && !q.isClosedForReceive)
         expect(1)
         launch {
             expect(5)
             check(!q.isEmpty && q.isClosedForSend && !q.isClosedForReceive)
-            assertEquals(42, q.receiveOrNull())
+            assertEquals(42, q.receiveCatching().getOrNull())
             expect(6)
             check(!q.isEmpty && q.isClosedForSend && q.isClosedForReceive)
-            assertNull(q.receiveOrNull())
+            assertNull(q.receiveCatching().getOrNull())
             expect(7)
         }
         expect(2)
@@ -134,7 +134,7 @@ class ArrayChannelTest : TestBase() {
         q.cancel()
         check(q.isClosedForSend)
         check(q.isClosedForReceive)
-        assertFailsWith<CancellationException> { q.receiveOrNull() }
+        assertFailsWith<CancellationException> { q.receiveCatching().getOrThrow() }
         finish(12)
     }
 
@@ -142,7 +142,7 @@ class ArrayChannelTest : TestBase() {
     fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(5)
         channel.cancel(TestCancellationException())
-        channel.receiveOrNull()
+        channel.receive()
     }
 
     @Test
@@ -160,7 +160,7 @@ class ArrayChannelTest : TestBase() {
             channel.offer(-1)
         }
         repeat(4) {
-            channel.receiveOrNull()
+            channel.receiveCatching().getOrNull()
         }
         checkBufferChannel(channel, capacity)
     }

--- a/kotlinx-coroutines-core/common/test/channels/ChannelUndeliveredElementFailureTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ChannelUndeliveredElementFailureTest.kt
@@ -70,33 +70,7 @@ class ChannelUndeliveredElementFailureTest : TestBase() {
     }
 
     @Test
-    fun testReceiveOrNullCancelledFail() = runTest(unhandled = shouldBeUnhandled) {
-        val channel = Channel(onUndeliveredElement = onCancelFail)
-        val job = launch(start = CoroutineStart.UNDISPATCHED) {
-            channel.receiveOrNull()
-            expectUnreached() // will be cancelled before it dispatches
-        }
-        channel.send(item)
-        job.cancel()
-    }
-
-    @Test
-    fun testReceiveOrNullSelectCancelledFail() = runTest(unhandled = shouldBeUnhandled) {
-        val channel = Channel(onUndeliveredElement = onCancelFail)
-        val job = launch(start = CoroutineStart.UNDISPATCHED) {
-            select<Unit> {
-                channel.onReceiveOrNull {
-                    expectUnreached()
-                }
-            }
-            expectUnreached() // will be cancelled before it dispatches
-        }
-        channel.send(item)
-        job.cancel()
-    }
-
-    @Test
-    fun testReceiveOrClosedCancelledFail() = runTest(unhandled = shouldBeUnhandled) {
+    fun testReceiveCatchingCancelledFail() = runTest(unhandled = shouldBeUnhandled) {
         val channel = Channel(onUndeliveredElement = onCancelFail)
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             channel.receiveCatching()

--- a/kotlinx-coroutines-core/common/test/channels/ConflatedBroadcastChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ConflatedBroadcastChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -68,7 +68,7 @@ class ConflatedBroadcastChannelTest : TestBase() {
             expect(14)
             assertEquals("three", sub.receive()) // suspends
             expect(17)
-            assertNull(sub.receiveOrNull()) // suspends until closed
+            assertNull(sub.receiveCatching().getOrNull()) // suspends until closed
             expect(20)
             sub.cancel()
             expect(21)

--- a/kotlinx-coroutines-core/common/test/channels/ConflatedChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ConflatedChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -27,7 +27,7 @@ open class ConflatedChannelTest : TestBase() {
         val q = createConflatedChannel<Int>()
         q.send(1)
         q.send(2) // shall conflated previously sent
-        assertEquals(2, q.receiveOrNull())
+        assertEquals(2, q.receiveCatching().getOrNull())
     }
 
     @Test
@@ -41,7 +41,7 @@ open class ConflatedChannelTest : TestBase() {
         // not it is closed for receive, too
         assertTrue(q.isClosedForSend)
         assertTrue(q.isClosedForReceive)
-        assertNull(q.receiveOrNull())
+        assertNull(q.receiveCatching().getOrNull())
     }
 
     @Test
@@ -82,7 +82,7 @@ open class ConflatedChannelTest : TestBase() {
         q.cancel()
         check(q.isClosedForSend)
         check(q.isClosedForReceive)
-        assertFailsWith<CancellationException> { q.receiveOrNull() }
+        assertFailsWith<CancellationException> { q.receiveCatching().getOrThrow() }
         finish(2)
     }
 
@@ -90,6 +90,6 @@ open class ConflatedChannelTest : TestBase() {
     fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = createConflatedChannel<Int>()
         channel.cancel(TestCancellationException())
-        channel.receiveOrNull()
+        channel.receive()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/LinkedListChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/LinkedListChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -18,8 +18,8 @@ class LinkedListChannelTest : TestBase() {
         check(!c.close())
         assertEquals(1, c.receive())
         assertEquals(2, c.poll())
-        assertEquals(3, c.receiveOrNull())
-        assertNull(c.receiveOrNull())
+        assertEquals(3, c.receiveCatching().getOrNull())
+        assertNull(c.receiveCatching().getOrNull())
     }
 
     @Test
@@ -31,13 +31,13 @@ class LinkedListChannelTest : TestBase() {
         q.cancel()
         check(q.isClosedForSend)
         check(q.isClosedForReceive)
-        assertFailsWith<CancellationException> { q.receiveOrNull() }
+        assertFailsWith<CancellationException> { q.receive() }
     }
 
     @Test
     fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(Channel.UNLIMITED)
         channel.cancel(TestCancellationException())
-        channel.receiveOrNull()
+        channel.receive()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
@@ -24,7 +24,7 @@ class ProduceTest : TestBase() {
         expect(4)
         check(c.receive() == 2)
         expect(5)
-        check(c.receiveOrNull() == null)
+        assertNull(c.receiveCatching().getOrNull())
         finish(7)
     }
 
@@ -49,7 +49,7 @@ class ProduceTest : TestBase() {
         expect(4)
         c.cancel()
         expect(5)
-        assertFailsWith<CancellationException> { c.receiveOrNull() }
+        assertFailsWith<CancellationException> { c.receiveCatching().getOrThrow() }
         expect(6)
         yield() // to produce
         finish(8)
@@ -76,7 +76,7 @@ class ProduceTest : TestBase() {
         expect(4)
         c.cancel(TestCancellationException())
         try {
-            assertNull(c.receiveOrNull())
+            c.receive()
             expectUnreached()
         } catch (e: TestCancellationException) {
             expect(5)

--- a/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -36,15 +36,15 @@ class RendezvousChannelTest : TestBase() {
     }
 
     @Test
-    fun testClosedReceiveOrNull() = runTest {
+    fun testClosedReceiveCatching() = runTest {
         val q = Channel<Int>(Channel.RENDEZVOUS)
         check(q.isEmpty && !q.isClosedForSend && !q.isClosedForReceive)
         expect(1)
         launch {
             expect(3)
-            assertEquals(42, q.receiveOrNull())
+            assertEquals(42, q.receiveCatching().getOrNull())
             expect(4)
-            assertNull(q.receiveOrNull())
+            assertNull(q.receiveCatching().getOrNull())
             expect(6)
         }
         expect(2)
@@ -233,9 +233,9 @@ class RendezvousChannelTest : TestBase() {
         expect(7)
         yield() // try to resume sender (it will not resume despite the close!)
         expect(8)
-        assertEquals(42, q.receiveOrNull())
+        assertEquals(42, q.receiveCatching().getOrNull())
         expect(9)
-        assertNull(q.receiveOrNull())
+        assertNull(q.receiveCatching().getOrNull())
         expect(10)
         yield() // to sender, it was resumed!
         finish(12)
@@ -266,7 +266,7 @@ class RendezvousChannelTest : TestBase() {
         q.cancel()
         check(q.isClosedForSend)
         check(q.isClosedForReceive)
-        assertFailsWith<CancellationException> { q.receiveOrNull() }
+        assertFailsWith<CancellationException> { q.receiveCatching().getOrThrow() }
         finish(12)
     }
 
@@ -274,6 +274,6 @@ class RendezvousChannelTest : TestBase() {
     fun testCancelWithCause() = runTest({ it is TestCancellationException }) {
         val channel = Channel<Int>(Channel.RENDEZVOUS)
         channel.cancel(TestCancellationException())
-        channel.receiveOrNull()
+        channel.receiveCatching().getOrThrow()
     }
 }

--- a/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
+++ b/kotlinx-coroutines-core/common/test/channels/TestChannelKind.kt
@@ -42,7 +42,6 @@ private class ChannelViaBroadcast<E>(
     override val isEmpty: Boolean get() = sub.isEmpty
 
     override suspend fun receive(): E = sub.receive()
-    override suspend fun receiveOrNull(): E? = sub.receiveOrNull()
     override suspend fun receiveCatching(): ChannelResult<E> = sub.receiveCatching()
     override fun iterator(): ChannelIterator<E> = sub.iterator()
     override fun tryReceive(): ChannelResult<E> = sub.tryReceive()
@@ -55,8 +54,6 @@ private class ChannelViaBroadcast<E>(
 
     override val onReceive: SelectClause1<E>
         get() = sub.onReceive
-    override val onReceiveOrNull: SelectClause1<E?>
-        get() = sub.onReceiveOrNull
     override val onReceiveCatching: SelectClause1<ChannelResult<E>>
         get() = sub.onReceiveCatching
 }

--- a/kotlinx-coroutines-core/common/test/selects/SelectLoopTest.kt
+++ b/kotlinx-coroutines-core/common/test/selects/SelectLoopTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("NAMED_ARGUMENTS_NOT_ALLOWED") // KT-21913
@@ -27,7 +27,7 @@ class SelectLoopTest : TestBase() {
         try {
             while (true) {
                 select<Unit> {
-                    channel.onReceiveOrNull {
+                    channel.onReceiveCatching {
                         expectUnreached()
                     }
                     job.onJoin {

--- a/kotlinx-coroutines-core/jvm/test-resources/stacktraces/channels/testReceiveOrNullFromClosedChannel.txt
+++ b/kotlinx-coroutines-core/jvm/test-resources/stacktraces/channels/testReceiveOrNullFromClosedChannel.txt
@@ -1,8 +1,0 @@
-kotlinx.coroutines.RecoverableTestException
-	at kotlinx.coroutines.exceptions.StackTraceRecoveryChannelsTest$testReceiveOrNullFromClosedChannel$1.invokeSuspend(StackTraceRecoveryChannelsTest.kt:43)
-	(Coroutine boundary)
-	at kotlinx.coroutines.exceptions.StackTraceRecoveryChannelsTest.channelReceiveOrNull(StackTraceRecoveryChannelsTest.kt:70)
-	at kotlinx.coroutines.exceptions.StackTraceRecoveryChannelsTest$testReceiveOrNullFromClosedChannel$1.invokeSuspend(StackTraceRecoveryChannelsTest.kt:44)
-Caused by: kotlinx.coroutines.RecoverableTestException
-	at kotlinx.coroutines.exceptions.StackTraceRecoveryChannelsTest$testReceiveOrNullFromClosedChannel$1.invokeSuspend(StackTraceRecoveryChannelsTest.kt:43)
-	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)

--- a/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ActorTest.kt
@@ -69,11 +69,11 @@ class ActorTest(private val capacity: Int) : TestBase() {
     @Test
     fun testCloseWithoutCause() = runTest {
         val actor = actor<Int>(capacity = capacity) {
-            val element = channel.receiveOrNull()
+            val element = channel.receive()
             expect(2)
             assertEquals(42, element)
-            val next = channel.receiveOrNull()
-            assertNull(next)
+            val next = channel.receiveCatching()
+            assertNull(next.exceptionOrNull())
             expect(3)
         }
 
@@ -88,11 +88,11 @@ class ActorTest(private val capacity: Int) : TestBase() {
     @Test
     fun testCloseWithCause() = runTest {
         val actor = actor<Int>(capacity = capacity) {
-            val element = channel.receiveOrNull()
+            val element = channel.receive()
             expect(2)
-            require(element!! == 42)
+            require(element == 42)
             try {
-                channel.receiveOrNull()
+                channel.receive()
             } catch (e: IOException) {
                 expect(3)
             }
@@ -111,7 +111,7 @@ class ActorTest(private val capacity: Int) : TestBase() {
         val job = async {
             actor<Int>(capacity = capacity) {
                 expect(1)
-                channel.receiveOrNull()
+                channel.receive()
                 expectUnreached()
             }
         }

--- a/kotlinx-coroutines-core/jvm/test/channels/BroadcastChannelMultiReceiveStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/BroadcastChannelMultiReceiveStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -67,10 +67,10 @@ class BroadcastChannelMultiReceiveStressTest(
                 val channel = broadcast.openSubscription()
                     when (receiverIndex % 5) {
                         0 -> doReceive(channel, receiverIndex)
-                        1 -> doReceiveOrNull(channel, receiverIndex)
+                        1 -> doReceiveCatching(channel, receiverIndex)
                         2 -> doIterator(channel, receiverIndex)
                         3 -> doReceiveSelect(channel, receiverIndex)
-                        4 -> doReceiveSelectOrNull(channel, receiverIndex)
+                        4 -> doReceiveCatchingSelect(channel, receiverIndex)
                     }
                 channel.cancel()
             }
@@ -124,9 +124,9 @@ class BroadcastChannelMultiReceiveStressTest(
         }
     }
 
-    private suspend fun doReceiveOrNull(channel: ReceiveChannel<Long>, receiverIndex: Int) {
+    private suspend fun doReceiveCatching(channel: ReceiveChannel<Long>, receiverIndex: Int) {
         while (true) {
-            val stop = doReceived(receiverIndex, channel.receiveOrNull() ?: break)
+            val stop = doReceived(receiverIndex, channel.receiveCatching().getOrNull() ?: break)
             if (stop) break
         }
     }
@@ -148,9 +148,9 @@ class BroadcastChannelMultiReceiveStressTest(
         }
     }
 
-    private suspend fun doReceiveSelectOrNull(channel: ReceiveChannel<Long>, receiverIndex: Int) {
+    private suspend fun doReceiveCatchingSelect(channel: ReceiveChannel<Long>, receiverIndex: Int) {
         while (true) {
-            val event = select<Long?> { channel.onReceiveOrNull { it } } ?: break
+            val event = select<Long?> { channel.onReceiveCatching { it.getOrNull() } } ?: break
             val stop = doReceived(receiverIndex, event)
             if (stop) break
         }

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelCancelUndeliveredElementStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelCancelUndeliveredElementStressTest.kt
@@ -89,7 +89,7 @@ class ChannelCancelUndeliveredElementStressTest : TestBase() {
     private suspend fun receiveOne(channel: Channel<Int>) {
         val received = when (Random.nextInt(3)) {
             0 -> channel.receive()
-            1 -> channel.receiveOrNull() ?: error("Cannot be closed yet")
+            1 -> channel.receiveCatching().getOrElse { error("Cannot be closed yet") }
             2 -> select {
                 channel.onReceive { it }
             }

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelSendReceiveStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -60,10 +60,10 @@ class ChannelSendReceiveStressTest(
             launch(pool + CoroutineName("receiver$receiverIndex")) {
                 when (receiverIndex % 5) {
                     0 -> doReceive(receiverIndex)
-                    1 -> doReceiveOrNull(receiverIndex)
+                    1 -> doReceiveCatching(receiverIndex)
                     2 -> doIterator(receiverIndex)
                     3 -> doReceiveSelect(receiverIndex)
-                    4 -> doReceiveSelectOrNull(receiverIndex)
+                    4 -> doReceiveCatchingSelect(receiverIndex)
                 }
                 receiversCompleted.incrementAndGet()
             }
@@ -152,9 +152,9 @@ class ChannelSendReceiveStressTest(
         }
     }
 
-    private suspend fun doReceiveOrNull(receiverIndex: Int) {
+    private suspend fun doReceiveCatching(receiverIndex: Int) {
         while (true) {
-            doReceived(receiverIndex, channel.receiveOrNull() ?: break)
+            doReceived(receiverIndex, channel.receiveCatching().getOrNull() ?: break)
         }
     }
 
@@ -173,9 +173,9 @@ class ChannelSendReceiveStressTest(
         }
     }
 
-    private suspend fun doReceiveSelectOrNull(receiverIndex: Int) {
+    private suspend fun doReceiveCatchingSelect(receiverIndex: Int) {
         while (true) {
-            val event = select<Int?> { channel.onReceiveOrNull { it } } ?: break
+            val event = select<Int?> { channel.onReceiveCatching { it.getOrNull() } } ?: break
             doReceived(receiverIndex, event)
         }
     }

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelUndeliveredElementStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelUndeliveredElementStressTest.kt
@@ -188,8 +188,8 @@ class ChannelUndeliveredElementStressTest(private val kind: TestChannelKind) : T
                     val receivedData = when (receiveMode) {
                         1 -> channel.receive()
                         2 -> select { channel.onReceive { it } }
-                        3 -> channel.receiveOrNull() ?: error("Should not be closed")
-                        4 -> select { channel.onReceiveOrNull { it ?: error("Should not be closed") } }
+                        3 -> channel.receiveCatching().getOrElse { error("Should not be closed") }
+                        4 -> select { channel.onReceiveCatching { it.getOrElse { error("Should not be closed") } } }
                         5 -> channel.receiveCatching().getOrThrow()
                         6 -> {
                             val iterator = channel.iterator()

--- a/kotlinx-coroutines-core/jvm/test/channels/ConflatedChannelCloseStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ConflatedChannelCloseStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.channels
@@ -64,7 +64,9 @@ class ConflatedChannelCloseStressTest : TestBase() {
         }
         val receiver = async(pool + NonCancellable) {
             while (isActive) {
-                curChannel.get().receiveOrNull()
+                curChannel.get().receiveCatching().getOrElse {
+                    it?.let { throw it }
+                }
                 received.incrementAndGet()
             }
         }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryChannelsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryChannelsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.exceptions
@@ -38,13 +38,6 @@ class StackTraceRecoveryChannelsTest : TestBase() {
     }
 
     @Test
-    fun testReceiveOrNullFromClosedChannel() = runTest {
-        val channel = Channel<Int>()
-        channel.close(RecoverableTestException())
-        channelReceiveOrNull(channel)
-    }
-
-    @Test
     fun testSendToClosedChannel() = runTest {
         val channel = Channel<Int>()
         channel.close(RecoverableTestException())
@@ -67,7 +60,6 @@ class StackTraceRecoveryChannelsTest : TestBase() {
     }
 
     private suspend fun channelReceive(channel: Channel<Int>) = channelOp { channel.receive() }
-    private suspend fun channelReceiveOrNull(channel: Channel<Int>) = channelOp { channel.receiveOrNull() }
 
     private suspend inline fun channelOp(block: () -> Unit) {
         try {
@@ -75,6 +67,7 @@ class StackTraceRecoveryChannelsTest : TestBase() {
             block()
             expectUnreached()
         } catch (e: RecoverableTestException) {
+            e.printStackTrace()
             verifyStackTrace("channels/${name.methodName}", e)
         }
     }

--- a/kotlinx-coroutines-core/jvm/test/guide/example-select-02.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/example-select-02.kt
@@ -11,17 +11,21 @@ import kotlinx.coroutines.selects.*
 
 suspend fun selectAorB(a: ReceiveChannel<String>, b: ReceiveChannel<String>): String =
     select<String> {
-        a.onReceiveOrNull { value -> 
-            if (value == null) 
-                "Channel 'a' is closed" 
-            else 
+        a.onReceiveCatching { it ->
+            val value = it.getOrNull()
+            if (value != null) {
                 "a -> '$value'"
+            } else {
+                "Channel 'a' is closed"
+            }
         }
-        b.onReceiveOrNull { value -> 
-            if (value == null) 
-                "Channel 'b' is closed"
-            else    
+        b.onReceiveCatching { it ->
+            val value = it.getOrNull()
+            if (value != null) {
                 "b -> '$value'"
+            } else {
+                "Channel 'b' is closed"
+            }
         }
     }
     

--- a/kotlinx-coroutines-core/jvm/test/guide/example-select-05.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/example-select-05.kt
@@ -13,12 +13,12 @@ fun CoroutineScope.switchMapDeferreds(input: ReceiveChannel<Deferred<String>>) =
     var current = input.receive() // start with first received deferred value
     while (isActive) { // loop while not cancelled/closed
         val next = select<Deferred<String>?> { // return next deferred value from this select or null
-            input.onReceiveOrNull { update ->
-                update // replaces next value to wait
+            input.onReceiveCatching { update ->
+                update.getOrNull()
             }
-            current.onAwait { value ->  
+            current.onAwait { value ->
                 send(value) // send value that current deferred has produced
-                input.receiveOrNull() // and use the next deferred from the input channel
+                input.receiveCatching().getOrNull() // and use the next deferred from the input channel
             }
         }
         if (next == null) {

--- a/reactive/kotlinx-coroutines-reactive/test/CancelledParentAttachTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/CancelledParentAttachTest.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.*
 import org.junit.*
 
 
-class CancelledParentAttachTest : TestBase() {
+class CancelledParentAttachTest : TestBase() {;
 
     @Test
     fun testFlow() = runTest {
@@ -17,4 +17,5 @@ class CancelledParentAttachTest : TestBase() {
         val j = Job().also { it.cancel() }
         f.asPublisher(j).asFlow().collect()
     }
+
 }

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherAsFlowTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherAsFlowTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.reactive
@@ -262,5 +262,15 @@ class PublisherAsFlowTest : TestBase() {
             BufferOverflow.DROP_LATEST -> (1..runSize).toList()
         }
         assertEquals(expected, list)
+    }
+
+    @Test
+    fun testException() = runTest {
+        expect(1)
+        val p = publish<Int> { throw TestException() }.asFlow()
+        p.catch {
+            assertTrue { it is TestException }
+            finish(2)
+        }.collect()
     }
 }

--- a/reactive/kotlinx-coroutines-reactive/test/PublisherSubscriptionSelectTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/PublisherSubscriptionSelectTest.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.reactive
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.selects.*
 import org.junit.Test
 import org.junit.runner.*
@@ -31,23 +32,23 @@ class PublisherSubscriptionSelectTest(private val request: Int) : TestBase() {
         val channelB = source.openSubscription(request)
         loop@ while (true) {
             val done: Int = select {
-                channelA.onReceiveOrNull {
-                    if (it != null) assertEquals(a++, it)
-                    if (it == null) 0 else 1
+                channelA.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(a++, it) }
+                    if (result.isSuccess) 1 else 0
                 }
-                channelB.onReceiveOrNull {
-                    if (it != null) assertEquals(b++, it)
-                    if (it == null) 0 else 2
+                channelB.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(b++, it) }
+                    if (result.isSuccess) 2 else 0
                 }
             }
             when (done) {
                 0 -> break@loop
                 1 -> {
-                    val r = channelB.receiveOrNull()
+                    val r = channelB.receiveCatching().getOrNull()
                     if (r != null) assertEquals(b++, r)
                 }
                 2 -> {
-                    val r = channelA.receiveOrNull()
+                    val r = channelA.receiveCatching().getOrNull()
                     if (r != null) assertEquals(a++, r)
                 }
             }

--- a/reactive/kotlinx-coroutines-rx2/test/ObservableSubscriptionSelectTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableSubscriptionSelectTest.kt
@@ -1,12 +1,14 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.rx2
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.selects.*
 import org.junit.Test
+import kotlin.onSuccess
 import kotlin.test.*
 
 class ObservableSubscriptionSelectTest : TestBase() {
@@ -22,23 +24,23 @@ class ObservableSubscriptionSelectTest : TestBase() {
         val channelB = source.openSubscription()
         loop@ while (true) {
             val done: Int = select {
-                channelA.onReceiveOrNull {
-                    if (it != null) assertEquals(a++, it)
-                    if (it == null) 0 else 1
+                channelA.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(a++, it) }
+                    if (result.isSuccess) 1 else 0
                 }
-                channelB.onReceiveOrNull {
-                    if (it != null) assertEquals(b++, it)
-                    if (it == null) 0 else 2
+                channelB.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(b++, it) }
+                    if (result.isSuccess) 2 else 0
                 }
             }
             when (done) {
                 0 -> break@loop
                 1 -> {
-                    val r = channelB.receiveOrNull()
+                    val r = channelB.receiveCatching().getOrNull()
                     if (r != null) assertEquals(b++, r)
                 }
                 2 -> {
-                    val r = channelA.receiveOrNull()
+                    val r = channelA.receiveCatching().getOrNull()
                     if (r != null) assertEquals(a++, r)
                 }
             }

--- a/reactive/kotlinx-coroutines-rx3/test/ObservableSubscriptionSelectTest.kt
+++ b/reactive/kotlinx-coroutines-rx3/test/ObservableSubscriptionSelectTest.kt
@@ -1,12 +1,14 @@
 /*
- * Copyright 2016-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.rx3
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.selects.*
 import org.junit.Test
+import kotlin.onSuccess
 import kotlin.test.*
 
 class ObservableSubscriptionSelectTest : TestBase() {
@@ -22,23 +24,23 @@ class ObservableSubscriptionSelectTest : TestBase() {
         val channelB = source.openSubscription()
         loop@ while (true) {
             val done: Int = select {
-                channelA.onReceiveOrNull {
-                    if (it != null) assertEquals(a++, it)
-                    if (it == null) 0 else 1
+                channelA.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(a++, it) }
+                    if (result.isSuccess) 1 else 0
                 }
-                channelB.onReceiveOrNull {
-                    if (it != null) assertEquals(b++, it)
-                    if (it == null) 0 else 2
+                channelB.onReceiveCatching { result ->
+                    result.onSuccess { assertEquals(b++, it) }
+                    if (result.isSuccess) 2 else 0
                 }
             }
             when (done) {
                 0 -> break@loop
                 1 -> {
-                    val r = channelB.receiveOrNull()
+                    val r = channelB.receiveCatching().getOrNull()
                     if (r != null) assertEquals(b++, r)
                 }
                 2 -> {
-                    val r = channelA.receiveOrNull()
+                    val r = channelA.receiveCatching().getOrNull()
                     if (r != null) assertEquals(a++, r)
                 }
             }


### PR DESCRIPTION
    * Raise deprecation level for members, introduce deprecation for extensions
    * Explain rationale behind deprecation
    * Provide default implementation for deprecated members in Channel interface
    * Get rid of the internal implementation, leverage receiveCatching
    * Introduce new extensions for ChannelResult and use them as replacement in our own operators

Fixes #1676