### PR TITLE
Introduced newSingleThreadContext and DefaultDispatcher backed with a worker

### DIFF
--- a/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
@@ -123,6 +123,6 @@ public abstract class AbstractCoroutine<in T>(
      * * [LAZY] does nothing.
      */
     public fun <R> start(start: CoroutineStart, receiver: R, block: suspend R.() -> T) {
-        start(block, receiver, this)
+        startAbstractCoroutine(start, receiver, this, block)
     }
 }

--- a/kotlinx-coroutines-core/concurrent/src/SingleThread.common.kt
+++ b/kotlinx-coroutines-core/concurrent/src/SingleThread.common.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+/**
+ * Creates a coroutine execution context using a single thread.
+ */
+@ExperimentalCoroutinesApi
+public expect fun newSingleThreadContext(name: String): SingleThreadDispatcher
+
+/**
+ * A coroutine dispatcher that is confined to a single thread.
+ */
+@ExperimentalCoroutinesApi
+public expect abstract class SingleThreadDispatcher : CoroutineDispatcher {
+    /**
+     * Closes this coroutine dispatcher and shuts down its thread.
+     */
+    @ExperimentalCoroutinesApi
+    public abstract fun close()
+}

--- a/kotlinx-coroutines-core/js/src/Builders.kt
+++ b/kotlinx-coroutines-core/js/src/Builders.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T, R> startAbstractCoroutine(
+    start: CoroutineStart,
+    receiver: R,
+    coroutine: AbstractCoroutine<T>,
+    noinline block: suspend R.() -> T
+) = startCoroutineImpl(start, receiver, coroutine, null, block)

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -8,7 +8,6 @@
 
 package kotlinx.coroutines
 
-import java.util.concurrent.locks.*
 import kotlin.contracts.*
 import kotlin.coroutines.*
 
@@ -99,3 +98,11 @@ private class BlockingCoroutine<T>(
         return state as T
     }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T, R> startAbstractCoroutine(
+    start: CoroutineStart,
+    receiver: R,
+    coroutine: AbstractCoroutine<T>,
+    noinline block: suspend R.() -> T
+) = startCoroutineImpl(start, receiver, coroutine, null, block)

--- a/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
@@ -30,8 +30,13 @@ import java.util.concurrent.atomic.AtomicInteger
  * @param name the base name of the created thread.
  */
 @ObsoleteCoroutinesApi
-public fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher =
+public actual fun newSingleThreadContext(name: String): ExecutorCoroutineDispatcher =
     newFixedThreadPoolContext(1, name)
