### PR TITLE
docs: fix ToC and add module name

### DIFF
--- a/docs/kc.tree
+++ b/docs/kc.tree
@@ -8,7 +8,6 @@
                  start-page="coroutines-guide.md">
 
     <toc-element id="coroutines-guide.md"/>
-    <toc-element id="async-programming.md"/>
     <toc-element id="coroutines-basics.md" accepts-web-file-names="basics.html,coroutines-basic-jvm.html"/>
     <toc-element toc-title="Intro to coroutines and channels – hands-on tutorial" href="https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels/"/>
     <toc-element id="cancellation-and-timeouts.md"/>

--- a/docs/project.ihp
+++ b/docs/project.ihp
@@ -3,6 +3,7 @@
 
 <ihp version="2.0">
     <categories src="c.list"/>
+    <module name="coroutines"/>
     <topics dir="topics"/>
     <images dir="images" web-path="/img/kotlin-coroutines/"/>
     <vars src="v.list"/>


### PR DESCRIPTION
- remove `async-programming.md` (stored in kotlin-web-site) from coroutines Table of Contents
- specify unique WebHelp module name to allow building help together with kotlin-web-site.