### PR TITLE
Document and tweak the contract of Executor.asCoroutineDispatcher and ExecutorService.asCoroutineDispatcher

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -75,19 +75,9 @@ private class DispatcherExecutor(@JvmField val dispatcher: CoroutineDispatcher) 
     override fun toString(): String = dispatcher.toString()
 }
 
-private class ExecutorCoroutineDispatcherImpl(override val executor: Executor) : ExecutorCoroutineDispatcherBase() {
-    init {
-        initFutureCancellation()
-    }
-}
+internal class ExecutorCoroutineDispatcherImpl(override val executor: Executor) : ExecutorCoroutineDispatcher(), Delay {
 
-internal abstract class ExecutorCoroutineDispatcherBase : ExecutorCoroutineDispatcher(), Delay {
-
-    private var removesFutureOnCancellation: Boolean = false
-
-    internal fun initFutureCancellation() {
-        removesFutureOnCancellation = removeFutureOnCancel(executor)
-    }
+    private var removesFutureOnCancellation: Boolean = removeFutureOnCancel(executor)
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         try {
@@ -149,7 +139,7 @@ internal abstract class ExecutorCoroutineDispatcherBase : ExecutorCoroutineDispa
     }
 
     override fun toString(): String = executor.toString()
-    override fun equals(other: Any?): Boolean = other is ExecutorCoroutineDispatcherBase && other.executor === executor
+    override fun equals(other: Any?): Boolean = other is ExecutorCoroutineDispatcherImpl && other.executor === executor
     override fun hashCode(): Int = System.identityHashCode(executor)
 }
 

--- a/kotlinx-coroutines-core/jvm/test/ExecutorAsCoroutineDispatcherDelayTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ExecutorAsCoroutineDispatcherDelayTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import org.junit.Test
+import java.lang.Runnable
+import java.util.concurrent.*
+import kotlin.test.*
+
+class ExecutorAsCoroutineDispatcherDelayTest : TestBase() {
+
+    private var callsToSchedule = 0
+
+    private inner class STPE : ScheduledThreadPoolExecutor(1) {
+        override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
+            if (delay != 0L) ++callsToSchedule
+            return super.schedule(command, delay, unit)
+        }
+    }
+
+    private inner class SES : ScheduledExecutorService by STPE()
+
+    @Test
+    fun testScheduledThreadPool() = runTest {
+        val executor = STPE()
+        withContext(executor.asCoroutineDispatcher()) {
+            delay(100)
+        }
+        executor.shutdown()
+        assertEquals(1, callsToSchedule)
+    }
+
+    @Test
+    fun testScheduledExecutorService() = runTest {
+        val executor = SES()
+        withContext(executor.asCoroutineDispatcher()) {
+            delay(100)
+        }
+        executor.shutdown()
+        assertEquals(1, callsToSchedule)
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/knit/ClosedAfterGuideTestExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/test/knit/ClosedAfterGuideTestExecutor.kt
@@ -8,9 +8,9 @@ import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import kotlin.coroutines.*
 
-public fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher = ClosedAfterGuideTestDispatcher(1, name)
+internal fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher = ClosedAfterGuideTestDispatcher(1, name)
 
-public fun newFixedThreadPoolContext(nThreads: Int, name: String): ExecutorCoroutineDispatcher =
+internal fun newFixedThreadPoolContext(nThreads: Int, name: String): ExecutorCoroutineDispatcher =
     ClosedAfterGuideTestDispatcher(nThreads, name)
 
 internal class PoolThread(

--- a/kotlinx-coroutines-core/jvm/test/knit/ClosedAfterGuideTestExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/test/knit/ClosedAfterGuideTestExecutor.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines // Trick to make guide tests use these declarations with executors that can be closed on our side implicitly
+
+import java.util.concurrent.*
+import java.util.concurrent.atomic.*
+import kotlin.coroutines.*
+
+public fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher = ClosedAfterGuideTestDispatcher(1, name)
+
+public fun newFixedThreadPoolContext(nThreads: Int, name: String): ExecutorCoroutineDispatcher =
+    ClosedAfterGuideTestDispatcher(nThreads, name)
+
+internal class PoolThread(
+    @JvmField val dispatcher: ExecutorCoroutineDispatcher, // for debugging & tests
+    target: Runnable, name: String
+) : Thread(target, name) {
+    init {
+        isDaemon = true
+    }
+}
+
+private class ClosedAfterGuideTestDispatcher(
+    private val nThreads: Int,
+    private val name: String
+) : ExecutorCoroutineDispatcher() {
+    private val threadNo = AtomicInteger()
+
+    override val executor: Executor =
+        Executors.newScheduledThreadPool(nThreads, object : ThreadFactory {
+            override fun newThread(target: java.lang.Runnable): Thread {
+                return PoolThread(
+                    this@ClosedAfterGuideTestDispatcher,
+                    target,
+                    if (nThreads == 1) name else name + "-" + threadNo.incrementAndGet()
+                )
+            }
+        })
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        executor.execute(wrapTask(block))
+    }
+
+    override fun close() {
+        (executor as ExecutorService).shutdown()
+    }
+
+    override fun toString(): String = "ThreadPoolDispatcher[$nThreads, $name]"
+}

--- a/kotlinx-coroutines-core/jvm/test/knit/TestUtil.kt
+++ b/kotlinx-coroutines-core/jvm/test/knit/TestUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.coroutines.knit
@@ -10,8 +10,6 @@ import kotlinx.coroutines.scheduling.*
 import kotlinx.knit.test.*
 import java.util.concurrent.*
 import kotlin.test.*
-
-fun wrapTask(block: Runnable) = kotlinx.coroutines.wrapTask(block)
 
 // helper function to dump exception to stdout for ease of debugging failed tests
 private inline fun <T> outputException(name: String, block: () -> T): T =


### PR DESCRIPTION
    * Document it properly
    * Make it more robust to signature changes and/or delegation (e.g. see the implementation of java.util.concurrent.Executors.newScheduledThreadPool)
    * Give a public way to reduce the memory pressure via ScheduledFuture.cancel