### PR TITLE
Fix typo in the documentation of CompletableJob#complete

### DIFF
--- a/kotlinx-coroutines-core/common/src/CompletableJob.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableJob.kt
@@ -21,7 +21,7 @@ public interface CompletableJob : Job {
      *
      * Subsequent invocations of this function have no effect and always produce `false`.
      *
-     * This function transitions this job into _completed- state if it was not completed or cancelled yet.
+     * This function transitions this job into _completed_ state if it was not completed or cancelled yet.
      * However, that if this job has children, then it transitions into _completing_ state and becomes _complete_
      * once all its children are [complete][isCompleted]. See [Job] for details.
      */


### PR DESCRIPTION
Within given PR a typo correction for documentation of `CompletableJob#complete` method is performed. Markdown markup contained a mistake  (`_completed-` -> `_completed_`).