### PR TITLE
Update DebugProbesKt.bin exclusion instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ normally and is only used by the debugger. To exclude it at no loss of functiona
 `android` block in your Gradle file for the application subproject:
 ```groovy
 packagingOptions {
-  exclude "DebugProbesKt.bin"
+    resources.excludes += "DebugProbesKt.bin"
 }
 ```
 


### PR DESCRIPTION
raw exclude call is now deprecated and gives the following warning,
```
  This property is deprecated. Use resources.excludes or jniLibs.excludes instead. Use
  jniLibs.excludes for .so file patterns, and use resources.excludes for all
  other file patterns.
```

Tested and works as expected here https://github.com/persian-calendar/DroidPersianCalendar/commit/b4c21e0d1eb4ea8f0a93e56de2f56793fa442608