### PR TITLE
Add integration with Huawei Mobile Service Tasks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ suspend fun main() = coroutineScope {
 * [ui](ui/README.md) &mdash; modules that provide coroutine dispatchers for various single-threaded UI libraries:
   * Android, JavaFX, and Swing.
 * [integration](integration/README.md) &mdash; modules that provide integration with various asynchronous callback- and future-based libraries:
-  * JDK8 [CompletionStage.await], Guava [ListenableFuture.await], Google Play Services [Task.await][gms.Task.await] and Huawei Mobile Services [Task.await][hms.Task.await];
+  * JDK8 [CompletionStage.await], Guava [ListenableFuture.await], Google Play Services [Task.await] and Huawei Mobile Services [Task.await](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
+    );
   * SLF4J MDC integration via [MDCContext].
 
 ## Documentation
@@ -291,12 +292,7 @@ See [Contributing Guidelines](CONTRIBUTING.md).
 <!--- MODULE kotlinx-coroutines-play-services -->
 <!--- INDEX kotlinx.coroutines.tasks -->
 
-[gms.Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
-
-<!--- MODULE kotlinx-coroutines-huawei-services -->
-<!--- INDEX kotlinx.coroutines.tasks -->
-
-[hms.Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
+[Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
 
 <!--- MODULE kotlinx-coroutines-reactive -->
 <!--- INDEX kotlinx.coroutines.reactive -->

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ suspend fun main() = coroutineScope {
 * [ui](ui/README.md) &mdash; modules that provide coroutine dispatchers for various single-threaded UI libraries:
   * Android, JavaFX, and Swing.
 * [integration](integration/README.md) &mdash; modules that provide integration with various asynchronous callback- and future-based libraries:
-  * JDK8 [CompletionStage.await], Guava [ListenableFuture.await], and Google Play Services [Task.await];
+  * JDK8 [CompletionStage.await], Guava [ListenableFuture.await], Google Play Services [Task.await][gms.Task.await] and Huawei Mobile Services [Task.await][hms.Task.await];
   * SLF4J MDC integration via [MDCContext].
 
 ## Documentation
@@ -291,7 +291,12 @@ See [Contributing Guidelines](CONTRIBUTING.md).
 <!--- MODULE kotlinx-coroutines-play-services -->
 <!--- INDEX kotlinx.coroutines.tasks -->
 
-[Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
+[gms.Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
+
+<!--- MODULE kotlinx-coroutines-huawei-services -->
+<!--- INDEX kotlinx.coroutines.tasks -->
+
+[hms.Task.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
 
 <!--- MODULE kotlinx-coroutines-reactive -->
 <!--- INDEX kotlinx.coroutines.reactive -->

--- a/integration/README.md
+++ b/integration/README.md
@@ -9,6 +9,7 @@ Module name below corresponds to the artifact name in Maven/Gradle.
 * [kotlinx-coroutines-guava](kotlinx-coroutines-guava/README.md) -- integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained).
 * [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j/README.md) -- integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html).
 * [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) -- integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks).
+* [kotlinx-coroutines-huawei-services](kotlinx-coroutines-huawei-services) -- integration with Huawei Mobile Services [Tasks API](https://developer.huawei.com/consumer/en/doc/HMSCore-References-V5/tasks-overview-0000001050202661-V5).
 
 ## Contributing
 

--- a/integration/kotlinx-coroutines-huawei-services/README.md
+++ b/integration/kotlinx-coroutines-huawei-services/README.md
@@ -1,0 +1,29 @@
+# Module kotlinx-coroutines-play-services
+
+Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks).
+
+Extension functions:
+
+| **Name** | **Description**
+| -------- | ---------------
+| [Task.await][await] | Awaits for completion of the Task (cancellable)
+| [Deferred.asTask][asTask] | Converts a deferred value to a Task
+
+## Example
+
+Using Firebase APIs becomes simple:
+
+```kotlin
+FirebaseAuth.getInstance().signInAnonymously().await()
+val snapshot = try {
+    FirebaseFirestore.getInstance().document("users/$id").get().await() // Cancellable await
+} catch (e: FirebaseFirestoreException) {
+    // Handle exception
+    return@async
+}
+
+// Do stuff
+```
+
+[await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
+[asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html

--- a/integration/kotlinx-coroutines-huawei-services/README.md
+++ b/integration/kotlinx-coroutines-huawei-services/README.md
@@ -1,29 +1,26 @@
-# Module kotlinx-coroutines-play-services
+# Module kotlinx-coroutines-huawei-services
 
-Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks).
+Integration with Huawei Mobile Services [Tasks API](https://developer.huawei.com/consumer/en/doc/HMSCore-References-V5/tasks-overview-0000001050202661-V5).
 
 Extension functions:
 
 | **Name** | **Description**
 | -------- | ---------------
-| [Task.await][await] | Awaits for completion of the Task (cancellable)
+| [Task.await][await] | Awaits for completion of the Task
+| [Task.asDeferred][asDeferred] | Awaits for a result of the Task
 | [Deferred.asTask][asTask] | Converts a deferred value to a Task
 
 ## Example
-
-Using Firebase APIs becomes simple:
-
 ```kotlin
-FirebaseAuth.getInstance().signInAnonymously().await()
-val snapshot = try {
-    FirebaseFirestore.getInstance().document("users/$id").get().await() // Cancellable await
-} catch (e: FirebaseFirestoreException) {
-    // Handle exception
-    return@async
+val locationProviderClient = LocationServices.getFusedLocationProviderClient(context)
+
+scope.launch {
+    val location: Location = locationProviderClient.getLastLocation().await()
 }
 
-// Do stuff
+val deferredLocation = locationProviderClient.getLastLocation().asDeferred()
 ```
 
-[await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/com.google.android.gms.tasks.-task/await.html
-[asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-play-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html
+[await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/com.huawei.hmf.tasks.-task/await.html
+[asDeferred]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/com.huawei.hmf.tasks.-task/as-deferred.html
+[asTask]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-huawei-services/kotlinx.coroutines.tasks/kotlinx.coroutines.-deferred/as-task.html

--- a/integration/kotlinx-coroutines-huawei-services/api/kotlinx-coroutines-huawei-services.api
+++ b/integration/kotlinx-coroutines-huawei-services/api/kotlinx-coroutines-huawei-services.api
@@ -1,0 +1,6 @@
+public final class kotlinx/coroutines/tasks/TasksKt {
+	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;)Lkotlinx/coroutines/Deferred;
+	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
+	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/integration/kotlinx-coroutines-huawei-services/api/kotlinx-coroutines-huawei-services.api
+++ b/integration/kotlinx-coroutines-huawei-services/api/kotlinx-coroutines-huawei-services.api
@@ -1,6 +1,6 @@
 public final class kotlinx/coroutines/tasks/TasksKt {
-	public static final fun asDeferred (Lcom/google/android/gms/tasks/Task;)Lkotlinx/coroutines/Deferred;
-	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
-	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun asDeferred (Lcom/huawei/hmf/tasks/Task;)Lkotlinx/coroutines/Deferred;
+	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/huawei/hmf/tasks/Task;
+	public static final fun await (Lcom/huawei/hmf/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/integration/kotlinx-coroutines-huawei-services/build.gradle.kts
+++ b/integration/kotlinx-coroutines-huawei-services/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+val tasksVersion = "16.0.1"
+
+val artifactType = Attribute.of("artifactType", String::class.java)
+val unpackedAar = Attribute.of("unpackedAar", Boolean::class.javaObjectType)
+
+configurations.configureEach {
+    afterEvaluate {
+        if (isCanBeResolved) {
+            attributes.attribute(unpackedAar, true) // request all AARs to be unpacked
+        }
+    }
+}
+
+dependencies {
+    attributesSchema {
+        attribute(unpackedAar)
+    }
+
+    artifactTypes {
+        create("aar") {
+            attributes.attribute(unpackedAar, false)
+        }
+    }
+
+    registerTransform(UnpackAar::class.java) {
+        from.attribute(unpackedAar, false).attribute(artifactType, "aar")
+        to.attribute(unpackedAar, true).attribute(artifactType, "jar")
+    }
+
+    api("com.google.android.gms:play-services-tasks:$tasksVersion") {
+        exclude(group="com.android.support")
+    }
+}
+
+externalDocumentationLink(
+    url = "https://developers.google.com/android/reference/"
+)

--- a/integration/kotlinx-coroutines-huawei-services/build.gradle.kts
+++ b/integration/kotlinx-coroutines-huawei-services/build.gradle.kts
@@ -2,7 +2,7 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-val tasksVersion = "16.0.1"
+val tasksVersion = "1.5.0.300"
 
 val artifactType = Attribute.of("artifactType", String::class.java)
 val unpackedAar = Attribute.of("unpackedAar", Boolean::class.javaObjectType)
@@ -13,6 +13,10 @@ configurations.configureEach {
             attributes.attribute(unpackedAar, true) // request all AARs to be unpacked
         }
     }
+}
+
+repositories {
+    maven { url = uri("https://developer.huawei.com/repo/") }
 }
 
 dependencies {
@@ -31,11 +35,11 @@ dependencies {
         to.attribute(unpackedAar, true).attribute(artifactType, "jar")
     }
 
-    api("com.google.android.gms:play-services-tasks:$tasksVersion") {
+    api("com.huawei.hmf:tasks:$tasksVersion") {
         exclude(group="com.android.support")
     }
 }
 
 externalDocumentationLink(
-    url = "https://developers.google.com/android/reference/"
+    url = "https://developer.huawei.com/consumer/en/hms"
 )

--- a/integration/kotlinx-coroutines-huawei-services/package.list
+++ b/integration/kotlinx-coroutines-huawei-services/package.list
@@ -1,0 +1,1 @@
+com.google.android.gms.tasks

--- a/integration/kotlinx-coroutines-huawei-services/src/Tasks.kt
+++ b/integration/kotlinx-coroutines-huawei-services/src/Tasks.kt
@@ -6,15 +6,9 @@
 
 package kotlinx.coroutines.tasks
 
-import com.google.android.gms.tasks.CancellationTokenSource
-import com.google.android.gms.tasks.RuntimeExecutionException
-import com.google.android.gms.tasks.Task
-import com.google.android.gms.tasks.TaskCompletionSource
+import com.huawei.hmf.tasks.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.*
 
 /**
@@ -35,7 +29,7 @@ public fun <T> Deferred<T>.asTask(): Task<T> {
         if (t == null) {
             source.setResult(getCompleted())
         } else {
-            source.setException(t as? Exception ?: RuntimeExecutionException(t))
+            source.setException(t as? Exception ?: RuntimeException(t))
         }
     }
 

--- a/integration/kotlinx-coroutines-huawei-services/src/Tasks.kt
+++ b/integration/kotlinx-coroutines-huawei-services/src/Tasks.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:Suppress("RedundantVisibilityModifier")
+
+package kotlinx.coroutines.tasks
+
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.google.android.gms.tasks.RuntimeExecutionException
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.*
+
+/**
+ * Converts this deferred to the instance of [Task].
+ * If deferred is cancelled then resulting task will be cancelled as well.
+ */
+public fun <T> Deferred<T>.asTask(): Task<T> {
+    val cancellation = CancellationTokenSource()
+    val source = TaskCompletionSource<T>(cancellation.token)
+
+    invokeOnCompletion callback@{
+        if (it is CancellationException) {
+            cancellation.cancel()
+            return@callback
+        }
+
+        val t = getCompletionExceptionOrNull()
+        if (t == null) {
+            source.setResult(getCompleted())
+        } else {
+            source.setException(t as? Exception ?: RuntimeExecutionException(t))
+        }
+    }
+
+    return source.task
+}
+
+/**
+ * Converts this task to an instance of [Deferred].
+ * If task is cancelled then resulting deferred will be cancelled as well.
+ */
+public fun <T> Task<T>.asDeferred(): Deferred<T> {
+    if (isComplete) {
+        val e = exception
+        return if (e == null) {
+            @Suppress("UNCHECKED_CAST")
+            CompletableDeferred<T>().apply { if (isCanceled) cancel() else complete(result as T) }
+        } else {
+            CompletableDeferred<T>().apply { completeExceptionally(e) }
+        }
+    }
+
+    val result = CompletableDeferred<T>()
+    addOnCompleteListener {
+        val e = it.exception
+        if (e == null) {
+            @Suppress("UNCHECKED_CAST")
+            if (isCanceled) result.cancel() else result.complete(it.result as T)
+        } else {
+            result.completeExceptionally(e)
+        }
+    }
+    return result
+}
+
+/**
+ * Awaits for completion of the task without blocking a thread.
+ *
+ * This suspending function is cancellable.
+ * If the [Job] of the current coroutine is cancelled or completed while this suspending function is waiting, this function
+ * stops waiting for the completion stage and immediately resumes with [CancellationException].
+ */
+public suspend fun <T> Task<T>.await(): T {
+    // fast path
+    if (isComplete) {
+        val e = exception
+        return if (e == null) {
+            if (isCanceled) {
+                throw CancellationException("Task $this was cancelled normally.")
+            } else {
+                @Suppress("UNCHECKED_CAST")
+                result as T
+            }
+        } else {
+            throw e
+        }
+    }
+
+    return suspendCancellableCoroutine { cont ->
+        addOnCompleteListener {
+            val e = exception
+            if (e == null) {
+                @Suppress("UNCHECKED_CAST")
+                if (isCanceled) cont.cancel() else cont.resume(result as T)
+            } else {
+                cont.resumeWithException(e)
+            }
+        }
+    }
+}

--- a/integration/kotlinx-coroutines-huawei-services/test/FakeAndroid.kt
+++ b/integration/kotlinx-coroutines-huawei-services/test/FakeAndroid.kt
@@ -1,0 +1,18 @@
+package android.os
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+class Handler(val looper: Looper) {
+    fun post(r: Runnable): Boolean {
+        GlobalScope.launch { r.run() }
+        return true
+    }
+}
+
+class Looper {
+    companion object {
+        @JvmStatic
+        fun getMainLooper() = Looper()
+    }
+}

--- a/integration/kotlinx-coroutines-huawei-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-huawei-services/test/TaskTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.tasks
+
+import com.google.android.gms.tasks.*
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import java.util.concurrent.locks.*
+import kotlin.concurrent.*
+import kotlin.test.*
+
+class TaskTest : TestBase() {
+    @Before
+    fun setup() {
+        ignoreLostThreads("ForkJoinPool.commonPool-worker-")
+    }
+
+    @Test
+    fun testCompletedDeferredAsTask() = runTest {
+        expect(1)
+        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+            expect(2) // Completed immediately
+            "OK"
+        }
+        expect(3)
+        val task = deferred.asTask()
+        assertEquals("OK", task.await())
+        finish(4)
+    }
+
+    @Test
+    fun testDeferredAsTask() = runTest {
+        expect(1)
+        val deferred = async {
+            expect(3) // Completed later
+            "OK"
+        }
+        expect(2)
+        val task = deferred.asTask()
+        assertEquals("OK", task.await())
+        finish(4)
+    }
+
+    @Test
+    fun testCancelledAsTask() {
+        val deferred = GlobalScope.async {
+            delay(100)
+        }.apply { cancel() }
+
+        val task = deferred.asTask()
+        try {
+            runTest { task.await() }
+        } catch (e: Exception) {
+            assertTrue(e is CancellationException)
+            assertTrue(task.isCanceled)
+        }
+    }
+
+    @Test
+    fun testThrowingAsTask() {
+        val deferred = GlobalScope.async<Int> {
+            throw TestException("Fail")
+        }
+
+        val task = deferred.asTask()
+        runTest(expected = { it is TestException }) {
+            task.await()
+        }
+    }
+
+    @Test
+    fun testStateAsTask() = runTest {
+        val lock = ReentrantLock().apply { lock() }
+
+        val deferred: Deferred<Int> = Tasks.call {
+            lock.withLock { 42 }
+        }.asDeferred()
+
+        assertFalse(deferred.isCompleted)
+        lock.unlock()
+
+        assertEquals(42, deferred.await())
+        assertTrue(deferred.isCompleted)
+    }
+
+    @Test
+    fun testTaskAsDeferred() = runTest {
+        val deferred = Tasks.forResult(42).asDeferred()
+        assertEquals(42, deferred.await())
+    }
+
+    @Test
+    fun testNullResultTaskAsDeferred() = runTest {
+        assertNull(Tasks.forResult(null).asDeferred().await())
+    }
+
+    @Test
+    fun testCancelledTaskAsDeferred() = runTest {
+        val deferred = Tasks.forCanceled<Int>().asDeferred()
+
+        assertTrue(deferred.isCancelled)
+        try {
+            deferred.await()
+            fail("deferred.await() should be cancelled")
+        } catch (e: Exception) {
+            assertTrue(e is CancellationException)
+        }
+    }
+
+    @Test
+    fun testFailedTaskAsDeferred() = runTest {
+        val deferred = Tasks.forException<Int>(TestException("something went wrong")).asDeferred()
+
+        assertTrue(deferred.isCancelled && deferred.isCompleted)
+        val completionException = deferred.getCompletionExceptionOrNull()!!
+        assertTrue(completionException is TestException)
+        assertEquals("something went wrong", completionException.message)
+
+        try {
+            deferred.await()
+            fail("deferred.await() should throw an exception")
+        } catch (e: Exception) {
+            assertTrue(e is TestException)
+            assertEquals("something went wrong", e.message)
+        }
+    }
+
+    @Test
+    fun testFailingTaskAsDeferred() = runTest {
+        val lock = ReentrantLock().apply { lock() }
+
+        val deferred: Deferred<Int> = Tasks.call {
+            lock.withLock { throw TestException("something went wrong") }
+        }.asDeferred()
+
+        assertFalse(deferred.isCompleted)
+        lock.unlock()
+
+        try {
+            deferred.await()
+            fail("deferred.await() should throw an exception")
+        } catch (e: Exception) {
+            assertTrue(e is TestException)
+            assertEquals("something went wrong", e.message)
+            assertSame(e.cause, deferred.getCompletionExceptionOrNull()) // debug mode stack augmentation
+        }
+    }
+
+    class TestException(message: String) : Exception(message)
+}

--- a/integration/kotlinx-coroutines-huawei-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-huawei-services/test/TaskTest.kt
@@ -4,7 +4,7 @@
 
 package kotlinx.coroutines.tasks
 
-import com.google.android.gms.tasks.*
+import com.huawei.hmf.tasks.*
 import kotlinx.coroutines.*
 import org.junit.*
 import org.junit.Test
@@ -75,7 +75,7 @@ class TaskTest : TestBase() {
     fun testStateAsTask() = runTest {
         val lock = ReentrantLock().apply { lock() }
 
-        val deferred: Deferred<Int> = Tasks.call {
+        val deferred: Deferred<Int> = Tasks.callInBackground {
             lock.withLock { 42 }
         }.asDeferred()
 
@@ -88,18 +88,18 @@ class TaskTest : TestBase() {
 
     @Test
     fun testTaskAsDeferred() = runTest {
-        val deferred = Tasks.forResult(42).asDeferred()
+        val deferred = Tasks.fromResult(42).asDeferred()
         assertEquals(42, deferred.await())
     }
 
     @Test
     fun testNullResultTaskAsDeferred() = runTest {
-        assertNull(Tasks.forResult(null).asDeferred().await())
+        assertNull(Tasks.fromResult(null).asDeferred().await())
     }
 
     @Test
     fun testCancelledTaskAsDeferred() = runTest {
-        val deferred = Tasks.forCanceled<Int>().asDeferred()
+        val deferred = Tasks.fromCanceled<Int>().asDeferred()
 
         assertTrue(deferred.isCancelled)
         try {
@@ -112,7 +112,7 @@ class TaskTest : TestBase() {
 
     @Test
     fun testFailedTaskAsDeferred() = runTest {
-        val deferred = Tasks.forException<Int>(TestException("something went wrong")).asDeferred()
+        val deferred = Tasks.fromException<Int>(TestException("something went wrong")).asDeferred()
 
         assertTrue(deferred.isCancelled && deferred.isCompleted)
         val completionException = deferred.getCompletionExceptionOrNull()!!
@@ -132,7 +132,7 @@ class TaskTest : TestBase() {
     fun testFailingTaskAsDeferred() = runTest {
         val lock = ReentrantLock().apply { lock() }
 
-        val deferred: Deferred<Int> = Tasks.call {
+        val deferred: Deferred<Int> = Tasks.callInBackground {
             lock.withLock { throw TestException("something went wrong") }
         }.asDeferred()
 

--- a/integration/kotlinx-coroutines-play-services/package.list
+++ b/integration/kotlinx-coroutines-play-services/package.list
@@ -1,1 +1,1 @@
-com.google.android.gms.tasks
+com.huawei.hmf.tasks

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,6 +39,7 @@ module('integration/kotlinx-coroutines-guava')
 module('integration/kotlinx-coroutines-jdk8')
 module('integration/kotlinx-coroutines-slf4j')
 module('integration/kotlinx-coroutines-play-services')
+module('integration/kotlinx-coroutines-huawei-services')
 
 module('reactive/kotlinx-coroutines-reactive')
 module('reactive/kotlinx-coroutines-reactor')

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -10,22 +10,22 @@ Library support for Kotlin coroutines. This reference is a companion to
 
 ## Modules
 
-| Name                                                                 | Description                                      |
-| ----------------------------------------------------------           | ------------------------------------------------ |
-| [kotlinx-coroutines-core](kotlinx-coroutines-core)                   | Core primitives to work with coroutines          |
-| [kotlinx-coroutines-debug](kotlinx-coroutines-debug)                 | Debugging utilities for coroutines               |
-| [kotlinx-coroutines-test](kotlinx-coroutines-test)                   | Test primitives for coroutines, `Main` dispatcher injection         |
-| [kotlinx-coroutines-reactive](kotlinx-coroutines-reactive)           | Utilities for [Reactive Streams](https://www.reactive-streams.org) |
-| [kotlinx-coroutines-reactor](kotlinx-coroutines-reactor)             | Utilities for [Reactor](https://projectreactor.io) |
-| [kotlinx-coroutines-rx2](kotlinx-coroutines-rx2)                     | Utilities for [RxJava 2.x](https://github.com/ReactiveX/RxJava) |
-| [kotlinx-coroutines-rx3](kotlinx-coroutines-rx3)                     | Utilities for [RxJava 3.x](https://github.com/ReactiveX/RxJava) |
-| [kotlinx-coroutines-android](kotlinx-coroutines-android)             | `Main` dispatcher for Android applications |
-| [kotlinx-coroutines-javafx](kotlinx-coroutines-javafx)               | `JavaFx` dispatcher for JavaFX UI applications |
-| [kotlinx-coroutines-swing](kotlinx-coroutines-swing)                 | `Swing` dispatcher for Swing UI applications |
-| [kotlinx-coroutines-jdk8](kotlinx-coroutines-jdk8)                   | Integration with JDK8 `CompletableFuture` (Android API level 24) |
-| [kotlinx-coroutines-guava](kotlinx-coroutines-guava)                 | Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) |
-| [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j)                 | Integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html) |
-| [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) | Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks)
+| Name                                                                     | Description                                      |
+| ----------------------------------------------------------               | ------------------------------------------------ |
+| [kotlinx-coroutines-core](kotlinx-coroutines-core)                       | Core primitives to work with coroutines          |
+| [kotlinx-coroutines-debug](kotlinx-coroutines-debug)                     | Debugging utilities for coroutines               |
+| [kotlinx-coroutines-test](kotlinx-coroutines-test)                       | Test primitives for coroutines, `Main` dispatcher injection         |
+| [kotlinx-coroutines-reactive](kotlinx-coroutines-reactive)               | Utilities for [Reactive Streams](https://www.reactive-streams.org) |
+| [kotlinx-coroutines-reactor](kotlinx-coroutines-reactor)                 | Utilities for [Reactor](https://projectreactor.io) |
+| [kotlinx-coroutines-rx2](kotlinx-coroutines-rx2)                         | Utilities for [RxJava 2.x](https://github.com/ReactiveX/RxJava) |
+| [kotlinx-coroutines-rx3](kotlinx-coroutines-rx3)                         | Utilities for [RxJava 3.x](https://github.com/ReactiveX/RxJava) |
+| [kotlinx-coroutines-android](kotlinx-coroutines-android)                 | `Main` dispatcher for Android applications |
+| [kotlinx-coroutines-javafx](kotlinx-coroutines-javafx)                   | `JavaFx` dispatcher for JavaFX UI applications |
+| [kotlinx-coroutines-swing](kotlinx-coroutines-swing)                     | `Swing` dispatcher for Swing UI applications |
+| [kotlinx-coroutines-jdk8](kotlinx-coroutines-jdk8)                       | Integration with JDK8 `CompletableFuture` (Android API level 24) |
+| [kotlinx-coroutines-guava](kotlinx-coroutines-guava)                     | Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) |
+| [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j)                     | Integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html) |
+| [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services)     | Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks)
 | [kotlinx-coroutines-huawei-services](kotlinx-coroutines-huawei-services) | Integration with Huawei Mobile Services [Tasks API](https://developer.huawei.com/consumer/en/doc/HMSCore-References-V5/tasks-overview-0000001050202661-V5) ||
 
 ## Examples

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -25,7 +25,8 @@ Library support for Kotlin coroutines. This reference is a companion to
 | [kotlinx-coroutines-jdk8](kotlinx-coroutines-jdk8)                   | Integration with JDK8 `CompletableFuture` (Android API level 24) |
 | [kotlinx-coroutines-guava](kotlinx-coroutines-guava)                 | Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained) |
 | [kotlinx-coroutines-slf4j](kotlinx-coroutines-slf4j)                 | Integration with SLF4J [MDC](https://logback.qos.ch/manual/mdc.html) |
-| [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) | Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks) |
+| [kotlinx-coroutines-play-services](kotlinx-coroutines-play-services) | Integration with Google Play Services [Tasks API](https://developers.google.com/android/guides/tasks)
+| [kotlinx-coroutines-huawei-services](kotlinx-coroutines-huawei-services) | Integration with Huawei Mobile Services [Tasks API](https://developer.huawei.com/consumer/en/doc/HMSCore-References-V5/tasks-overview-0000001050202661-V5) ||
 
 ## Examples
 


### PR DESCRIPTION
Huawei Mobile Services library provides very similar Tasks API to Google Mobile Services. It helps developers easily switch between this two libraries.

This PR contains HMS integration - with the same Coroutines API as GMS. Implementation was copied from `play-services` module, and then adapted for Huawei Services. Differences are visible in this commit: https://github.com/Kotlin/kotlinx.coroutines/commit/d3ce28a8d0ad8daeef743124826581a3d0b1e249