+
+/**
+ * A coroutine dispatcher that is confined to a single thread.
+ */
+public actual typealias SingleThreadDispatcher = ExecutorCoroutineDispatcher
 
 /**
  * Creates a coroutine execution context with the fixed-size thread-pool and built-in [yield] support.

--- a/kotlinx-coroutines-core/native/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/native/src/CoroutineContext.kt
@@ -25,16 +25,14 @@ internal actual object DefaultExecutor : CoroutineDispatcher(), Delay {
 
 internal fun loopWasShutDown(): Nothing = error("Cannot execute task because event loop was shut down")
 
-internal actual fun createDefaultDispatcher(): CoroutineDispatcher =
-    DefaultExecutor
+internal actual fun createDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
-@SharedImmutable
 internal actual val DefaultDelay: Delay = DefaultExecutor
 
 public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext {
     val combined = coroutineContext + context
-    return if (combined !== DefaultExecutor && combined[ContinuationInterceptor] == null)
-        combined + DefaultExecutor else combined
+    return if (combined !== Dispatchers.Default && combined[ContinuationInterceptor] == null)
+        combined + Dispatchers.Default else combined
 }
 
 // No debugging facilities on native

--- a/kotlinx-coroutines-core/native/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/native/src/Dispatchers.kt
@@ -4,19 +4,43 @@
 
 package kotlinx.coroutines
 
+import kotlinx.atomicfu.*
+import kotlinx.atomicfu.locks.*
 import kotlin.coroutines.*
 
 public actual object Dispatchers {
-    public actual val Default: CoroutineDispatcher = createDefaultDispatcher()
-    public actual val Main: MainCoroutineDispatcher = NativeMainDispatcher(Default)
-    public actual val Unconfined: CoroutineDispatcher get() = kotlinx.coroutines.Unconfined // Avoid freezing
+    public actual val Default: CoroutineDispatcher get() = DefaultDispatcher
+    public actual val Main: MainCoroutineDispatcher = createMainDispatcher(Default)
+    public actual val Unconfined: CoroutineDispatcher get() = kotlinx.coroutines.Unconfined
 }
 
-private class NativeMainDispatcher(val delegate: CoroutineDispatcher) : MainCoroutineDispatcher() {
-    override val immediate: MainCoroutineDispatcher
-        get() = throw UnsupportedOperationException("Immediate dispatching is not supported on Native")
-    override fun dispatch(context: CoroutineContext, block: Runnable) = delegate.dispatch(context, block)
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean = delegate.isDispatchNeeded(context)
-    override fun dispatchYield(context: CoroutineContext, block: Runnable) = delegate.dispatchYield(context, block)
-    override fun toString(): String = toStringInternalImpl() ?: delegate.toString()
+internal expect fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher
+
+// Create DefaultDispatcher thread only when explicitly requested
+internal object DefaultDispatcher : CoroutineDispatcher(), Delay, ThreadBoundInterceptor {
+    private val lock = reentrantLock()
+    private val _delegate = atomic<SingleThreadDispatcher?>(null)
+
+    private val delegate: SingleThreadDispatcher
+        get() = _delegate.value ?: getOrCreateDefaultDispatcher()
+
+    private fun getOrCreateDefaultDispatcher() = lock.withLock {
+        _delegate.value ?: newSingleThreadContext("DefaultDispatcher").also { _delegate.value = it }
+    }
+
+    override val thread: Thread
+        get() = delegate.thread
+    override fun dispatch(context: CoroutineContext, block: Runnable) =
+        delegate.dispatch(context, block)
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) =
+        (delegate as Delay).scheduleResumeAfterDelay(timeMillis, continuation)
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
+        (delegate as Delay).invokeOnTimeout(timeMillis, block, context)
+    override fun toString(): String =
+        delegate.toString()
+
+    // only for tests
+    internal fun shutdown() {
+        _delegate.getAndSet(null)?.close()
+    }
 }

--- a/kotlinx-coroutines-core/native/src/Thread.native.kt
+++ b/kotlinx-coroutines-core/native/src/Thread.native.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.native.concurrent.*
+
+internal abstract class Thread {
+    abstract fun execute(block: () -> Unit)
+    abstract fun parkNanos(timeout: Long)
+}
+
+@ThreadLocal
+private val currentThread: Thread = initCurrentThread()
+
+internal fun currentThread(): Thread = currentThread
+
+internal expect fun initCurrentThread(): Thread
+
+internal expect fun Worker.toThread(): Thread
+
+internal fun Worker.execute(block: () -> Unit) {
+    executeAfter(0, block)
+}
+
+internal open class WorkerThread(val worker: Worker = Worker.current) : Thread() {
+    override fun execute(block: () -> Unit) = worker.execute(block)
+
+    override fun parkNanos(timeout: Long) {
+        // Note: worker is parked in microseconds
+        worker.park(timeout / 1000L, process = true)
+    }
+
+    override fun equals(other: Any?): Boolean = other is WorkerThread && other.worker == worker
+    override fun hashCode(): Int = worker.hashCode()
+    override fun toString(): String = worker.name
+}
+
+internal interface ThreadBoundInterceptor {
+    val thread: Thread
+}
+
+internal fun ThreadBoundInterceptor.checkCurrentThread() {
+    val current = currentThread()
+    check(current == thread) { "This dispatcher can be used only from a single thread $thread, but now in $current" }
+}

--- a/kotlinx-coroutines-core/native/src/Thread.native.kt
+++ b/kotlinx-coroutines-core/native/src/Thread.native.kt
@@ -40,8 +40,3 @@ internal open class WorkerThread(val worker: Worker = Worker.current) : Thread()
 internal interface ThreadBoundInterceptor {
     val thread: Thread
 }
-
-internal fun ThreadBoundInterceptor.checkCurrentThread() {
-    val current = currentThread()
-    check(current == thread) { "This dispatcher can be used only from a single thread $thread, but now in $current" }
-}

--- a/kotlinx-coroutines-core/native/src/Workers.kt
+++ b/kotlinx-coroutines-core/native/src/Workers.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.atomicfu.*
+import kotlin.coroutines.*
+import kotlin.native.concurrent.*
+
+/**
+ * Creates a coroutine execution context using a single thread.
+ */
+@ExperimentalCoroutinesApi
+public actual fun newSingleThreadContext(name: String): SingleThreadDispatcher =
+    WorkerCoroutineDispatcherImpl(name).apply { start() }
+
+/**
+ * A coroutine dispatcher that is confined to a single thread.
+ */
+@ExperimentalCoroutinesApi
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+public actual abstract class SingleThreadDispatcher : CoroutineDispatcher() {
+    /**
+     * A reference to this dispatcher's worker.
+     */
+    @ExperimentalCoroutinesApi
+    public abstract val worker: Worker
+
+    internal abstract val thread: Thread
+
+    /**
+     * Closes this coroutine dispatcher and shuts down its thread.
+     */
+    @ExperimentalCoroutinesApi
+    public actual abstract fun close()
+}
+
+private class WorkerCoroutineDispatcherImpl(name: String) : SingleThreadDispatcher(), ThreadBoundInterceptor, Delay {
+    override val worker = Worker.start(name = name)
+    override val thread = WorkerThread(worker)
+    private val isClosed = atomic(false)
+
+    fun start() {
+        worker.execute {
+            workerMain {
+                runEventLoop(ThreadLocalEventLoop.eventLoop) { isClosed.value }
+            }
+        }
+    }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        checkCurrentThread()
+        (ThreadLocalEventLoop.eventLoop as Delay).scheduleResumeAfterDelay(timeMillis, continuation)
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
+        checkCurrentThread()
+        return (ThreadLocalEventLoop.eventLoop as Delay).invokeOnTimeout(timeMillis, block, context)
+    }
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        checkCurrentThread()
+        ThreadLocalEventLoop.eventLoop.dispatch(context, block)
+    }
+
+    override fun close() {
+        isClosed.value = true
+        worker.requestTermination().result // Note: calling "result" blocks
+    }
+}

