### PR TITLE
Use cancellation exception from standard library in Kotlin/JS and K/N

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/internal/FlowScopeTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/internal/FlowScopeTest.kt
@@ -68,7 +68,7 @@ class FlowScopeTest : TestBase() {
             flowScope {
                 flowScope {
                     launch {
-                       throw CancellationException(null)
+                       throw CancellationException("")
                     }
                 }
             }

--- a/kotlinx-coroutines-core/js/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/js/src/Exceptions.kt
@@ -10,12 +10,7 @@ package kotlinx.coroutines
  * **It is not printed to console/log by default uncaught exception handler**.
  * (see [CoroutineExceptionHandler]).
  */
-public actual open class CancellationException(
-    message: String?,
-    cause: Throwable?
-) : IllegalStateException(message, cause) {
-    public actual constructor(message: String?) : this(message, null)
-}
+public actual typealias CancellationException = kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed

--- a/kotlinx-coroutines-core/native/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/native/src/Exceptions.kt
@@ -10,13 +10,7 @@ package kotlinx.coroutines
  * **It is not printed to console/log by default uncaught exception handler**.
  * (see [CoroutineExceptionHandler]).
  */
-public actual open class CancellationException(
-    message: String?,
-    cause: Throwable?
-) : IllegalStateException(message, cause) {
-    public actual constructor(message: String?) : this(message, null)
-}
-
+public actual typealias CancellationException = kotlin.coroutines.cancellation.CancellationException
 /**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed
  * without cause, or with a cause or exception that is not [CancellationException]

--- a/kotlinx-coroutines-core/native/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/native/src/Exceptions.kt
@@ -11,6 +11,7 @@ package kotlinx.coroutines
  * (see [CoroutineExceptionHandler]).
  */
 public actual typealias CancellationException = kotlin.coroutines.cancellation.CancellationException
+
 /**
  * Thrown by cancellable suspending functions if the [Job] of the coroutine is cancelled or completed
  * without cause, or with a cause or exception that is not [CancellationException]


### PR DESCRIPTION
    * On JVM it uses java.util.concurrent.CancellationException, same as stdlib declaration
    * Fully backward compatible for JVM, Native-friendly for Obj-C interop