### PR TITLE
Make helpRemove actually lock-free and address multiple chained remov…

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/LockFreeLinkedList.kt
@@ -259,7 +259,7 @@ public actual open class LockFreeLinkedListNode {
     // Helps with removal of this node
     public actual fun helpRemove() {
         // Note: this node must be already removed
-        (next as Removed).ref.correctPrev(null)
+        (next as Removed).ref.helpRemovePrev()
     }
 
     // Helps with removal of nodes that are previous to this

--- a/kotlinx-coroutines-core/jvm/test/AbstractLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/AbstractLincheckTest.kt
@@ -15,7 +15,7 @@ abstract class AbstractLincheckTest : VerifierState() {
     open fun StressOptions.customize(isStressTest: Boolean): StressOptions = this
 
     @Test
-    open fun modelCheckingTest() = ModelCheckingOptions()
+    fun modelCheckingTest() = ModelCheckingOptions()
         .iterations(if (isStressTest) 100 else 20)
         .invocationsPerIteration(if (isStressTest) 10_000 else 1_000)
         .commonConfiguration()

--- a/kotlinx-coroutines-core/jvm/test/lincheck/MutexLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/lincheck/MutexLincheckTest.kt
@@ -9,14 +9,9 @@ import kotlinx.coroutines.sync.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
-import org.junit.*
 
 class MutexLincheckTest : AbstractLincheckTest() {
     private val mutex = Mutex()
-
-    override fun modelCheckingTest() {
-        // Ignored via empty body as the only way
-    }
 
     @Operation
     fun tryLock() = mutex.tryLock()


### PR DESCRIPTION
…ed nodes

    * The previous version invoked correctPrev on the next node and bailed out fi it was removed, effectively blocking the progress of any attempts to remove previous node
    * Use helpRemovePrev in helpRemove that was actually implemented to avoid such problem

Fixes #2590