### PR TITLE
Add a preserveLatest option to Flow::sample()

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/SampleTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/SampleTest.kt
@@ -298,4 +298,19 @@ class SampleTest : TestBase() {
         assertEquals(listOf("A", "B", "D"), result)
         finish(5)
     }
+
+    @Test
+    public fun testTrailingElement() = withVirtualTime {
+        expect(1)
+        val flow = flow {
+            expect(3)
+            emit("A")
+            expect(4)
+        }
+
+        expect(2)
+        val result = flow.sample(1000, preserveLatest = true).toList()
+        assertEquals(listOf("A"), result)
+        finish(5)
+    }
 }


### PR DESCRIPTION
This is a somewhat lighter-weight approach to https://github.com/Kotlin/kotlinx.coroutines/pull/2738

The .sample() operator for flows is useful for rate-limiting a flow, but there are use-cases where it is undesirable to potentially lose trailing items.

The motivating use-case here is something like a async progress bar. It is acceptable to drop intermediate progress, but it is very important that the last event does not get dropped.