### PR TITLE
[native-mt, 1.5.0-RC] Fix withTimeout throwing InvalidMutabilityException.

### DIFF
--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -153,7 +153,7 @@ public suspend fun <T> withContext(
         newContext.ensureActive()
         // FAST PATH #1 -- new context is the same as the old one
         if (newContext === oldContext) {
-            val coroutine = ScopeCoroutine(newContext, uCont)
+            val coroutine = ScopeCoroutine(newContext, uCont, true)
             return@sc coroutine.startUndispatchedOrReturn(coroutine, block)
         }
         // FAST PATH #2 -- the new dispatcher is the same as the old one (something else changed)
@@ -267,7 +267,7 @@ private const val RESUMED = 2
 internal class DispatchedCoroutine<in T>(
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(context, uCont) {
+) : ScopeCoroutine<T>(context, uCont, true) {
     // this is copy-and-paste of a decision state machine inside AbstractionContinuation
     // todo: we may some-how abstract it via inline class
     private val _decision = atomic(UNDECIDED)

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -260,7 +260,7 @@ public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R 
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
     return suspendCoroutineUninterceptedOrReturn { uCont ->
-        val coroutine = ScopeCoroutine(uCont.context, uCont)
+        val coroutine = ScopeCoroutine(uCont.context, uCont, true)
         coroutine.startUndispatchedOrReturn(coroutine, block)
     }
 }

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -65,6 +65,6 @@ private class SupervisorJobImpl(parent: Job?) : JobImpl(parent) {
 private class SupervisorCoroutine<in T>(
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(context, uCont) {
+) : ScopeCoroutine<T>(context, uCont, true) {
     override fun childCancelled(cause: Throwable): Boolean = false
 }

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -151,7 +151,12 @@ private fun <U, T: U> setupTimeout(
 private class TimeoutCoroutine<U, in T: U>(
     @JvmField val time: Long,
     uCont: Continuation<U> // unintercepted continuation
-) : ScopeCoroutine<T>(uCont.context, uCont), Runnable {
+) : ScopeCoroutine<T>(uCont.context, uCont, false), Runnable {
+    init {
+        // Kludge for native
+        if (!isReuseSupportedInPlatform()) initParentForNativeUndispatchedCoroutine()
+    }
+
     override fun run() {
         cancelCoroutine(TimeoutCancellationException(time, this))
     }

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowCoroutine.kt
@@ -66,7 +66,7 @@ internal fun <T> CoroutineScope.flowProduce(
 private class FlowCoroutine<T>(
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(context, uCont) {
+) : ScopeCoroutine<T>(context, uCont, true) {
     public override fun childCancelled(cause: Throwable): Boolean {
         if (cause is ChildCancelledException) return true
         return cancelImpl(cause)

--- a/kotlinx-coroutines-core/common/src/internal/Scopes.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Scopes.kt
@@ -13,7 +13,8 @@ import kotlin.jvm.*
  */
 internal open class ScopeCoroutine<in T>(
     context: CoroutineContext,
-    uCont: Continuation<T>
+    uCont: Continuation<T>,
+    useInitNativeKludge: Boolean
 ) : AbstractCoroutine<T>(context, true, true), CoroutineStackFrame {
     @JvmField
     val uCont: Continuation<T> = uCont.asShareable() // unintercepted continuation, shareable
@@ -25,7 +26,7 @@ internal open class ScopeCoroutine<in T>(
 
     init {
         // Kludge for native
-        if (!isReuseSupportedInPlatform()) initParentForNativeUndispatchedCoroutine()
+        if (useInitNativeKludge && !isReuseSupportedInPlatform()) initParentForNativeUndispatchedCoroutine()
     }
 
     protected open fun initParentForNativeUndispatchedCoroutine() {

--- a/kotlinx-coroutines-core/js/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/js/src/CoroutineContext.kt
@@ -57,6 +57,6 @@ internal actual val CoroutineContext.coroutineName: String? get() = null // not 
 internal actual class UndispatchedCoroutine<in T> actual constructor(
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(context, uCont) {
+) : ScopeCoroutine<T>(context, uCont, true) {
     override fun afterResume(state: Any?) = uCont.resumeWith(recoverResult(state, uCont))
 }

--- a/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
@@ -113,7 +113,7 @@ private object UndispatchedMarker: CoroutineContext.Element, CoroutineContext.Ke
 internal actual class UndispatchedCoroutine<in T>actual constructor (
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(if (context[UndispatchedMarker] == null) context + UndispatchedMarker else context, uCont) {
+) : ScopeCoroutine<T>(if (context[UndispatchedMarker] == null) context + UndispatchedMarker else context, uCont, true) {
 
     private var savedContext: CoroutineContext? = null
     private var savedOldValue: Any? = null

--- a/kotlinx-coroutines-core/native/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/native/src/CoroutineContext.kt
@@ -43,6 +43,6 @@ internal actual val CoroutineContext.coroutineName: String? get() = null // not 
 internal actual class UndispatchedCoroutine<in T> actual constructor(
     context: CoroutineContext,
     uCont: Continuation<T>
-) : ScopeCoroutine<T>(context, uCont) {
+) : ScopeCoroutine<T>(context, uCont, true) {
     override fun afterResume(state: Any?) = uCont.resumeWith(recoverResult(state, uCont))
 }

--- a/kotlinx-coroutines-core/native/test/WithTimeoutNativeTest.kt
+++ b/kotlinx-coroutines-core/native/test/WithTimeoutNativeTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.test.*
+import kotlin.time.*
+import kotlin.native.concurrent.freeze
+
+class WithTimeoutNativeTest {
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `withTimeout should not raise an exception when parent job is frozen`() = runBlocking {
+        this.coroutineContext[Job.Key]!!.freeze()
+        try {
+            withTimeout(Duration.seconds(Int.MAX_VALUE)) {}
+        } catch (error: Throwable) {
+            fail("withTimeout has raised an exception.", error)
+        }
+    }
+}


### PR DESCRIPTION
Resolves #2688.

`TimeoutCoroutine` subclasses `ScopeCoroutine` and adds a backing field `time`.

Since `ScopeCoroutine` may potentially freeze itself during its init block (by adding itself to a frozen job as a child), the init steps of `TimeoutCoroutine` as a subclass may consequentially fail, due to the object now potentially failing `MutationCheck()`.

* Introduced a `useInitNativeKludge` constructor parameter in `ScopeCoroutine` to control whether the init kludge for native is enabled.

* Fixed #2688 by changing `TimeoutCoroutine` to disable the superclass' kludge, in favour of having the kludge as its own init block.

* Added a failing test case.
    * The test case suffers from issue (2) in #2688 though, that the test runner should have been reporting the `InvalidMutabilityException`. But instead, `runBlocking()` eats the exception and continues to spin indefinitely. ~I didn't dig into why this happens.~ It looks like a consequence of (unexpectedly?) failing during initialisation, which failed child does not remove itself from the parent.