### PR TITLE
Create r8 specific proguard rules for kotlin.coroutines.core

### DIFF
--- a/docs/kc.tree
+++ b/docs/kc.tree
@@ -7,18 +7,19 @@
                  name="Kotlin coroutines"
                  start-page="coroutines-guide.md">
 
-    <toc-element id="coroutines-guide.md"/>
-    <toc-element id="coroutines-basics.md" accepts-web-file-names="basics.html,coroutines-basic-jvm.html"/>
-    <toc-element toc-title="Intro to coroutines and channels – hands-on tutorial" href="https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels/"/>
-    <toc-element id="cancellation-and-timeouts.md"/>
-    <toc-element id="composing-suspending-functions.md"/>
-    <toc-element id="coroutine-context-and-dispatchers.md"/>
-    <toc-element id="flow.md"/>
-    <toc-element id="channels.md"/>
-    <toc-element id="exception-handling.md"/>
-    <toc-element id="shared-mutable-state-and-concurrency.md"/>
-    <toc-element id="select-expression.md"/>
-    <toc-element id="debug-coroutines-with-idea.md"/>
-    <toc-element id="debug-flow-with-idea.md"/>
-
+    <chunk include-id="coroutines">
+        <toc-element id="coroutines-guide.md"/>
+        <toc-element id="coroutines-basics.md" accepts-web-file-names="basics.html,coroutines-basic-jvm.html"/>
+        <toc-element toc-title="Intro to coroutines and channels – hands-on tutorial" href="https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels/"/>
+        <toc-element id="cancellation-and-timeouts.md"/>
+        <toc-element id="composing-suspending-functions.md"/>
+        <toc-element id="coroutine-context-and-dispatchers.md"/>
+        <toc-element id="flow.md"/>
+        <toc-element id="channels.md"/>
+        <toc-element id="exception-handling.md"/>
+        <toc-element id="shared-mutable-state-and-concurrency.md"/>
+        <toc-element id="select-expression.md"/>
+        <toc-element id="debug-coroutines-with-idea.md"/>
+        <toc-element id="debug-flow-with-idea.md"/>
+    </chunk>
 </product-profile>

--- a/docs/kc.tree
+++ b/docs/kc.tree
@@ -8,7 +8,6 @@
                  start-page="coroutines-guide.md">
 
     <toc-element id="coroutines-guide.md"/>
-    <toc-element id="async-programming.md"/>
     <toc-element id="coroutines-basics.md" accepts-web-file-names="basics.html,coroutines-basic-jvm.html"/>
     <toc-element toc-title="Intro to coroutines and channels – hands-on tutorial" href="https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels/"/>
     <toc-element id="cancellation-and-timeouts.md"/>

--- a/docs/project.ihp
+++ b/docs/project.ihp
@@ -3,6 +3,7 @@
 
 <ihp version="2.0">
     <categories src="c.list"/>
+    <module name="coroutines"/>
     <topics dir="topics"/>
     <images dir="images" web-path="/img/kotlin-coroutines/"/>
     <vars src="v.list"/>

--- a/docs/topics/flow.md
+++ b/docs/topics/flow.md
@@ -157,7 +157,7 @@ Notice the following differences in the code with the [Flow] from the earlier ex
 * Values are _emitted_ from the flow using [emit][FlowCollector.emit] function.
 * Values are _collected_ from the flow using [collect][collect] function.  
 
-> We can replace [delay] with `Thread.sleep` in the body of `foo`'s `flow { ... }` and see that the main
+> We can replace [delay] with `Thread.sleep` in the body of `simple`'s `flow { ... }` and see that the main
 > thread is blocked in this case. 
 >
 {type="note"}

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -93,7 +93,7 @@ public fun <T, R> Flow<T>.scan(initial: R, @BuilderInference operation: suspend 
  * Note that initial value should be immutable (or should not be mutated) as it is shared between different collectors.
  * For example:
  * ```
- * flowOf(1, 2, 3).scan(emptyList<Int>()) { acc, value -> acc + value }.toList()
+ * flowOf(1, 2, 3).runningFold(emptyList<Int>()) { acc, value -> acc + value }.toList()
  * ```
  * will produce `[], [1], [1, 2], [1, 2, 3]]`.
  */

--- a/kotlinx-coroutines-core/jvm/resources/META-INF/r8/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/r8/coroutines.pro
@@ -1,0 +1,16 @@
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# Same story for the standard library's SafeContinuation that also uses AtomicReferenceFieldUpdater
+-keepclassmembers class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}
+
+# These classes are only required by kotlinx.coroutines.debug.AgentPremain, which is only loaded when
+# kotlinx-coroutines-core is used as a Java agent, so these are not needed in contexts where ProGuard is used.
+-dontwarn java.lang.instrument.ClassFileTransformer
+-dontwarn sun.misc.SignalHandler
+-dontwarn java.lang.instrument.Instrumentation
+-dontwarn sun.misc.Signal


### PR DESCRIPTION
This CL removes the -keepnames rule for service loader classes to allow R8 to optimize them.