### PR TITLE
Depend on the local kotlinx-coroutines-core in android-unit-test proj…

### DIFF
--- a/ui/kotlinx-coroutines-android/android-unit-tests/build.gradle.kts
+++ b/ui/kotlinx-coroutines-android/android-unit-tests/build.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 dependencies {
+    kotlinCompilerPluginClasspathMain(project(":kotlinx-coroutines-core"))
     testImplementation("com.google.android:android:${version("android")}")
     testImplementation("org.robolectric:robolectric:${version("robolectric")}")
     testImplementation(project(":kotlinx-coroutines-test"))


### PR DESCRIPTION
…ect classpath

Otherwise, the dependency from Kotlin plugin to coroutines 1.4.3 (plugin -> compiler.jar -> coroutines) leaks into the runtime classpath