### PR TITLE
Create R8 specific to allow for service loader optimizations

### DIFF
--- a/kotlinx-coroutines-core/jvm/resources/META-INF/r8/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/r8/coroutines.pro
@@ -1,0 +1,16 @@
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# Same story for the standard library's SafeContinuation that also uses AtomicReferenceFieldUpdater
+-keepclassmembers class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}
+
+# These classes are only required by kotlinx.coroutines.debug.AgentPremain, which is only loaded when
+# kotlinx-coroutines-core is used as a Java agent, so these are not needed in contexts where ProGuard is used.
+-dontwarn java.lang.instrument.ClassFileTransformer
+-dontwarn sun.misc.SignalHandler
+-dontwarn java.lang.instrument.Instrumentation
+-dontwarn sun.misc.Signal


### PR DESCRIPTION
Creating R8 specific rules will allow Proguard to continue to work while allow R8 to remove the ServiceLoaders.