### PR TITLE
Rename TimeSource to AbstractTimeSource due to KT-42625

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/AbstractTimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/src/AbstractTimeSource.kt
@@ -10,21 +10,21 @@ package kotlinx.coroutines
 import java.util.concurrent.locks.*
 import kotlin.internal.InlineOnly
 
-internal interface TimeSource {
-    fun currentTimeMillis(): Long
-    fun nanoTime(): Long
-    fun wrapTask(block: Runnable): Runnable
-    fun trackTask()
-    fun unTrackTask()
-    fun registerTimeLoopThread()
-    fun unregisterTimeLoopThread()
-    fun parkNanos(blocker: Any, nanos: Long) // should return immediately when nanos <= 0
-    fun unpark(thread: Thread)
+internal abstract class AbstractTimeSource {
+    abstract fun currentTimeMillis(): Long
+    abstract fun nanoTime(): Long
+    abstract fun wrapTask(block: Runnable): Runnable
+    abstract fun trackTask()
+    abstract fun unTrackTask()
+    abstract fun registerTimeLoopThread()
+    abstract fun unregisterTimeLoopThread()
+    abstract fun parkNanos(blocker: Any, nanos: Long) // should return immediately when nanos <= 0
+    abstract fun unpark(thread: Thread)
 }
 
 // For tests only
 // @JvmField: Don't use JvmField here to enable R8 optimizations via "assumenosideeffects"
-internal var timeSource: TimeSource? = null
+internal var timeSource: AbstractTimeSource? = null
 
 @InlineOnly
 internal inline fun currentTimeMillis(): Long =

--- a/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines
@@ -42,7 +42,7 @@ private const val REAL_PARK_NANOS = 10_000_000L // 10 ms -- park for a little to
 @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 internal class VirtualTimeSource(
     private val log: PrintStream?
-) : TimeSource {
+) : AbstractTimeSource() {
     private val mainThread: Thread = Thread.currentThread()
     private var checkpointNanos: Long = System.nanoTime()
 


### PR DESCRIPTION
    * It is the second TimeSource in our codebase
    * Also make it abstract to let CHA kick in

Fixes #2691