### PR TITLE
General cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ buildscript {
             throw new IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with snapshot compiler")
         }
     }
-    // These three flags are enabled in train builds for JVM IR compiler testing
-    ext.jvm_ir_enabled = rootProject.properties['enable_jvm_ir'] != null
-    ext.jvm_ir_api_check_enabled = rootProject.properties['enable_jvm_ir_api_check'] != null
     ext.native_targets_enabled = rootProject.properties['disable_native_targets'] == null
 
     // Determine if any project dependency is using a snapshot version
@@ -286,15 +283,6 @@ knitPrepare.dependsOn getTasksByName("dokkaHtmlMultiModule", true)
 
 dependencies {
     dokkaHtmlMultiModulePlugin("org.jetbrains.kotlinx:dokka-pathsaver-plugin:$knit_version")
-}
-
-// Disable binary compatibility check for JVM IR compiler output by default
-if (jvm_ir_enabled) {
-    subprojects { project ->
-        configure(tasks.matching { it.name == "apiCheck" }) {
-            enabled = enabled && jvm_ir_api_check_enabled
-        }
-    }
 }
 
 // Opt-in for build scan in order to troubleshoot Gradle on TC

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,6 @@ configure(subprojects.findAll { !sourceless.contains(it.name) }) {
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile).all {
         kotlinOptions.freeCompilerArgs += experimentalAnnotations.collect { "-Xuse-experimental=" + it }
         kotlinOptions.freeCompilerArgs += "-progressive"
-        kotlinOptions.freeCompilerArgs += "-XXLanguage:+InlineClasses"
         // Disable KT-36770 for RxJava2 integration
         kotlinOptions.freeCompilerArgs += "-XXLanguage:-ProhibitUsingNullableTypeParameterAgainstNotNullAnnotated"
         // Remove null assertions to get smaller bytecode on Android

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 apply plugin: 'jdk-convention'
-apply from: rootProject.file("gradle/experimental.gradle")
+apply from: rootProject.file("gradle/opt-in.gradle")
 
 def coreModule = "kotlinx-coroutines-core"
 // Not applicable for Kotlin plugin
@@ -167,7 +167,7 @@ configure(subprojects.findAll { !sourceless.contains(it.name) }) {
 
     // Configure options for all Kotlin compilation tasks
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile).all {
-        kotlinOptions.freeCompilerArgs += experimentalAnnotations.collect { "-Xuse-experimental=" + it }
+        kotlinOptions.freeCompilerArgs += optInAnnotations.collect { "-Xopt-in=" + it }
         kotlinOptions.freeCompilerArgs += "-progressive"
         // Disable KT-36770 for RxJava2 integration
         kotlinOptions.freeCompilerArgs += "-XXLanguage:-ProhibitUsingNullableTypeParameterAgainstNotNullAnnotated"

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -40,12 +40,8 @@ fun MavenPom.configureMavenCentralMetadata(project: Project) {
 }
 
 fun mavenRepositoryUri(): URI {
-    // TODO -SNAPSHOT detection can be made here as well
     val repositoryId: String? = System.getenv("libs.repository.id")
     return if (repositoryId == null) {
-        // Using implicitly created staging, for MPP it's likely to be a mistake because
-        // publication on TeamCity will create 3 independent staging repositories
-        System.err.println("Warning: using an implicitly created staging for coroutines")
         URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
     } else {
         URI("https://oss.sonatype.org/service/local/staging/deployByRepositoryId/$repositoryId")

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -15,12 +15,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_6
 }
 
-if (rootProject.extra.get("jvm_ir_enabled") as Boolean) {
-    kotlin.target.compilations.configureEach {
-        kotlinOptions.useIR = true
-    }
-}
-
 dependencies {
     testImplementation(kotlin("test"))
     // Workaround to make addSuppressed work in tests

--- a/gradle/compile-jvm-multiplatform.gradle
+++ b/gradle/compile-jvm-multiplatform.gradle
@@ -6,13 +6,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 kotlin {
-    jvm {
-        if (rootProject.ext.jvm_ir_enabled) {
-            compilations.all {
-                kotlinOptions.useIR = true
-            }
-        }
-    }
+    jvm {}
     sourceSets {
         jvmTest.dependencies {
             api "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/gradle/opt-in.gradle
+++ b/gradle/opt-in.gradle
@@ -3,10 +3,10 @@
  */
 
 // For new mpp
-ext.experimentalAnnotations = [
-        "kotlin.Experimental",
+ext.optInAnnotations = [
         "kotlin.experimental.ExperimentalTypeInference",
         "kotlin.ExperimentalMultiplatform",
+        "kotlinx.coroutines.DelicateCoroutinesApi",
         "kotlinx.coroutines.ExperimentalCoroutinesApi",
         "kotlinx.coroutines.ObsoleteCoroutinesApi",
         "kotlinx.coroutines.InternalCoroutinesApi",

--- a/gradle/opt-in.gradle
+++ b/gradle/opt-in.gradle
@@ -2,7 +2,6 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-// For new mpp
 ext.optInAnnotations = [
         "kotlin.experimental.ExperimentalTypeInference",
         "kotlin.ExperimentalMultiplatform",

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -81,7 +81,7 @@ kotlin {
         }
         languageSettings {
             progressiveMode = true
-            experimentalAnnotations.each { useExperimentalAnnotation(it) }
+            optInAnnotations.each { useExperimentalAnnotation(it) }
         }
     }
 

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -201,12 +201,6 @@ jvmTest {
         // Configure the IDEA runner for Lincheck
         configureJvmForLincheck(jvmTest)
     }
-    // TODO: JVM IR generates different stacktrace so temporary disable stacktrace tests
-    if (rootProject.ext.jvm_ir_enabled) {
-        filter {
-            excludeTestsMatching('kotlinx.coroutines.exceptions.StackTraceRecovery*')
-        }
-    }
 }
 
 // Setup manifest for kotlinx-coroutines-core-jvm.jar

--- a/kotlinx-coroutines-core/common/README.md
+++ b/kotlinx-coroutines-core/common/README.md
@@ -57,9 +57,9 @@ helper function. [NonCancellable] job object is provided to suppress cancellatio
 | ---------------- | --------------------------------------------- | ------------------------------------------------ | --------------------------
 | [Job]            | [join][Job.join]                              | [onJoin][Job.onJoin]                   | [isCompleted][Job.isCompleted]
 | [Deferred]       | [await][Deferred.await]                       | [onAwait][Deferred.onAwait]                 | [isCompleted][Job.isCompleted]
-| [SendChannel][kotlinx.coroutines.channels.SendChannel]    | [send][kotlinx.coroutines.channels.SendChannel.send]                      | [onSend][kotlinx.coroutines.channels.SendChannel.onSend]                   | [offer][kotlinx.coroutines.channels.SendChannel.offer]
-| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receive][kotlinx.coroutines.channels.ReceiveChannel.receive]             | [onReceive][kotlinx.coroutines.channels.ReceiveChannel.onReceive]             | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
-| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveCatching][kotlinx.coroutines.channels.ReceiveChannel.receiveCatching] | [onReceiveCatching][kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching] | [poll][kotlinx.coroutines.channels.ReceiveChannel.poll]
+| [SendChannel][kotlinx.coroutines.channels.SendChannel]    | [send][kotlinx.coroutines.channels.SendChannel.send]                      | [onSend][kotlinx.coroutines.channels.SendChannel.onSend]                   | [trySend][kotlinx.coroutines.channels.SendChannel.trySend]
+| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receive][kotlinx.coroutines.channels.ReceiveChannel.receive]             | [onReceive][kotlinx.coroutines.channels.ReceiveChannel.onReceive]             | [tryReceive][kotlinx.coroutines.channels.ReceiveChannel.tryReceive]
+| [ReceiveChannel][kotlinx.coroutines.channels.ReceiveChannel] | [receiveCatching][kotlinx.coroutines.channels.ReceiveChannel.receiveCatching] | [onReceiveCatching][kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching] | [tryReceive][kotlinx.coroutines.channels.ReceiveChannel.tryReceive]
 | [Mutex][kotlinx.coroutines.sync.Mutex]          | [lock][kotlinx.coroutines.sync.Mutex.lock]                            | [onLock][kotlinx.coroutines.sync.Mutex.onLock]                   | [tryLock][kotlinx.coroutines.sync.Mutex.tryLock]
 | none            | [delay]                                        | [onTimeout][kotlinx.coroutines.selects.SelectBuilder.onTimeout]                   | none
 
@@ -146,9 +146,9 @@ Low-level primitives for finer-grained control of coroutines.
 [kotlinx.coroutines.channels.SendChannel.send]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/send.html
 [kotlinx.coroutines.channels.ReceiveChannel.receive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/receive.html
 [kotlinx.coroutines.channels.SendChannel.onSend]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/on-send.html
-[kotlinx.coroutines.channels.SendChannel.offer]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/offer.html
+[kotlinx.coroutines.channels.SendChannel.trySend]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/try-send.html
 [kotlinx.coroutines.channels.ReceiveChannel.onReceive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive.html
-[kotlinx.coroutines.channels.ReceiveChannel.poll]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/poll.html
+[kotlinx.coroutines.channels.ReceiveChannel.tryReceive]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/try-receive.html
 [kotlinx.coroutines.channels.ReceiveChannel.receiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/receive-catching.html
 [kotlinx.coroutines.channels.ReceiveChannel.onReceiveCatching]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/on-receive-catching.html
 

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -154,6 +154,8 @@ public interface SendChannel<in E> {
      * ```
      *
      * See https://github.com/Kotlin/kotlinx.coroutines/issues/974 for more context.
+     *
+     * @suppress **Deprecated**.
      */
     @Deprecated(
         level = DeprecationLevel.WARNING,
@@ -308,6 +310,8 @@ public interface ReceiveChannel<out E> {
      * The replacement `tryReceive().getOrNull()` is a default that ignores all close exceptions and
      * proceeds with `null`, while `poll` throws an exception if the channel was closed with an exception.
      * Replacement with the very same 'poll' semantics is `tryReceive().onClosed { if (it != null) throw it }.getOrNull()`
+     *
+     * @suppress **Deprecated**.
      */
     @Deprecated(
         level = DeprecationLevel.WARNING,
@@ -336,6 +340,8 @@ public interface ReceiveChannel<out E> {
      * The replacement `receiveCatching().getOrNull()` is a safe default that ignores all close exceptions and
      * proceeds with `null`, while `receiveOrNull` throws an exception if the channel was closed with an exception.
      * Replacement with the very same `receiveOrNull` semantics is `receiveCatching().onClosed { if (it != null) throw it }.getOrNull()`.
+     *
+     * @suppress **Deprecated**
      */
     @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
     @LowPriorityInOverloadResolution

--- a/kotlinx-coroutines-core/common/src/channels/Deprecated.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Deprecated.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.*
 import kotlin.jvm.*
 
+/** @suppress **/
 @PublishedApi // Binary compatibility
 internal fun consumesAll(vararg channels: ReceiveChannel<*>): CompletionHandler =
     { cause: Throwable? ->
@@ -28,6 +29,7 @@ internal fun consumesAll(vararg channels: ReceiveChannel<*>): CompletionHandler 
         exception?.let { throw it }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.elementAt(index: Int): E = consume {
     if (index < 0)
@@ -40,6 +42,7 @@ public suspend fun <E> ReceiveChannel<E>.elementAt(index: Int): E = consume {
     throw IndexOutOfBoundsException("ReceiveChannel doesn't contain element at index $index.")
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.elementAtOrNull(index: Int): E? =
     consume {
@@ -53,6 +56,7 @@ public suspend fun <E> ReceiveChannel<E>.elementAtOrNull(index: Int): E? =
         return null
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.first(): E =
     consume {
@@ -62,6 +66,7 @@ public suspend fun <E> ReceiveChannel<E>.first(): E =
         return iterator.next()
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.firstOrNull(): E? =
     consume {
@@ -71,6 +76,7 @@ public suspend fun <E> ReceiveChannel<E>.firstOrNull(): E? =
         return iterator.next()
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.indexOf(element: E): Int {
     var index = 0
@@ -82,6 +88,7 @@ public suspend fun <E> ReceiveChannel<E>.indexOf(element: E): Int {
     return -1
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.last(): E =
     consume {
@@ -94,6 +101,7 @@ public suspend fun <E> ReceiveChannel<E>.last(): E =
         return last
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.lastIndexOf(element: E): Int {
     var lastIndex = -1
@@ -106,6 +114,7 @@ public suspend fun <E> ReceiveChannel<E>.lastIndexOf(element: E): Int {
     return lastIndex
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.lastOrNull(): E? =
     consume {
@@ -118,6 +127,7 @@ public suspend fun <E> ReceiveChannel<E>.lastOrNull(): E? =
         return last
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.single(): E =
     consume {
@@ -130,6 +140,7 @@ public suspend fun <E> ReceiveChannel<E>.single(): E =
         return single
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.singleOrNull(): E? =
     consume {
@@ -142,6 +153,7 @@ public suspend fun <E> ReceiveChannel<E>.singleOrNull(): E? =
         return single
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun <E> ReceiveChannel<E>.drop(n: Int, context: CoroutineContext = Dispatchers.Unconfined): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
@@ -158,8 +170,12 @@ public fun <E> ReceiveChannel<E>.drop(n: Int, context: CoroutineContext = Dispat
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E> ReceiveChannel<E>.dropWhile(context: CoroutineContext = Dispatchers.Unconfined, predicate: suspend (E) -> Boolean): ReceiveChannel<E> =
+public fun <E> ReceiveChannel<E>.dropWhile(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    predicate: suspend (E) -> Boolean
+): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         for (e in this@dropWhile) {
             if (!predicate(e)) {
@@ -173,15 +189,22 @@ public fun <E> ReceiveChannel<E>.dropWhile(context: CoroutineContext = Dispatche
     }
 
 @PublishedApi
-internal fun <E> ReceiveChannel<E>.filter(context: CoroutineContext = Dispatchers.Unconfined, predicate: suspend (E) -> Boolean): ReceiveChannel<E> =
+internal fun <E> ReceiveChannel<E>.filter(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    predicate: suspend (E) -> Boolean
+): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         for (e in this@filter) {
             if (predicate(e)) send(e)
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E> ReceiveChannel<E>.filterIndexed(context: CoroutineContext = Dispatchers.Unconfined, predicate: suspend (index: Int, E) -> Boolean): ReceiveChannel<E> =
+public fun <E> ReceiveChannel<E>.filterIndexed(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    predicate: suspend (index: Int, E) -> Boolean
+): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         var index = 0
         for (e in this@filterIndexed) {
@@ -189,8 +212,12 @@ public fun <E> ReceiveChannel<E>.filterIndexed(context: CoroutineContext = Dispa
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E> ReceiveChannel<E>.filterNot(context: CoroutineContext = Dispatchers.Unconfined, predicate: suspend (E) -> Boolean): ReceiveChannel<E> =
+public fun <E> ReceiveChannel<E>.filterNot(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    predicate: suspend (E) -> Boolean
+): ReceiveChannel<E> =
     filter(context) { !predicate(it) }
 
 @PublishedApi
@@ -198,6 +225,7 @@ public fun <E> ReceiveChannel<E>.filterNot(context: CoroutineContext = Dispatche
 internal fun <E : Any> ReceiveChannel<E?>.filterNotNull(): ReceiveChannel<E> =
     filter { it != null } as ReceiveChannel<E>
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E : Any, C : MutableCollection<in E>> ReceiveChannel<E?>.filterNotNullTo(destination: C): C {
     consumeEach {
@@ -206,6 +234,7 @@ public suspend fun <E : Any, C : MutableCollection<in E>> ReceiveChannel<E?>.fil
     return destination
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E : Any, C : SendChannel<E>> ReceiveChannel<E?>.filterNotNullTo(destination: C): C {
     consumeEach {
@@ -214,6 +243,7 @@ public suspend fun <E : Any, C : SendChannel<E>> ReceiveChannel<E?>.filterNotNul
     return destination
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun <E> ReceiveChannel<E>.take(n: Int, context: CoroutineContext = Dispatchers.Unconfined): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
@@ -228,8 +258,12 @@ public fun <E> ReceiveChannel<E>.take(n: Int, context: CoroutineContext = Dispat
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E> ReceiveChannel<E>.takeWhile(context: CoroutineContext = Dispatchers.Unconfined, predicate: suspend (E) -> Boolean): ReceiveChannel<E> =
+public fun <E> ReceiveChannel<E>.takeWhile(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    predicate: suspend (E) -> Boolean
+): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         for (e in this@takeWhile) {
             if (!predicate(e)) return@produce
@@ -253,6 +287,7 @@ internal suspend fun <E, C : MutableCollection<in E>> ReceiveChannel<E>.toCollec
     return destination
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <K, V> ReceiveChannel<Pair<K, V>>.toMap(): Map<K, V> =
     toMap(LinkedHashMap())
@@ -265,16 +300,22 @@ internal suspend fun <K, V, M : MutableMap<in K, in V>> ReceiveChannel<Pair<K, V
     return destination
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.toMutableList(): MutableList<E> =
     toCollection(ArrayList())
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.toSet(): Set<E> =
     this.toMutableSet()
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E, R> ReceiveChannel<E>.flatMap(context: CoroutineContext = Dispatchers.Unconfined, transform: suspend (E) -> ReceiveChannel<R>): ReceiveChannel<R> =
+public fun <E, R> ReceiveChannel<E>.flatMap(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: suspend (E) -> ReceiveChannel<R>
+): ReceiveChannel<R> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         for (e in this@flatMap) {
             transform(e).toChannel(this)
@@ -282,7 +323,10 @@ public fun <E, R> ReceiveChannel<E>.flatMap(context: CoroutineContext = Dispatch
     }
 
 @PublishedApi
-internal fun <E, R> ReceiveChannel<E>.map(context: CoroutineContext = Dispatchers.Unconfined, transform: suspend (E) -> R): ReceiveChannel<R> =
+internal fun <E, R> ReceiveChannel<E>.map(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: suspend (E) -> R
+): ReceiveChannel<R> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         consumeEach {
             send(transform(it))
@@ -290,7 +334,10 @@ internal fun <E, R> ReceiveChannel<E>.map(context: CoroutineContext = Dispatcher
     }
 
 @PublishedApi
-internal fun <E, R> ReceiveChannel<E>.mapIndexed(context: CoroutineContext = Dispatchers.Unconfined, transform: suspend (index: Int, E) -> R): ReceiveChannel<R> =
+internal fun <E, R> ReceiveChannel<E>.mapIndexed(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: suspend (index: Int, E) -> R
+): ReceiveChannel<R> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         var index = 0
         for (e in this@mapIndexed) {
@@ -298,14 +345,23 @@ internal fun <E, R> ReceiveChannel<E>.mapIndexed(context: CoroutineContext = Dis
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E, R : Any> ReceiveChannel<E>.mapIndexedNotNull(context: CoroutineContext = Dispatchers.Unconfined, transform: suspend (index: Int, E) -> R?): ReceiveChannel<R> =
+public fun <E, R : Any> ReceiveChannel<E>.mapIndexedNotNull(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: suspend (index: Int, E) -> R?
+): ReceiveChannel<R> =
     mapIndexed(context, transform).filterNotNull()
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
-public fun <E, R : Any> ReceiveChannel<E>.mapNotNull(context: CoroutineContext = Dispatchers.Unconfined, transform: suspend (E) -> R?): ReceiveChannel<R> =
+public fun <E, R : Any> ReceiveChannel<E>.mapNotNull(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: suspend (E) -> R?
+): ReceiveChannel<R> =
     map(context, transform).filterNotNull()
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun <E> ReceiveChannel<E>.withIndex(context: CoroutineContext = Dispatchers.Unconfined): ReceiveChannel<IndexedValue<E>> =
     GlobalScope.produce(context, onCompletion = consumes()) {
@@ -315,12 +371,16 @@ public fun <E> ReceiveChannel<E>.withIndex(context: CoroutineContext = Dispatche
         }
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun <E> ReceiveChannel<E>.distinct(): ReceiveChannel<E> =
     this.distinctBy { it }
 
 @PublishedApi
-internal fun <E, K> ReceiveChannel<E>.distinctBy(context: CoroutineContext = Dispatchers.Unconfined, selector: suspend (E) -> K): ReceiveChannel<E> =
+internal fun <E, K> ReceiveChannel<E>.distinctBy(
+    context: CoroutineContext = Dispatchers.Unconfined,
+    selector: suspend (E) -> K
+): ReceiveChannel<E> =
     GlobalScope.produce(context, onCompletion = consumes()) {
         val keys = HashSet<K>()
         for (e in this@distinctBy) {
@@ -336,12 +396,14 @@ internal fun <E, K> ReceiveChannel<E>.distinctBy(context: CoroutineContext = Dis
 internal suspend fun <E> ReceiveChannel<E>.toMutableSet(): MutableSet<E> =
     toCollection(LinkedHashSet())
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.any(): Boolean =
     consume {
         return iterator().hasNext()
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.count(): Int {
     var count = 0
@@ -349,6 +411,7 @@ public suspend fun <E> ReceiveChannel<E>.count(): Int {
     return count
 }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.maxWith(comparator: Comparator<in E>): E? =
     consume {
@@ -362,6 +425,7 @@ public suspend fun <E> ReceiveChannel<E>.maxWith(comparator: Comparator<in E>): 
         return max
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.minWith(comparator: Comparator<in E>): E? =
     consume {
@@ -375,22 +439,29 @@ public suspend fun <E> ReceiveChannel<E>.minWith(comparator: Comparator<in E>): 
         return min
     }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public suspend fun <E> ReceiveChannel<E>.none(): Boolean =
     consume {
         return !iterator().hasNext()
     }
 
+/** @suppress **/
 @Deprecated(message = "Left for binary compatibility", level = DeprecationLevel.HIDDEN)
 public fun <E : Any> ReceiveChannel<E?>.requireNoNulls(): ReceiveChannel<E> =
     map { it ?: throw IllegalArgumentException("null element found in $this.") }
 
+/** @suppress **/
 @Deprecated(message = "Binary compatibility", level = DeprecationLevel.HIDDEN)
 public infix fun <E, R> ReceiveChannel<E>.zip(other: ReceiveChannel<R>): ReceiveChannel<Pair<E, R>> =
     zip(other) { t1, t2 -> t1 to t2 }
 
 @PublishedApi // Binary compatibility
-internal fun <E, R, V> ReceiveChannel<E>.zip(other: ReceiveChannel<R>, context: CoroutineContext = Dispatchers.Unconfined, transform: (a: E, b: R) -> V): ReceiveChannel<V> =
+internal fun <E, R, V> ReceiveChannel<E>.zip(
+    other: ReceiveChannel<R>,
+    context: CoroutineContext = Dispatchers.Unconfined,
+    transform: (a: E, b: R) -> V
+): ReceiveChannel<V> =
     GlobalScope.produce(context, onCompletion = consumesAll(this, other)) {
         val otherIterator = other.iterator()
         this@zip.consumeEach { element1 ->

--- a/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
@@ -278,37 +278,7 @@ private class CancellableFlowImpl<T>(private val flow: Flow<T>) : CancellableFlo
 }
 
 /**
- * The operator that changes the context where all transformations applied to the given flow within a [builder] are executed.
- * This operator is context preserving and does not affect the context of the preceding and subsequent operations.
- *
- * Example:
- *
- * ```
- * flow // not affected
- *     .map { ... } // Not affected
- *     .flowWith(Dispatchers.IO) {
- *         map { ... } // in IO
- *         .filter { ... } // in IO
- *     }
- *     .map { ... } // Not affected
- * ```
- *
- * For more explanation of context preservation please refer to [Flow] documentation.
- *
- * This operator is deprecated without replacement because it was discovered that it doesn't play well with coroutines
- * and flow semantics:
- *
- * 1) It doesn't prevent context elements from the downstream to leak into its body
- *     ```
- *     flowOf(1).flowWith(EmptyCoroutineContext) {
- *         onEach { println(kotlin.coroutines.coroutineContext[CoroutineName]) } // Will print 42
- *     }.flowOn(CoroutineName(42))
- *     ```
- * 2) To avoid such leaks, new primitive should be introduced to `kotlinx.coroutines` -- the subtraction of contexts.
- *    And this will become a new concept to learn, maintain and explain.
- * 3) It defers the execution of declarative [builder] until the moment of [collection][Flow.collect] similarly
- *    to `Observable.defer`. But it is unexpected because nothing in the name `flowWith` reflects this fact.
- * 4) It can be confused with [flowOn] operator, though [flowWith] is much rarer.
+ * @suppress
  */
 @FlowPreview
 @Deprecated(message = "flowWith is deprecated without replacement, please refer to its KDoc for an explanation", level = DeprecationLevel.ERROR) // Error in beta release, removal in 1.4

--- a/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
@@ -278,6 +278,38 @@ private class CancellableFlowImpl<T>(private val flow: Flow<T>) : CancellableFlo
 }
 
 /**
+ * The operator that changes the context where all transformations applied to the given flow within a [builder] are executed.
+ * This operator is context preserving and does not affect the context of the preceding and subsequent operations.
+ *
+ * Example:
+ *
+ * ```
+ * flow // not affected
+ *     .map { ... } // Not affected
+ *     .flowWith(Dispatchers.IO) {
+ *         map { ... } // in IO
+ *         .filter { ... } // in IO
+ *     }
+ *     .map { ... } // Not affected
+ * ```
+ *
+ * For more explanation of context preservation please refer to [Flow] documentation.
+ *
+ * This operator is deprecated without replacement because it was discovered that it doesn't play well with coroutines
+ * and flow semantics:
+ *
+ * 1) It doesn't prevent context elements from the downstream to leak into its body
+ *     ```
+ *     flowOf(1).flowWith(EmptyCoroutineContext) {
+ *         onEach { println(kotlin.coroutines.coroutineContext[CoroutineName]) } // Will print 42
+ *     }.flowOn(CoroutineName(42))
+ *     ```
+ * 2) To avoid such leaks, new primitive should be introduced to `kotlinx.coroutines` -- the subtraction of contexts.
+ *    And this will become a new concept to learn, maintain and explain.
+ * 3) It defers the execution of declarative [builder] until the moment of [collection][Flow.collect] similarly
+ *    to `Observable.defer`. But it is unexpected because nothing in the name `flowWith` reflects this fact.
+ * 4) It can be confused with [flowOn] operator, though [flowWith] is much rarer.
+ *
  * @suppress
  */
 @FlowPreview

--- a/kotlinx-coroutines-core/common/src/internal/ConcurrentLinkedList.kt
+++ b/kotlinx-coroutines-core/common/src/internal/ConcurrentLinkedList.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.internal
 
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
+import kotlin.jvm.*
 import kotlin.native.concurrent.SharedImmutable
 
 /**
@@ -227,8 +228,8 @@ private inline fun AtomicInt.addConditionally(delta: Int, condition: (cur: Int) 
     }
 }
 
-@Suppress("EXPERIMENTAL_FEATURE_WARNING") // We are using inline class only internally, so it is Ok
-internal inline class SegmentOrClosed<S : Segment<S>>(private val value: Any?) {
+@JvmInline
+internal value class SegmentOrClosed<S : Segment<S>>(private val value: Any?) {
     val isClosed: Boolean get() = value === CLOSED
     @Suppress("UNCHECKED_CAST")
     val segment: S get() = if (value === CLOSED) error("Does not contain segment") else value as S

--- a/kotlinx-coroutines-core/common/src/internal/InlineList.kt
+++ b/kotlinx-coroutines-core/common/src/internal/InlineList.kt
@@ -7,14 +7,16 @@
 package kotlinx.coroutines.internal
 
 import kotlinx.coroutines.assert
+import kotlin.jvm.*
 
 /*
  * Inline class that represents a mutable list, but does not allocate an underlying storage
  * for zero and one elements.
  * Cannot be parametrized with `List<*>`.
  */
-internal inline class InlineList<E>(private val holder: Any? = null) {
-    public operator fun plus(element: E): InlineList<E>  {
+@JvmInline
+internal value class InlineList<E>(private val holder: Any? = null) {
+    operator fun plus(element: E): InlineList<E>  {
         assert { element !is List<*> } // Lists are prohibited
         return when (holder) {
             null -> InlineList(element)
@@ -31,7 +33,7 @@ internal inline class InlineList<E>(private val holder: Any? = null) {
         }
     }
 
-    public inline fun forEachReversed(action: (E) -> Unit) {
+    inline fun forEachReversed(action: (E) -> Unit) {
         when (holder) {
             null -> return
             !is ArrayList<*> -> action(holder as E)

--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelsJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelsJvmTest.kt
@@ -25,7 +25,6 @@ class ChannelsJvmTest : TestBase() {
         assertEquals(45, runBlocking { sum.await() })
     }
 
-    // Uncomment lines when migrated to 1.5, these are bugs in inline classes codegen
     @Test
     fun testTrySendBlockingClosedChannel() {
         run {
@@ -33,7 +32,7 @@ class ChannelsJvmTest : TestBase() {
             channel.trySendBlocking(Unit)
                 .onSuccess { expectUnreached() }
                 .onFailure { assertTrue(it is ClosedSendChannelException) }
-//                .also { assertTrue { it.isClosed } }
+                .also { assertTrue { it.isClosed } }
         }
 
         run {
@@ -41,7 +40,7 @@ class ChannelsJvmTest : TestBase() {
             channel.trySendBlocking(Unit)
                 .onSuccess { expectUnreached() }
                 .onFailure { assertTrue(it is TestException) }
-//                .also { assertTrue { it.isClosed } }
+                .also { assertTrue { it.isClosed } }
         }
 
         run {
@@ -49,8 +48,7 @@ class ChannelsJvmTest : TestBase() {
             channel.trySendBlocking(Unit)
                 .onSuccess { expectUnreached() }
                 .onFailure { assertTrue(it is TestCancellationException) }
-//                .also { assertTrue { it.isClosed } }
+                .also { assertTrue { it.isClosed } }
         }
     }
-
 }

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -31,16 +31,6 @@ dependencies {
     api "net.java.dev.jna:jna-platform:$jna_version"
 }
 
-// TODO: JVM IR generates different stacktrace so temporary disable stacktrace tests
-if (rootProject.ext.jvm_ir_enabled) {
-    tasks.named('test', Test) {
-        filter {
-//            excludeTest('kotlinx.coroutines.debug.CoroutinesDumpTest', 'testCreationStackTrace')
-            excludeTestsMatching('kotlinx.coroutines.debug.DebugProbesTest')
-        }
-    }
-}
-
 java {
     /* This is needed to be able to run JUnit5 tests. Otherwise, Gradle complains that it can't find the
     JVM1.6-compatible version of the `junit-jupiter-api` artifact. */

--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -100,6 +100,8 @@ public suspend fun <T> Publisher<T>.awaitSingle(): T = awaitOne(Mode.SINGLE)
  *
  * @throws NoSuchElementException if the publisher does not emit any value
  * @throws IllegalArgumentException if the publisher emits more than one value
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated without a replacement due to its name incorrectly conveying the behavior. " +
@@ -127,6 +129,7 @@ public suspend fun <T> Publisher<T>.awaitSingleOrDefault(default: T): T = awaitO
  * meaning.
  *
  * @throws IllegalArgumentException if the publisher emits more than one value
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated without a replacement due to its name incorrectly conveying the behavior. " +
@@ -156,6 +159,7 @@ public suspend fun <T> Publisher<T>.awaitSingleOrNull(): T? = awaitOne(Mode.SING
  * meaning.
  *
  * @throws IllegalArgumentException if the publisher emits more than one value
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated without a replacement due to its name incorrectly conveying the behavior. " +

--- a/reactive/kotlinx-coroutines-reactive/src/Migration.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Migration.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.*
 import org.reactivestreams.*
 
 // Binary compatibility with Spring 5.2 RC
+/** @suppress */
 @Deprecated(
     message = "Replaced in favor of ReactiveFlow extension, please import kotlinx.coroutines.reactive.* instead of kotlinx.coroutines.reactive.FlowKt",
     level = DeprecationLevel.HIDDEN
@@ -20,6 +21,7 @@ import org.reactivestreams.*
 public fun <T : Any> Publisher<T>.asFlowDeprecated(): Flow<T> = asFlow()
 
 // Binary compatibility with Spring 5.2 RC
+/** @suppress */
 @Deprecated(
     message = "Replaced in favor of ReactiveFlow extension, please import kotlinx.coroutines.reactive.* instead of kotlinx.coroutines.reactive.FlowKt",
     level = DeprecationLevel.HIDDEN
@@ -27,6 +29,7 @@ public fun <T : Any> Publisher<T>.asFlowDeprecated(): Flow<T> = asFlow()
 @JvmName("asPublisher")
 public fun <T : Any> Flow<T>.asPublisherDeprecated(): Publisher<T> = asPublisher()
 
+/** @suppress */
 @FlowPreview
 @Deprecated(
     message = "batchSize parameter is deprecated, use .buffer() instead to control the backpressure",

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -61,6 +61,7 @@ private const val CLOSED = -1L    // closed, but have not signalled onCompleted/
 private const val SIGNALLED = -2L  // already signalled subscriber onCompleted/onError
 private val DEFAULT_HANDLER: (Throwable, CoroutineContext) -> Unit = { t, ctx -> if (t !is CancellationException) handleCoroutineException(ctx, t) }
 
+/** @suppress */
 @Suppress("CONFLICTING_JVM_DECLARATIONS", "RETURN_TYPE_MISMATCH_ON_INHERITANCE")
 @InternalCoroutinesApi
 public class PublisherCoroutine<in T>(

--- a/reactive/kotlinx-coroutines-reactor/README.md
+++ b/reactive/kotlinx-coroutines-reactor/README.md
@@ -27,7 +27,6 @@ Conversion functions:
 | -------- | ---------------
 | [Job.asMono][kotlinx.coroutines.Job.asMono] | Converts a job to a hot Mono
 | [Deferred.asMono][kotlinx.coroutines.Deferred.asMono] | Converts a deferred value to a hot Mono
-| [ReceiveChannel.asFlux][kotlinx.coroutines.channels.ReceiveChannel.asFlux] | Converts a streaming channel to a hot Flux
 | [Scheduler.asCoroutineDispatcher][reactor.core.scheduler.Scheduler.asCoroutineDispatcher] | Converts a scheduler to a [CoroutineDispatcher]
 
 <!--- MODULE kotlinx-coroutines-core -->
@@ -50,7 +49,6 @@ Conversion functions:
 [ReactorContext]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/-reactor-context/index.html
 [kotlinx.coroutines.Job.asMono]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/as-mono.html
 [kotlinx.coroutines.Deferred.asMono]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/as-mono.html
-[kotlinx.coroutines.channels.ReceiveChannel.asFlux]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/as-flux.html
 [reactor.core.scheduler.Scheduler.asCoroutineDispatcher]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/as-coroutine-dispatcher.html
 
 <!--- END -->

--- a/reactive/kotlinx-coroutines-reactor/src/Convert.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Convert.kt
@@ -42,6 +42,7 @@ public fun <T> Deferred<T?>.asMono(context: CoroutineContext): Mono<T> = mono(co
  * Every subscriber receives values from this channel in a **fan-out** fashion. If the are multiple subscribers,
  * they'll receive values in a round-robin way.
  * @param context -- the coroutine context from which the resulting flux is going to be signalled
+ * @suppress
  */
 @Deprecated(message = "Deprecated in the favour of consumeAsFlow()",
     level = DeprecationLevel.ERROR,

--- a/reactive/kotlinx-coroutines-reactor/src/Flux.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Flux.kt
@@ -83,6 +83,9 @@ private fun <T> Subscriber<T>?.reject(t: Throwable) {
     onError(t)
 }
 
+/**
+ * @suppress
+ */
 @Deprecated(
     message = "CoroutineScope.flux is deprecated in favour of top-level flux",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-reactor/src/Migration.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Migration.kt
@@ -9,6 +9,7 @@ package kotlinx.coroutines.reactor
 import kotlinx.coroutines.flow.*
 import reactor.core.publisher.*
 
+/** @suppress **/
 @Deprecated(
     message = "Replaced in favor of ReactiveFlow extension, please import kotlinx.coroutines.reactor.* instead of kotlinx.coroutines.reactor.FlowKt",
     level = DeprecationLevel.HIDDEN

--- a/reactive/kotlinx-coroutines-reactor/src/Mono.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Mono.kt
@@ -125,6 +125,9 @@ private class MonoCoroutine<in T>(
     override fun isDisposed(): Boolean = disposed
 }
 
+/**
+ * @suppress
+ */
 @Deprecated(
     message = "CoroutineScope.mono is deprecated in favour of top-level mono",
     level = DeprecationLevel.HIDDEN,
@@ -148,6 +151,8 @@ public fun <T> CoroutineScope.mono(
  * ```
  * It looks like more than one value could be returned from `findById` and [awaitFirst] discards the extra elements,
  * when in fact, at most a single value can be present.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Mono produces at most one value, so the semantics of dropping the remaining elements are not useful. " +
@@ -170,6 +175,8 @@ public suspend fun <T> Mono<T>.awaitFirst(): T = awaitSingle()
  * ```
  * It looks like more than one value could be returned from `findById` and [awaitFirstOrDefault] discards the extra
  * elements, when in fact, at most a single value can be present.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Mono produces at most one value, so the semantics of dropping the remaining elements are not useful. " +
@@ -192,6 +199,8 @@ public suspend fun <T> Mono<T>.awaitFirstOrDefault(default: T): T = awaitSingleO
  * ```
  * It looks like more than one value could be returned from `findById` and [awaitFirstOrNull] discards the extra
  * elements, when in fact, at most a single value can be present.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Mono produces at most one value, so the semantics of dropping the remaining elements are not useful. " +
@@ -214,6 +223,8 @@ public suspend fun <T> Mono<T>.awaitFirstOrNull(): T? = awaitSingleOrNull()
  * ```
  * It looks like more than one value could be returned from `findById` and [awaitFirstOrElse] discards the extra
  * elements, when in fact, at most a single value can be present.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Mono produces at most one value, so the semantics of dropping the remaining elements are not useful. " +
@@ -236,6 +247,8 @@ public suspend fun <T> Mono<T>.awaitFirstOrElse(defaultValue: () -> T): T = awai
  * ```
  * It looks like more than one value could be returned from `findById` and [awaitLast] discards the initial elements,
  * when in fact, at most a single value can be present.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Mono produces at most one value, so the last element is the same as the first. " +

--- a/reactive/kotlinx-coroutines-reactor/src/ReactorContext.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/ReactorContext.kt
@@ -68,6 +68,7 @@ public fun ContextView.asCoroutineContext(): ReactorContext = ReactorContext(thi
 /**
  * Wraps the given [Context] into [ReactorContext], so it can be added to the coroutine's context
  * and later used via `coroutineContext[ReactorContext]`.
+ * @suppress
  */
 @Deprecated("The more general version for ContextView should be used instead", level = DeprecationLevel.HIDDEN)
 public fun Context.asCoroutineContext(): ReactorContext = readOnly().asCoroutineContext() // `readOnly()` is zero-cost.

--- a/reactive/kotlinx-coroutines-rx2/README.md
+++ b/reactive/kotlinx-coroutines-rx2/README.md
@@ -25,9 +25,8 @@ Suspending extension functions and suspending iteration:
 | **Name** | **Description**
 | -------- | ---------------
 | [CompletableSource.await][io.reactivex.CompletableSource.await] | Awaits for completion of the completable value 
-| [MaybeSource.await][io.reactivex.MaybeSource.await] | Awaits for the value of the maybe and returns it or null 
-| [MaybeSource.awaitOrDefault][io.reactivex.MaybeSource.awaitOrDefault] | Awaits for the value of the maybe and returns it or default 
-| [MaybeSource.openSubscription][io.reactivex.MaybeSource.openSubscription] | Subscribes to maybe and returns [ReceiveChannel] 
+| [MaybeSource.awaitSingle][io.reactivex.MaybeSource.awaitSingle] | Awaits for the value of the maybe and returns it or throws an exception
+| [MaybeSource.awaitSingleOrNull][io.reactivex.MaybeSource.awaitSingleOrNull] | Awaits for the value of the maybe and returns it or null 
 | [SingleSource.await][io.reactivex.SingleSource.await] | Awaits for completion of the single value and returns it 
 | [ObservableSource.awaitFirst][io.reactivex.ObservableSource.awaitFirst] | Awaits for the first value from the given observable
 | [ObservableSource.awaitFirstOrDefault][io.reactivex.ObservableSource.awaitFirstOrDefault] | Awaits for the first value from the given observable or default
@@ -57,7 +56,6 @@ Conversion functions:
 <!--- INDEX kotlinx.coroutines.channels -->
 
 [ProducerScope]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/index.html
-[ReceiveChannel]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-receive-channel/index.html
 
 <!--- INDEX kotlinx.coroutines.flow -->
 
@@ -75,9 +73,8 @@ Conversion functions:
 [Flow.asObservable]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/as-observable.html
 [ObservableSource.asFlow]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/as-flow.html
 [io.reactivex.CompletableSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await.html
-[io.reactivex.MaybeSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await.html
-[io.reactivex.MaybeSource.awaitOrDefault]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await-or-default.html
-[io.reactivex.MaybeSource.openSubscription]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/open-subscription.html
+[io.reactivex.MaybeSource.awaitSingle]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await-single.html
+[io.reactivex.MaybeSource.awaitSingleOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await-single-or-null.html
 [io.reactivex.SingleSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await.html
 [io.reactivex.ObservableSource.awaitFirst]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await-first.html
 [io.reactivex.ObservableSource.awaitFirstOrDefault]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/await-first-or-default.html

--- a/reactive/kotlinx-coroutines-rx2/src/RxAwait.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxAwait.kt
@@ -76,6 +76,7 @@ public suspend fun <T> MaybeSource<T>.awaitSingle(): T = awaitSingleOrNull() ?: 
  *
  * Deprecated in favor of [awaitSingleOrNull] in order to reflect that `null` can be returned to denote the absence of
  * a value, as opposed to throwing in such case.
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated in favor of awaitSingleOrNull()",
@@ -97,6 +98,7 @@ public suspend fun <T> MaybeSource<T>.await(): T? = awaitSingleOrNull()
  *
  * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of [MaybeSource.await] for
  * details).
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated in favor of awaitSingleOrNull()",

--- a/reactive/kotlinx-coroutines-rx2/src/RxChannel.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxChannel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.reactive.*
  *
  * This API is deprecated in the favour of [Flow].
  * [MaybeSource] doesn't have a corresponding [Flow] adapter, so it should be transformed to [Observable] first.
+ * @suppress
  */
 @Deprecated(message = "Deprecated in the favour of Flow", level = DeprecationLevel.ERROR) // Will be hidden in 1.5
 public fun <T> MaybeSource<T>.openSubscription(): ReceiveChannel<T> {
@@ -32,6 +33,7 @@ public fun <T> MaybeSource<T>.openSubscription(): ReceiveChannel<T> {
  *
  * This API is deprecated in the favour of [Flow].
  * [ObservableSource] doesn't have a corresponding [Flow] adapter, so it should be transformed to [Observable] first.
+ * @suppress
  */
 @Deprecated(message = "Deprecated in the favour of Flow", level = DeprecationLevel.ERROR) // Will be hidden in 1.5
 public fun <T> ObservableSource<T>.openSubscription(): ReceiveChannel<T> {

--- a/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxCompletable.kt
@@ -60,6 +60,9 @@ private class RxCompletableCoroutine(
     }
 }
 
+/**
+ * @suppress
+ */
 @Deprecated(
     message = "CoroutineScope.rxCompletable is deprecated in favour of top-level rxCompletable",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxConvert.kt
@@ -149,6 +149,7 @@ public fun <T : Any> ReceiveChannel<T>.asObservable(context: CoroutineContext): 
         send(t)
 }
 
+/** @suppress **/
 @Suppress("UNUSED") // KT-42513
 @JvmOverloads // binary compatibility
 @JvmName("from")
@@ -156,6 +157,7 @@ public fun <T : Any> ReceiveChannel<T>.asObservable(context: CoroutineContext): 
 public fun <T: Any> Flow<T>._asFlowable(context: CoroutineContext = EmptyCoroutineContext): Flowable<T> =
     asFlowable(context)
 
+/** @suppress **/
 @Suppress("UNUSED") // KT-42513
 @JvmOverloads // binary compatibility
 @JvmName("from")

--- a/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
@@ -40,6 +40,7 @@ public fun <T: Any> rxFlowable(
     return Flowable.fromPublisher(publishInternal(GlobalScope, context, RX_HANDLER, block))
 }
 
+/** @suppress */
 @Deprecated(
     message = "CoroutineScope.rxFlowable is deprecated in favour of top-level rxFlowable",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxMaybe.kt
@@ -61,6 +61,7 @@ private class RxMaybeCoroutine<T>(
     }
 }
 
+/** @suppress */
 @Deprecated(
     message = "CoroutineScope.rxMaybe is deprecated in favour of top-level rxMaybe",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -191,6 +191,7 @@ private class RxObservableCoroutine<T : Any>(
     }
 }
 
+/** @suppress */
 @Deprecated(
     message = "CoroutineScope.rxObservable is deprecated in favour of top-level rxObservable",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxSingle.kt
@@ -60,6 +60,7 @@ private class RxSingleCoroutine<T: Any>(
     }
 }
 
+/** @suppress */
 @Deprecated(
     message = "CoroutineScope.rxSingle is deprecated in favour of top-level rxSingle",
     level = DeprecationLevel.HIDDEN,

--- a/reactive/kotlinx-coroutines-rx3/README.md
+++ b/reactive/kotlinx-coroutines-rx3/README.md
@@ -25,8 +25,8 @@ Suspending extension functions and suspending iteration:
 | **Name** | **Description**
 | -------- | ---------------
 | [CompletableSource.await][io.reactivex.rxjava3.core.CompletableSource.await] | Awaits for completion of the completable value 
-| [MaybeSource.await][io.reactivex.rxjava3.core.MaybeSource.await] | Awaits for the value of the maybe and returns it or null 
-| [MaybeSource.awaitOrDefault][io.reactivex.rxjava3.core.MaybeSource.awaitOrDefault] | Awaits for the value of the maybe and returns it or default 
+| [MaybeSource.awaitSingle][io.reactivex.rxjava3.core.MaybeSource.awaitSingle] | Awaits for the value of the maybe and returns it or throws an exception
+| [MaybeSource.awaitSingleOrNull][io.reactivex.rxjava3.core.MaybeSource.awaitSingleOrNull] | Awaits for the value of the maybe and returns it or null 
 | [SingleSource.await][io.reactivex.rxjava3.core.SingleSource.await] | Awaits for completion of the single value and returns it 
 | [ObservableSource.awaitFirst][io.reactivex.rxjava3.core.ObservableSource.awaitFirst] | Awaits for the first value from the given observable
 | [ObservableSource.awaitFirstOrDefault][io.reactivex.rxjava3.core.ObservableSource.awaitFirstOrDefault] | Awaits for the first value from the given observable or default
@@ -73,8 +73,8 @@ Conversion functions:
 [Flow.asObservable]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/as-observable.html
 [ObservableSource.asFlow]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/as-flow.html
 [io.reactivex.rxjava3.core.CompletableSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await.html
-[io.reactivex.rxjava3.core.MaybeSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await.html
-[io.reactivex.rxjava3.core.MaybeSource.awaitOrDefault]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await-or-default.html
+[io.reactivex.rxjava3.core.MaybeSource.awaitSingle]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await-single.html
+[io.reactivex.rxjava3.core.MaybeSource.awaitSingleOrNull]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await-single-or-null.html
 [io.reactivex.rxjava3.core.SingleSource.await]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await.html
 [io.reactivex.rxjava3.core.ObservableSource.awaitFirst]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await-first.html
 [io.reactivex.rxjava3.core.ObservableSource.awaitFirstOrDefault]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/await-first-or-default.html

--- a/reactive/kotlinx-coroutines-rx3/src/RxAwait.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxAwait.kt
@@ -76,6 +76,8 @@ public suspend fun <T> MaybeSource<T>.awaitSingle(): T = awaitSingleOrNull() ?: 
  *
  * Deprecated in favor of [awaitSingleOrNull] in order to reflect that `null` can be returned to denote the absence of
  * a value, as opposed to throwing in such case.
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated in favor of awaitSingleOrNull()",
@@ -97,6 +99,8 @@ public suspend fun <T> MaybeSource<T>.await(): T? = awaitSingleOrNull()
  *
  * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of [MaybeSource.await] for
  * details).
+ *
+ * @suppress
  */
 @Deprecated(
     message = "Deprecated in favor of awaitSingleOrNull()",

--- a/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
@@ -147,7 +147,7 @@ public fun <T: Any> Flow<T>.asFlowable(context: CoroutineContext = EmptyCoroutin
 public fun <T: Any> Flow<T>._asFlowable(context: CoroutineContext = EmptyCoroutineContext): Flowable<T> =
     asFlowable(context)
 
-/* @suppress */
+/** @suppress */
 @Suppress("UNUSED") // KT-42513
 @JvmOverloads // binary compatibility
 @JvmName("from")

--- a/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxConvert.kt
@@ -139,6 +139,7 @@ public fun <T: Any> Flow<T>.asObservable(context: CoroutineContext = EmptyCorout
 public fun <T: Any> Flow<T>.asFlowable(context: CoroutineContext = EmptyCoroutineContext): Flowable<T> =
     Flowable.fromPublisher(asPublisher(context))
 
+/** @suppress */
 @Suppress("UNUSED") // KT-42513
 @JvmOverloads // binary compatibility
 @JvmName("from")
@@ -146,6 +147,7 @@ public fun <T: Any> Flow<T>.asFlowable(context: CoroutineContext = EmptyCoroutin
 public fun <T: Any> Flow<T>._asFlowable(context: CoroutineContext = EmptyCoroutineContext): Flowable<T> =
     asFlowable(context)
 
+/* @suppress */
 @Suppress("UNUSED") // KT-42513
 @JvmOverloads // binary compatibility
 @JvmName("from")

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -120,7 +120,7 @@ internal class HandlerContext private constructor(
      * @param handler a handler.
      * @param name an optional name for debugging.
      */
-    public constructor(
+    constructor(
         handler: Handler,
         name: String? = null
     ) : this(handler, name, false)


### PR DESCRIPTION
* Do not generate Dokka documentation for deprecated members
* Get rid of inline classes notation 
* Opt-in into DelicateCoroutineApi in our own project
* Get rid of JVM IR checks that are no longer relevant