### PR TITLE
Embrace new channel API

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -727,6 +727,7 @@ public final class kotlinx/coroutines/channels/ChannelsKt {
 	public static final synthetic fun toMutableList (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toMutableSet (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun toSet (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun trySendBlocking (Lkotlinx/coroutines/channels/SendChannel;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final synthetic fun withIndex (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/channels/ReceiveChannel;
 	public static synthetic fun withIndex$default (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Lkotlinx/coroutines/channels/ReceiveChannel;
 	public static final synthetic fun zip (Lkotlinx/coroutines/channels/ReceiveChannel;Lkotlinx/coroutines/channels/ReceiveChannel;)Lkotlinx/coroutines/channels/ReceiveChannel;

--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -261,7 +261,6 @@ public fun <T> flowViaChannel(
  * }
  * ```
  */
-@ExperimentalCoroutinesApi
 public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T> =
     ChannelFlowBuilder(block)
 
@@ -302,11 +301,10 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  *         override fun onNextValue(value: T) {
  *             // To avoid blocking you can configure channel capacity using
  *             // either buffer(Channel.CONFLATED) or buffer(Channel.UNLIMITED) to avoid overfill
- *             try {
- *                 sendBlocking(value)
- *             } catch (e: Exception) {
- *                 // Handle exception from the channel: failure in flow or premature closing
- *             }
+ *             trySendBlocking(value)
+ *                 .onFailure { throwable ->
+ *                     // Downstream has been cancelled or failed, can log here
+ *                 }
  *         }
  *         override fun onApiError(cause: Throwable) {
  *             cancel(CancellationException("API Error", cause))
@@ -327,7 +325,6 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  * > `awaitClose` block can be called at any time due to asynchronous nature of cancellation, even
  * > concurrently with the call of the callback.
  */
-@ExperimentalCoroutinesApi
 public fun <T> callbackFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T> = CallbackFlowBuilder(block)
 
 // ChannelFlow implementation that is the first in the chain of flow operations and introduces (builds) a flow

--- a/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
@@ -11,28 +11,28 @@ import kotlinx.coroutines.*
 
 /**
  * **Deprecated** blocking variant of send.
- *
  * This method is deprecated in the favour of [trySendBlocking].
  *
- * `sendBlocking` is considered to be dangerous primitive -- it throws
+ * `sendBlocking` is a dangerous primitive &mdash; it throws an exception
  * if the channel was closed or, more commonly, cancelled.
- * Cancellation exceptions are not ignored by non-blocking code and frequently
+ * Cancellation exceptions in non-blocking code are unexpected and frequently
  * trigger internal failures.
  *
- * These bugs were hard-to-spot during code review and also forced users to write
- * their own wrappers around `sendBlocking`, so it was decided to deprecate
- * this function and provide a more explicit primitive instead.
+ * These bugs are hard-to-spot during code review and they forced users to write
+ * their own wrappers around `sendBlocking`.
+ * So this function is deprecated and replaced with a more explicit primitive.
  *
  * The real-world example of broken usage with Firebase:
+ *
  * ```kotlin
  * callbackFlow {
  *     val listener = object : ValueEventListener {
- *         override fun onDataChange(snapshot: com.google.firebase.database.DataSnapshot) {
+ *         override fun onDataChange(snapshot: DataSnapshot) {
  *             // This line may fail and crash the app when the downstream flow is cancelled
  *             sendBlocking(DataSnapshot(snapshot))
  *         }
  *
- *         override fun onCancelled(error: com.google.firebase.database.DatabaseError) {
+ *         override fun onCancelled(error: DatabaseError) {
  *             close(error.toException())
  *         }
  *     }
@@ -45,7 +45,7 @@ import kotlinx.coroutines.*
 @Deprecated(
     level = DeprecationLevel.WARNING,
     message = "Deprecated in the favour of 'trySendBlocking'. " +
-        "Consider handle the result of 'trySendBlocking' explicitly and rethrow exception if necessary",
+        "Consider handling the result of 'trySendBlocking' explicitly and rethrow exception if necessary",
     replaceWith = ReplaceWith("trySendBlocking(element)")
 )
 public fun <E> SendChannel<E>.sendBlocking(element: E) {
@@ -67,13 +67,14 @@ public fun <E> SendChannel<E>.sendBlocking(element: E) {
  * so this function should not be used from coroutine.
  *
  * Example of usage:
+ *
  * ```
  * // From callback API
  * channel.trySendBlocking(element)
  *     .onSuccess { /* request next element or debug log */ }
  *     .onFailure { t: Throwable? -> /* throw or log */ }
- *
  * ```
+ *
  * For this operation it is guaranteed that [failure][ChannelResult.failed] always contains an exception in it.
  *
  * @throws [InterruptedException] if the current thread is interrupted during the blocking send operation.

--- a/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
@@ -10,7 +10,7 @@ package kotlinx.coroutines.channels
 import kotlinx.coroutines.*
 
 /**
- * ### Deprecation note.
+ * **Deprecated** blocking variant of send.
  *
  * This method is deprecated in the favour of [trySendBlocking].
  *
@@ -22,6 +22,25 @@ import kotlinx.coroutines.*
  * These bugs were hard-to-spot during code review and also forced users to write
  * their own wrappers around `sendBlocking`, so it was decided to deprecate
  * this function and provide a more explicit primitive instead.
+ *
+ * The real-world example of broken usage with Firebase:
+ * ```kotlin
+ * callbackFlow {
+ *     val listener = object : ValueEventListener {
+ *         override fun onDataChange(snapshot: com.google.firebase.database.DataSnapshot) {
+ *             // This line may fail and crash the app when the downstream flow is cancelled
+ *             sendBlocking(DataSnapshot(snapshot))
+ *         }
+ *
+ *         override fun onCancelled(error: com.google.firebase.database.DatabaseError) {
+ *             close(error.toException())
+ *         }
+ *     }
+ *
+ *     firebaseQuery.addValueEventListener(listener)
+ *     awaitClose { firebaseQuery.removeEventListener(listener) }
+ * }
+ * ```
  */
 @Deprecated(
     level = DeprecationLevel.WARNING,
@@ -59,6 +78,7 @@ public fun <E> SendChannel<E>.sendBlocking(element: E) {
  *
  * @throws [InterruptedException] if the current thread is interrupted during the blocking send operation.
  */
+@Throws(InterruptedException::class)
 public fun <E> SendChannel<E>.trySendBlocking(element: E): ChannelResult<Unit> {
     /*
      * Sent successfully -- bail out.

--- a/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Channels.kt
@@ -10,12 +10,25 @@ package kotlinx.coroutines.channels
 import kotlinx.coroutines.*
 
 /**
- * Adds [element] into to this channel, **blocking** the caller while this channel is full,
- * or throws exception if the channel [Channel.isClosedForSend] (see [Channel.close] for details).
+ * ### Deprecation note.
  *
- * This is a way to call [Channel.send] method inside a blocking code using [runBlocking],
- * so this function should not be used from coroutine.
+ * This method is deprecated in the favour of [trySendBlocking].
+ *
+ * `sendBlocking` is considered to be dangerous primitive -- it throws
+ * if the channel was closed or, more commonly, cancelled.
+ * Cancellation exceptions are not ignored by non-blocking code and frequently
+ * trigger internal failures.
+ *
+ * These bugs were hard-to-spot during code review and also forced users to write
+ * their own wrappers around `sendBlocking`, so it was decided to deprecate
+ * this function and provide a more explicit primitive instead.
  */
+@Deprecated(
+    level = DeprecationLevel.WARNING,
+    message = "Deprecated in the favour of 'trySendBlocking'. " +
+        "Consider handle the result of 'trySendBlocking' explicitly and rethrow exception if necessary",
+    replaceWith = ReplaceWith("trySendBlocking(element)")
+)
 public fun <E> SendChannel<E>.sendBlocking(element: E) {
     // fast path
     if (offer(element))
@@ -23,5 +36,40 @@ public fun <E> SendChannel<E>.sendBlocking(element: E) {
     // slow path
     runBlocking {
         send(element)
+    }
+}
+
+/**
+ * Adds [element] into to this channel, **blocking** the caller while this channel is full,
+ * and returning either [successful][ChannelResult.isSuccess] result when the element was added, or
+ * failed result representing closed channel with a corresponding exception.
+ *
+ * This is a way to call [Channel.send] method in a safe manner inside a blocking code using [runBlocking] and catching,
+ * so this function should not be used from coroutine.
+ *
+ * Example of usage:
+ * ```
+ * // From callback API
+ * channel.trySendBlocking(element)
+ *     .onSuccess { /* request next element or debug log */ }
+ *     .onFailure { t: Throwable? -> /* throw or log */ }
+ *
+ * ```
+ * For this operation it is guaranteed that [failure][ChannelResult.failed] always contains an exception in it.
+ *
+ * @throws [InterruptedException] if the current thread is interrupted during the blocking send operation.
+ */
+public fun <E> SendChannel<E>.trySendBlocking(element: E): ChannelResult<Unit> {
+    /*
+     * Sent successfully -- bail out.
+     * But failure may indicate either that the channel it full or that
+     * it is close. Go to slow path on failure to simplify the successful path and
+     * to materialize default exception.
+     */
+    trySend(element).onSuccess { return ChannelResult.success(Unit) }
+    return runBlocking {
+        val r = runCatching { send(element) }
+        if (r.isSuccess) ChannelResult.success(Unit)
+        else ChannelResult.closed(r.exceptionOrNull())
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
@@ -142,7 +142,7 @@ internal class VirtualTimeSource(
     }
 
     private fun minParkedTill(): Long =
-        threads.values.map { if (it.permit) NOT_PARKED else it.parkedTill }.min() ?: NOT_PARKED
+        threads.values.map { if (it.permit) NOT_PARKED else it.parkedTill }.minOrNull() ?: NOT_PARKED
 
     @Synchronized
     fun shutdown() {

--- a/kotlinx-coroutines-core/jvm/test/flow/StateFlowStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/flow/StateFlowStressTest.kt
@@ -62,7 +62,7 @@ class StateFlowStressTest : TestBase() {
         for (second in 1..nSeconds) {
             delay(1000)
             val cs = collected.map { it.sum() }
-            println("$second: emitted=${emitted.sum()}, collected=${cs.min()}..${cs.max()}")
+            println("$second: emitted=${emitted.sum()}, collected=${cs.minOrNull()}..${cs.maxOrNull()}")
         }
         emitters.cancelAndJoin()
         collectors.cancelAndJoin()

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -49,7 +49,7 @@ abstract class SchedulerTestBase : TestBase() {
 
         private fun maxSequenceNumber(): Int? {
             return Thread.getAllStackTraces().keys.asSequence().filter { it is CoroutineScheduler.Worker }
-                .map { sequenceNumber(it.name) }.max()
+                .map { sequenceNumber(it.name) }.maxOrNull()
         }
 
         private fun sequenceNumber(threadName: String): Int {

--- a/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
@@ -82,10 +82,14 @@ public fun <T: Any> ObservableSource<T>.asFlow(): Flow<T> = callbackFlow {
         override fun onComplete() { close() }
         override fun onSubscribe(d: Disposable) { if (!disposableRef.compareAndSet(null, d)) d.dispose() }
         override fun onNext(t: T) {
+            /*
+             * Channel was closed by the downstream, so the exception (if any)
+             * also was handled by the same downstream
+             */
             try {
-                sendBlocking(t)
-            } catch (ignored: Throwable) { // TODO: Replace when this issue is fixed: https://github.com/Kotlin/kotlinx.coroutines/issues/974
-                // Is handled by the downstream flow
+                trySendBlocking(t)
+            } catch (e: InterruptedException) {
+                // RxJava interrupts the source
             }
         }
         override fun onError(e: Throwable) { close(e) }

--- a/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
@@ -82,10 +82,14 @@ public fun <T: Any> ObservableSource<T>.asFlow(): Flow<T> = callbackFlow {
         override fun onComplete() { close() }
         override fun onSubscribe(d: Disposable) { if (!disposableRef.compareAndSet(null, d)) d.dispose() }
         override fun onNext(t: T) {
+            /*
+             * Channel was closed by the downstream, so the exception (if any)
+             * also was handled by the same downstream
+             */
             try {
-                sendBlocking(t)
-            } catch (ignored: Throwable) { // TODO: Replace when this issue is fixed: https://github.com/Kotlin/kotlinx.coroutines/issues/974
-                // Is handled by the downstream flow
+                trySendBlocking(t)
+            } catch (e: InterruptedException) {
+                // RxJava interrupts the source
             }
         }
         override fun onError(e: Throwable) { close(e) }


### PR DESCRIPTION
    * Introduce trySendBlocking and deprecate sendBlocking
    * Use it in callbackFlow example
    * Stabilize callbackFlow and channelFlow as they finally have error-safe API
    * Irrelevant: migrate from deprecated stdlib API to be able to build with Kotlin 1.5