### PR TITLE
Move `isInstalledStatically` field to a separate object

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
@@ -5,6 +5,7 @@
 package kotlinx.coroutines.debug
 
 import kotlinx.coroutines.debug.internal.DebugProbesImpl
+import kotlinx.coroutines.debug.internal.AgentInstallationType
 import sun.misc.*
 import java.lang.instrument.*
 import java.lang.instrument.ClassFileTransformer
@@ -19,15 +20,13 @@ import android.annotation.*
 @SuppressLint("all")
 internal object AgentPremain {
 
-    public var isInstalledStatically = false
-
     private val enableCreationStackTraces = runCatching {
         System.getProperty("kotlinx.coroutines.debug.enable.creation.stack.trace")?.toBoolean()
     }.getOrNull() ?: DebugProbesImpl.enableCreationStackTraces
 
     @JvmStatic
     public fun premain(args: String?, instrumentation: Instrumentation) {
-        isInstalledStatically = true
+        AgentInstallationType.isInstalledStatically = true
         instrumentation.addTransformer(DebugProbesTransformer)
         DebugProbesImpl.enableCreationStackTraces = enableCreationStackTraces
         DebugProbesImpl.install()
@@ -52,7 +51,7 @@ internal object AgentPremain {
              * on the fly (-> get rid of ASM dependency).
              * You can verify its content either by using javap on it or looking at out integration test module.
              */
-            isInstalledStatically = true
+            AgentInstallationType.isInstalledStatically = true
             return loader.getResourceAsStream("DebugProbesKt.bin").readBytes()
         }
     }

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/AgentInstallationType.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/AgentInstallationType.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.debug.internal
+
+/**
+ * Object used to differentiate between agent installed statically or dinamically.
+ * This is done in a separate object so [DebugProbesImpl] can check for static installation
+ * without having to depend on [AgentPremain], which is not compatible with Android.
+ */
+internal object AgentInstallationType {
+    internal var isInstalledStatically = false
+}

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -82,7 +82,7 @@ internal object DebugProbesImpl {
     public fun install(): Unit = coroutineStateLock.write {
         if (++installations > 1) return
         startWeakRefCleanerThread()
-        if (AgentPremain.isInstalledStatically) return
+        if (AgentInstallationType.isInstalledStatically) return
         dynamicAttach?.invoke(true) // attach
     }
 
@@ -92,7 +92,7 @@ internal object DebugProbesImpl {
         stopWeakRefCleanerThread()
         capturedCoroutinesMap.clear()
         callerInfoCache.clear()
-        if (AgentPremain.isInstalledStatically) return
+        if (AgentInstallationType.isInstalledStatically) return
         dynamicAttach?.invoke(false) // detach
     }
 


### PR DESCRIPTION
By doing this DebugProbesImpl can check for static installation without having to depend on AgentPremain, which is not compatible with Android.