### PR TITLE
Remove deprecated SendChannel.isFull 

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -567,7 +567,6 @@ public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : k
 public final class kotlinx/coroutines/channels/BroadcastChannel$DefaultImpls {
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
-	public static synthetic fun isFull (Lkotlinx/coroutines/channels/BroadcastChannel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/lang/Object;)Z
 }
 
@@ -601,7 +600,6 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 
 public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
 	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)V
-	public static synthetic fun isFull (Lkotlinx/coroutines/channels/Channel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/Channel;Ljava/lang/Object;)Z
 	public static fun poll (Lkotlinx/coroutines/channels/Channel;)Ljava/lang/Object;
 }
@@ -797,7 +795,6 @@ public final class kotlinx/coroutines/channels/ConflatedBroadcastChannel : kotli
 	public final fun getValueOrNull ()Ljava/lang/Object;
 	public fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public fun isClosedForSend ()Z
-	public synthetic fun isFull ()Z
 	public fun offer (Ljava/lang/Object;)Z
 	public fun openSubscription ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -818,7 +815,6 @@ public abstract interface class kotlinx/coroutines/channels/ProducerScope : kotl
 }
 
 public final class kotlinx/coroutines/channels/ProducerScope$DefaultImpls {
-	public static synthetic fun isFull (Lkotlinx/coroutines/channels/ProducerScope;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/ProducerScope;Ljava/lang/Object;)Z
 }
 
