### PR TITLE
Add linuxArm32Hfp and linuxArm64 build targets

### DIFF
--- a/gradle/compile-native-multiplatform.gradle
+++ b/gradle/compile-native-multiplatform.gradle
@@ -14,6 +14,8 @@ kotlin {
 
     targets {
         addTarget(presets.linuxX64)
+        addTarget(presets.linuxArm32Hfp)
+        addTarget(presets.linuxArm64)
         addTarget(presets.iosArm64)
         addTarget(presets.iosArm32)
         addTarget(presets.iosX64)

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -96,8 +96,10 @@ kotlin {
                     freeCompilerArgs += ["-e", "kotlinx.coroutines.mainBackground"]
                 }
             }
-            testRuns {
-                background { setExecutionSourceFrom(binaries.backgroundDebugTest) }
+            if (!(it instanceof org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget) || (it instanceof org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithHostTests)) {
+                testRuns {
+                    background { setExecutionSourceFrom(binaries.backgroundDebugTest) }
+                }
             }
         }
     }


### PR DESCRIPTION
Note: depends on kotlinx.atomicfu ARM builds (PR for support here: https://github.com/Kotlin/kotlinx.atomicfu/pull/193 )