### PR TITLE
Move DebugProbesKt from debug to core module

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbes.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbes.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.debug.internal
+
+import kotlin.coroutines.*
+
+// Stubs which are injected as coroutine probes. Require direct match of signatures
+internal fun probeCoroutineResumed(frame: Continuation<*>) = DebugProbesImpl.probeCoroutineResumed(frame)
+
+internal fun probeCoroutineSuspended(frame: Continuation<*>) = DebugProbesImpl.probeCoroutineSuspended(frame)
+internal fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> =
+    DebugProbesImpl.probeCoroutineCreated(completion)

--- a/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -143,10 +143,3 @@ public object DebugProbes {
      */
     public fun dumpCoroutines(out: PrintStream = System.out): Unit = DebugProbesImpl.dumpCoroutines(out)
 }
-
-// Stubs which are injected as coroutine probes. Require direct match of signatures
-internal fun probeCoroutineResumed(frame: Continuation<*>) = DebugProbesImpl.probeCoroutineResumed(frame)
-
-internal fun probeCoroutineSuspended(frame: Continuation<*>) = DebugProbesImpl.probeCoroutineSuspended(frame)
-internal fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> =
-    DebugProbesImpl.probeCoroutineCreated(completion)

--- a/kotlinx-coroutines-debug/src/internal/Attach.kt
+++ b/kotlinx-coroutines-debug/src/internal/Attach.kt
@@ -20,7 +20,7 @@ internal class ByteBuddyDynamicAttach : Function1<Boolean, Unit> {
     private fun attach() {
         ByteBuddyAgent.install(ByteBuddyAgent.AttachmentProvider.ForEmulatedAttachment.INSTANCE)
         val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
-        val cl2 = Class.forName("kotlinx.coroutines.debug.DebugProbesKt")
+        val cl2 = Class.forName("kotlinx.coroutines.debug.internal.DebugProbesKt")
 
         ByteBuddy()
             .redefine(cl2)


### PR DESCRIPTION
This change will allow Android Studio to instrument DebugProbesKt from kotlin stdlib, without relying on DebugProbesKt.bin.