### PR TITLE
Polish coroutines-basics.md

### DIFF
--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -152,6 +152,11 @@ suspend fun doWorld() = coroutineScope {  // this: CoroutineScope
 
 This code also prints:
 
+```text
+Hello
+World!
+```
+
 <!--- TEST
 Hello
 World!
@@ -166,7 +171,7 @@ Let's launch two concurrent coroutines inside a `doWorld` suspending function:
 import kotlinx.coroutines.*
 
 //sampleStart
-// Sequentially executes doWorld followed by "Hello"
+// Sequentially executes doWorld followed by "Done"
 fun main() = runBlocking {
     doWorld()
     println("Done")


### PR DESCRIPTION
This PR polishes `coroutines-basics.md` a bit.