### PR TITLE
Remove InternalCoroutinesApi from overridden releaseInterceptedContin…

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -99,7 +99,6 @@ public abstract class CoroutineDispatcher :
     public final override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
         DispatchedContinuation(this, continuation)
 
-    @InternalCoroutinesApi
     public override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
         /*
          * Unconditional cast is safe here: we only return DispatchedContinuation from `interceptContinuation`,


### PR DESCRIPTION
…uation.

Otherwise compilation fails on 1.5.30 due to KT-45844