### PR TITLE
Fix -Poverwrite.probes not being propagated to the test

### DIFF
--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -81,6 +81,7 @@ task debugAgentTest(type: Test) {
     jvmArgs ('-javaagent:' + project(':kotlinx-coroutines-debug').shadowJar.outputs.files.getFiles()[0])
     testClassesDirs = sourceSet.output.classesDirs
     classpath = sourceSet.runtimeClasspath
+    systemProperties project.properties.subMap(["overwrite.probes"])
 }
 
 task coreAgentTest(type: Test) {


### PR DESCRIPTION
This affected `PrecompiledDebugProbesTest#testClassFileContent`.