### PR TITLE
Add debugger-related manifest to root metadata artifact of kotlinx-co…

### DIFF
--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -208,8 +208,20 @@ jvmTest {
     }
 }
 
-jvmJar {
-    manifest {
+// Setup manifest for kotlinx-coroutines-core-jvm.jar
+jvmJar { setupManifest(it) }
+
+/*
+ * Setup manifest for kotlinx-coroutines-core.jar
+ * This is convenient for users that pass -javaagent arg manually and also is a workaround #2619 and KTIJ-5659.
+ * This manifest contains reference to AgentPremain that belongs to
+ * kotlinx-coroutines-core-jvm, but our resolving machinery guarantees that
+ * any JVM project that depends on -core artifact also depends on -core-jvm one.
+ */
+metadataJar { setupManifest(it) }
+
+static def setupManifest(Jar jar) {
+    jar.manifest {
         attributes "Premain-Class": "kotlinx.coroutines.debug.AgentPremain"
         attributes "Can-Retransform-Classes": "true"
     }


### PR DESCRIPTION
…routines-core

    * It fixes IDEA issue that was introduced in coroutines 1.4.3 where we switched to Kotlin 1.4.30 and stopped producing root artifact with JVM classes
    * It simplifies manual -javaagent specification for end-users who shouldn't even be aware of kotlinx-coroutines-core-jvm.jar

Fixes #2619