### PR TITLE
Clarify Dispatchers.IO's implementation note

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -107,9 +107,10 @@ public actual object Dispatchers {
      *
      * ### Implementation note
      *
-     * This dispatcher shares threads with a [Default][Dispatchers.Default] dispatcher, so using
-     * `withContext(Dispatchers.IO) { ... }` does not lead to an actual switching to another thread &mdash;
-     * typically execution continues in the same thread.
+     * This dispatcher shares threads with the [Default][Dispatchers.Default] dispatcher, so using
+     * `withContext(Dispatchers.IO) { ... }` when already running on the [Default][Dispatchers.Default]
+     * dispatcher does not lead to an actual switching to another thread &mdash; typically execution
+     * continues in the same thread.
      * As a result of thread sharing, more than 64 (default parallelism) threads can be created (but not used)
      * during operations over IO dispatcher.
      */


### PR DESCRIPTION
This implementation note mentions that withContext(IO) does not lead to a
context switch, which may be misunderstood as a general statement, while
it in fact only applies to switches between Default and IO dispatchers.

This is one example of misunderstanding:
https://stackoverflow.com/questions/68069529/is-kotlinx-coroutines-withcontext-safe-to-use-with-spring-webflux