### PR TITLE
Make 100k coroutine sample runnable

### DIFF
--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -263,6 +263,7 @@ fun main() = runBlocking {
 }
 //sampleEnd
 ```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt).
 >


### PR DESCRIPTION
This should fix a few problems with this example:
1. The `//sampleStart` comments were showing up, when I think they were supposed to not
2. This code section is the only one that's not runnable. If this is cheap, feels like this should be runnable in browser?

![image](https://user-images.githubusercontent.com/105529/132971377-6872c843-1bb8-4e2e-a89d-cd3e0aa2913e.png)