--- a/kotlinx-coroutines-core/native/src/Workers.kt
+++ b/kotlinx-coroutines-core/native/src/Workers.kt
@@ -49,20 +49,14 @@ private class WorkerCoroutineDispatcherImpl(name: String) : SingleThreadDispatch
         }
     }
 
-    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
-        checkCurrentThread()
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) =
         (ThreadLocalEventLoop.eventLoop as Delay).scheduleResumeAfterDelay(timeMillis, continuation)
-    }
 
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
-        checkCurrentThread()
-        return (ThreadLocalEventLoop.eventLoop as Delay).invokeOnTimeout(timeMillis, block, context)
-    }
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
+        (ThreadLocalEventLoop.eventLoop as Delay).invokeOnTimeout(timeMillis, block, context)
 
-    override fun dispatch(context: CoroutineContext, block: Runnable) {
-        checkCurrentThread()
+    override fun dispatch(context: CoroutineContext, block: Runnable) =
         ThreadLocalEventLoop.eventLoop.dispatch(context, block)
-    }
 
     override fun close() {
         isClosed.value = true

--- a/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.cinterop.*
+import platform.CoreFoundation.*
+import platform.darwin.*
+import kotlin.coroutines.*
+import kotlin.native.concurrent.*
+import kotlin.native.internal.NativePtr
+
+internal fun isMainThread(): Boolean = CFRunLoopGetCurrent() == CFRunLoopGetMain()
+
+internal actual fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher =
+    DarwinMainDispatcher(false)
+
+@Suppress("EXPERIMENTAL_UNSIGNED_LITERALS")
+private class DarwinMainDispatcher(
+    private val invokeImmediately: Boolean
+) : MainCoroutineDispatcher(), Delay, ThreadBoundInterceptor {
+    override val thread
+        get() = mainThread
+
+    override val immediate: MainCoroutineDispatcher =
+        if (invokeImmediately) this else DarwinMainDispatcher(true)
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean = !(invokeImmediately && isMainThread())
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatch_async(dispatch_get_main_queue()) {
+            block.run()
+        }
+    }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        val timer = Timer()
+        val timerBlock: TimerBlock = {
+            timer.dispose()
+            continuation.resume(Unit)
+        }
+        timer.start(timeMillis, timerBlock)
+        continuation.disposeOnCancellation(timer)
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
+        val timer = Timer()
+        val timerBlock: TimerBlock = {
+            timer.dispose()
+            block.run()
+        }
+        timer.start(timeMillis, timerBlock)
+        return timer
+    }
+
+    override fun toString(): String =
+        "MainDispatcher${ if(invokeImmediately) "[immediate]" else "" }"
+}
+
+internal typealias TimerBlock = (CFRunLoopTimerRef?) -> Unit
+
+private val TIMER_NEW = NativePtr.NULL
+
+private val TIMER_DISPOSED = NativePtr.NULL.plus(1)
+
+private class Timer : DisposableHandle {
+    private val ref = AtomicNativePtr(TIMER_NEW)
+
+    fun start(timeMillis: Long, timerBlock: TimerBlock) {
+        val fireDate = CFAbsoluteTimeGetCurrent() + timeMillis / 1000.0
+        @Suppress("EXPERIMENTAL_UNSIGNED_LITERALS")
+        val timer = CFRunLoopTimerCreateWithHandler(null, fireDate, 0.0, 0u, 0, timerBlock)
+        CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes)
+        if (!ref.compareAndSet(TIMER_NEW, timer.rawValue)) {
+            // dispose was already called concurrently
+            release(timer)
+        }
+    }
+
+    override fun dispose() {
+        while (true) {
+            val ptr = ref.value
+            if (ptr == TIMER_DISPOSED) return
+            if (ref.compareAndSet(ptr, TIMER_DISPOSED)) {
+                if (ptr != TIMER_NEW) release(interpretCPointer(ptr))
+                return
+            }
+        }
+    }
+
+    private fun release(timer: CFRunLoopTimerRef?) {
+        CFRunLoopRemoveTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes)
+        CFRelease(timer)
+    }
+}

