### PR TITLE
Fix the coroutine debugger in the IDE

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -58,6 +58,11 @@ internal object DebugProbesImpl {
      */
     private val dynamicAttach = getDynamicAttach()
 
+    init {
+        Class.forName("_COROUTINE._CREATION")
+        Class.forName("_COROUTINE._BOUNDARY")
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun getDynamicAttach(): Function1<Boolean, Unit>? = runCatching {
         val clz = Class.forName("kotlinx.coroutines.debug.internal.ByteBuddyDynamicAttach")


### PR DESCRIPTION
https://github.com/Kotlin/kotlinx.coroutines/pull/2461 introduced a problem where the coroutine debugger in the IDE would crash.

According to @nikita-nazarov, the coroutine debugger crashes at a point where a stack trace is already available and the IDE plugin attempts to look up every class listed in the stack trace.

The new classes listed in the artificial stack frames were never loaded, as only their names were accessed. Now, we force these classes to be loaded at the point where `DebugProbesImpl` is, and it seems like the crash disappears.

Fixes https://github.com/Kotlin/kotlinx.coroutines/issues/2690