### PR TITLE
Add repeat and repeatUntil as flow operators

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -993,6 +993,8 @@ public final class kotlinx/coroutines/flow/FlowKt {
 	public static final fun publishOn (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun receiveAsFlow (Lkotlinx/coroutines/channels/ReceiveChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun reduce (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun repeat (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
+	public static final fun repeatUntil (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun replay (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun replay (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
 	public static final synthetic fun retry (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;

--- a/kotlinx-coroutines-core/common/src/flow/operators/Repeat.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Repeat.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:JvmMultifileClass
+@file:JvmName("FlowKt")
+
+package kotlinx.coroutines.flow
+
+import kotlin.jvm.*
+
+/**
+ * The [repeat] operator allows you to repeat an emission multiples times.
+ * (similar RxJava repeat operator)
+ * For example:
+ * ```kotlin
+ * flow {
+ *     emit(1)
+ * }.repeat(3)
+ * ```
+ * produces the following emissions
+ * ```text
+ * 1, 1, 1
+ * ```
+ * */
+public fun <T> Flow<T>.repeat(times: Int): Flow<T> = flow {
+    repeat (times) { emitAll(this@repeat) }
+}
+
+/**
+ * Similar to [repeat] operator, the [repeatUntil] allows you to repeat an emission
+ * until the provided [condition] returns true.
+ *
+ * (similar RxJava repeatUntil operator)
+ * */
+public fun <T> Flow<T>.repeatUntil(condition: () -> Boolean): Flow<T> = flow {
+    while(!condition()) { emitAll(this@repeatUntil) }
+}

--- a/kotlinx-coroutines-core/common/test/flow/operators/RepeatTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/RepeatTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow.operators
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlin.test.*
+
+class RepeatTest : TestBase() {
+
+    @Test
+    fun testRepeat() = runTest {
+        val flow = flow { emit(1) }
+        assertEquals(3, flow.repeat(3).sum())
+    }
+
+    @Test
+    fun testRepeatUntil() = runTest {
+        val flow = flow { emit(1) }
+        var count = 0
+        assertEquals(3, flow.repeatUntil { count++ == 3 }.sum())
+    }
+}


### PR DESCRIPTION
This pull request adds an implementation of repeat and RepeatUntil as Flow operators.
### repeat
```kotlin
flow { emit(1) }
	.repeat(3) 
```
Expected behavior:
```text
1, 1, 1
```

### repeatUntil
```kotlin
flow { emit(1) }
	.repeatUntil { myCondition() } 
```
In this case, the flow will `emit` until the `myCondition()` returns `true`.