--- a/kotlinx-coroutines-core/nativeDarwin/src/Thread.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Thread.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlinx.atomicfu.*
+import kotlinx.cinterop.*
+import platform.CoreFoundation.*
+import platform.darwin.*
+import kotlin.native.concurrent.*
+
+/**
+ * Initializes the main thread. Must be called from the main thread if the application's interaction
+ * with Kotlin runtime and coroutines API otherwise starts from background threads.
+ */
+@ExperimentalCoroutinesApi
+public fun initMainThread() {
+    getOrCreateMainThread()
+}
+
+internal actual fun initCurrentThread(): Thread =
+    if (isMainThread()) mainThread else WorkerThread()
+
+internal actual fun Worker.toThread(): Thread =
+    if (this == mainThread.worker) mainThread else WorkerThread(this)
+
+private val _mainThread = atomic<MainThread?>(null)
+
+internal val mainThread: MainThread get() = _mainThread.value ?: getOrCreateMainThread()
+
+private fun getOrCreateMainThread(): MainThread {
+    require(isMainThread()) {
+        "Coroutines must be initialized from the main thread: call 'initMainThread' from the main thread first"
+    }
+    _mainThread.value?.let { return it }
+    return MainThread().also { _mainThread.value = it }
+}
+
+internal class MainThread : WorkerThread() {
+    private val posted = atomic(false)
+
+    private val processQueueBlock: dispatch_block_t =  {
+        posted.value = false // next execute will post a fresh task
+        while (worker.processQueue()) { /* process all */ }
+    }
+
+    override fun execute(block: () -> Unit) {
+        super.execute(block)
+        // post to main queue if needed
+        if (posted.compareAndSet(false, true)) {
+            dispatch_async(dispatch_get_main_queue(), processQueueBlock)
+        }
+    }
+
+    fun shutdown() {
+        // Cleanup posted processQueueBlock
+        execute {
+            CFRunLoopStop(CFRunLoopGetCurrent())
+        }
+        CFRunLoopRun()
+        assert(!posted.value) // nothing else should have been posted
+    }
+
+    override fun toString(): String = "MainThread"
+}

--- a/kotlinx-coroutines-core/nativeDarwin/test/Launcher.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/test/Launcher.kt
@@ -22,7 +22,10 @@ fun mainBackground(args: Array<String>) {
 
 // This is a separate entry point for tests with leak checker
 fun mainNoExit(args: Array<String>) {
+    Platform.isMemoryLeakCheckerActive = true
     workerMain { // autoreleasepool to make sure interop objects are properly freed
         testLauncherEntryPoint(args)
+        mainThread.shutdown()
+        DefaultDispatcher.shutdown()
     }
 }

--- a/kotlinx-coroutines-core/nativeOther/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeOther/src/Dispatchers.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.coroutines.*
+
+internal actual fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher =
+    NativeMainDispatcher(default)
+
+private class NativeMainDispatcher(val delegate: CoroutineDispatcher) : MainCoroutineDispatcher() {
+    override val immediate: MainCoroutineDispatcher
+        get() = throw UnsupportedOperationException("Immediate dispatching is not supported on this platform")
+    override fun dispatch(context: CoroutineContext, block: Runnable) = delegate.dispatch(context, block)
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean = delegate.isDispatchNeeded(context)
+    override fun dispatchYield(context: CoroutineContext, block: Runnable) = delegate.dispatchYield(context, block)
+    override fun toString(): String = toStringInternalImpl() ?: delegate.toString()
+}

--- a/kotlinx-coroutines-core/nativeOther/src/Thread.kt
+++ b/kotlinx-coroutines-core/nativeOther/src/Thread.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines
+
+import kotlin.native.concurrent.*
+
+internal actual fun initCurrentThread(): Thread = WorkerThread()
+
+internal actual fun Worker.toThread(): Thread = WorkerThread(this)


### PR DESCRIPTION
Making dispatchers actually multithreaded: `newSingleThreadContext` and  `Dispatchers.Default` backed by a worker
#2797 