### PR TITLE
Make releaseInterceptedContinuation final

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -158,7 +158,7 @@ public abstract class kotlinx/coroutines/CoroutineDispatcher : kotlin/coroutines
 	public fun isDispatchNeeded (Lkotlin/coroutines/CoroutineContext;)Z
 	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
 	public final fun plus (Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public fun releaseInterceptedContinuation (Lkotlin/coroutines/Continuation;)V
+	public final fun releaseInterceptedContinuation (Lkotlin/coroutines/Continuation;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -99,7 +99,7 @@ public abstract class CoroutineDispatcher :
     public final override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
         DispatchedContinuation(this, continuation)
 
-    public override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
+    public final override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
         /*
          * Unconditional cast is safe here: we only return DispatchedContinuation from `interceptContinuation`,
          * any ClassCastException can only indicate compiler bug


### PR DESCRIPTION
    * CoroutineDispatcher is internal for implementation and always has been
    * Overriding this method may lead to memory leaks in parent coroutines and is considered dangerous