@@ -851,7 +847,6 @@ public abstract interface class kotlinx/coroutines/channels/SendChannel {
 	public abstract fun getOnSend ()Lkotlinx/coroutines/selects/SelectClause2;
 	public abstract fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun isClosedForSend ()Z
-	public abstract synthetic fun isFull ()Z
 	public abstract fun offer (Ljava/lang/Object;)Z
 	public abstract fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun trySend-JP2dKIU (Ljava/lang/Object;)Ljava/lang/Object;
@@ -859,7 +854,6 @@ public abstract interface class kotlinx/coroutines/channels/SendChannel {
 
 public final class kotlinx/coroutines/channels/SendChannel$DefaultImpls {
 	public static synthetic fun close$default (Lkotlinx/coroutines/channels/SendChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
-	public static synthetic fun isFull (Lkotlinx/coroutines/channels/SendChannel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/SendChannel;Ljava/lang/Object;)Z
 }
 

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -567,6 +567,7 @@ public abstract interface class kotlinx/coroutines/channels/BroadcastChannel : k
 public final class kotlinx/coroutines/channels/BroadcastChannel$DefaultImpls {
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
+	public static synthetic fun isFull (Lkotlinx/coroutines/channels/BroadcastChannel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/BroadcastChannel;Ljava/lang/Object;)Z
 }
 
@@ -600,6 +601,7 @@ public abstract interface class kotlinx/coroutines/channels/Channel : kotlinx/co
 
 public final class kotlinx/coroutines/channels/Channel$DefaultImpls {
 	public static synthetic fun cancel (Lkotlinx/coroutines/channels/Channel;)V
+	public static synthetic fun isFull (Lkotlinx/coroutines/channels/Channel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/Channel;Ljava/lang/Object;)Z
 	public static fun poll (Lkotlinx/coroutines/channels/Channel;)Ljava/lang/Object;
 }
@@ -795,7 +797,7 @@ public final class kotlinx/coroutines/channels/ConflatedBroadcastChannel : kotli
 	public final fun getValueOrNull ()Ljava/lang/Object;
 	public fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public fun isClosedForSend ()Z
-	public fun isFull ()Z
+	public synthetic fun isFull ()Z
 	public fun offer (Ljava/lang/Object;)Z
 	public fun openSubscription ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -816,6 +818,7 @@ public abstract interface class kotlinx/coroutines/channels/ProducerScope : kotl
 }
 
 public final class kotlinx/coroutines/channels/ProducerScope$DefaultImpls {
+	public static synthetic fun isFull (Lkotlinx/coroutines/channels/ProducerScope;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/ProducerScope;Ljava/lang/Object;)Z
 }
 
@@ -848,7 +851,7 @@ public abstract interface class kotlinx/coroutines/channels/SendChannel {
 	public abstract fun getOnSend ()Lkotlinx/coroutines/selects/SelectClause2;
 	public abstract fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun isClosedForSend ()Z
-	public abstract fun isFull ()Z
+	public abstract synthetic fun isFull ()Z
 	public abstract fun offer (Ljava/lang/Object;)Z
 	public abstract fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun trySend-JP2dKIU (Ljava/lang/Object;)Ljava/lang/Object;
@@ -856,6 +859,7 @@ public abstract interface class kotlinx/coroutines/channels/SendChannel {
 
 public final class kotlinx/coroutines/channels/SendChannel$DefaultImpls {
 	public static synthetic fun close$default (Lkotlinx/coroutines/channels/SendChannel;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static synthetic fun isFull (Lkotlinx/coroutines/channels/SendChannel;)Z
 	public static fun offer (Lkotlinx/coroutines/channels/SendChannel;Ljava/lang/Object;)Z
 }
 

--- a/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt
@@ -127,8 +127,7 @@ internal abstract class AbstractSendChannel<E>(
     // ------ SendChannel ------
 
     public final override val isClosedForSend: Boolean get() = closedForSend != null
-    public override val isFull: Boolean get() = isFullImpl
-    protected val isFullImpl: Boolean get() = queue.nextNode !is ReceiveOrClosed<*> && isBufferFull
+    private val isFullImpl: Boolean get() = queue.nextNode !is ReceiveOrClosed<*> && isBufferFull
 
     public final override suspend fun send(element: E) {
         // fast path -- try offer non-blocking

--- a/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ArrayChannel.kt
@@ -49,7 +49,6 @@ internal open class ArrayChannel<E>(
     protected final override val isBufferAlwaysFull: Boolean get() = false
     protected final override val isBufferFull: Boolean get() = size.value == capacity && onBufferOverflow == BufferOverflow.SUSPEND
 
-    override val isFull: Boolean get() = lock.withLock { isFullImpl }
     override val isEmpty: Boolean get() = lock.withLock { isEmptyImpl }
     override val isClosedForReceive: Boolean get() = lock.withLock { super.isClosedForReceive }
 

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -31,14 +31,12 @@ public interface SendChannel<in E> {
     public val isClosedForSend: Boolean
 
     /**
-     * Returns `true` if the channel is full (out of capacity), which means that an attempt to [send] will suspend.
-     * This function returns `false`  if the channel [is closed for `send`][isClosedForSend].
+     * Warning in 1.2, error in 1.3, hidden in 1.5
      *
      * @suppress **Will be removed in next releases, no replacement.**
      */
-    @ExperimentalCoroutinesApi
-    @Deprecated(level = DeprecationLevel.ERROR, message = "Will be removed in next releases without replacement")
-    public val isFull: Boolean
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Will be removed in next releases without replacement")
+    public val isFull: Boolean get() = true
 
     /**
      * Sends the specified [element] to this channel, suspending the caller while the buffer of this channel is full

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -31,14 +31,6 @@ public interface SendChannel<in E> {
     public val isClosedForSend: Boolean
 
     /**
-     * Warning in 1.2, error in 1.3, hidden in 1.5
-     *
-     * @suppress **Will be removed in next releases, no replacement.**
-     */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Will be removed in next releases without replacement")
-    public val isFull: Boolean get() = true
-
-    /**
      * Sends the specified [element] to this channel, suspending the caller while the buffer of this channel is full
      * or if it does not exist, or throws an exception if the channel [is closed for `send`][isClosedForSend] (see [close] for details).
      *

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBroadcastChannel.kt
@@ -94,7 +94,6 @@ public class ConflatedBroadcastChannel<E>() : BroadcastChannel<E> {
     }
 
     public override val isClosedForSend: Boolean get() = _state.value is Closed
-    public override val isFull: Boolean get() = false
 
     @Suppress("UNCHECKED_CAST")
     public override fun openSubscription(): ReceiveChannel<E> {

--- a/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
@@ -10,7 +10,7 @@ package kotlinx.coroutines.channels
 import kotlinx.coroutines.*
 
 /**
- * Adds [element] into to this channel, **blocking** the caller while this channel [Channel.isFull],
+ * Adds [element] into to this channel, **blocking** the caller while this channel is full,
  * or throws exception if the channel [Channel.isClosedForSend] (see [Channel.close] for details).
  *
  * This is a way to call [Channel.send] method inside a blocking code using [runBlocking],

--- a/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
+++ b/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
@@ -57,7 +57,6 @@ public final class kotlinx/coroutines/reactive/PublisherCoroutine : kotlinx/coro
 	public fun invokeOnClose (Lkotlin/jvm/functions/Function1;)Ljava/lang/Void;
 	public synthetic fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public fun isClosedForSend ()Z
-	public synthetic fun isFull ()Z
 	public fun offer (Ljava/lang/Object;)Z
 	public synthetic fun onCompleted (Ljava/lang/Object;)V
 	public fun registerSelectClause2 (Lkotlinx/coroutines/selects/SelectInstance;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V

--- a/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
+++ b/reactive/kotlinx-coroutines-reactive/api/kotlinx-coroutines-reactive.api
@@ -57,7 +57,7 @@ public final class kotlinx/coroutines/reactive/PublisherCoroutine : kotlinx/coro
 	public fun invokeOnClose (Lkotlin/jvm/functions/Function1;)Ljava/lang/Void;
 	public synthetic fun invokeOnClose (Lkotlin/jvm/functions/Function1;)V
 	public fun isClosedForSend ()Z
-	public fun isFull ()Z
+	public synthetic fun isFull ()Z
 	public fun offer (Ljava/lang/Object;)Z
 	public synthetic fun onCompleted (Ljava/lang/Object;)V
 	public fun registerSelectClause2 (Lkotlinx/coroutines/selects/SelectInstance;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -91,7 +91,6 @@ public class PublisherCoroutine<in T>(
     private var cancelled = false // true when Subscription.cancel() is invoked
 
     override val isClosedForSend: Boolean get() = isCompleted
-    override val isFull: Boolean = mutex.isLocked
     override fun close(cause: Throwable?): Boolean = cancelCoroutine(cause)
     override fun invokeOnClose(handler: (Throwable?) -> Unit): Nothing =
         throw UnsupportedOperationException("PublisherCoroutine doesn't support invokeOnClose")

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -80,7 +80,6 @@ private class RxObservableCoroutine<T : Any>(
     private val _signal = atomic(OPEN)
 
     override val isClosedForSend: Boolean get() = isCompleted
-    override val isFull: Boolean = mutex.isLocked
     override fun close(cause: Throwable?): Boolean = cancelCoroutine(cause)
     override fun invokeOnClose(handler: (Throwable?) -> Unit) =
         throw UnsupportedOperationException("RxObservableCoroutine doesn't support invokeOnClose")

--- a/reactive/kotlinx-coroutines-rx3/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxObservable.kt
@@ -66,7 +66,6 @@ private class RxObservableCoroutine<T: Any>(
     private val _signal = atomic(OPEN)
 
     override val isClosedForSend: Boolean get() = isCompleted
-    override val isFull: Boolean = mutex.isLocked
     override fun close(cause: Throwable?): Boolean = cancelCoroutine(cause)
     override fun invokeOnClose(handler: (Throwable?) -> Unit) =
         throw UnsupportedOperationException("RxObservableCoroutine doesn't support invokeOnClose")


### PR DESCRIPTION
Also, give it default stub implementation and remove it from all the subclasses. This implementation previously was partially correct, was used as a performance optimization and can be safely introduced for a marginally popular method