### PR TITLE
Introduce animalsniffer checks to coroutines and compile against Java…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,21 +2,13 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.konan.target.HostManager
-import org.gradle.util.VersionNumber
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 apply plugin: 'jdk-convention'
 apply from: rootProject.file("gradle/opt-in.gradle")
-
-def coreModule = "kotlinx-coroutines-core"
-// Not applicable for Kotlin plugin
-def sourceless = ['kotlinx.coroutines', 'kotlinx-coroutines-bom', 'integration-testing']
-def internal = ['kotlinx.coroutines', 'benchmarks', 'integration-testing']
-// Not published
-def unpublished = internal + ['example-frontend-js', 'android-unit-tests']
 
 buildscript {
     /*
@@ -61,6 +53,7 @@ buildscript {
         classpath "org.jetbrains.kotlinx:kotlinx-knit:$knit_version"
         classpath "com.moowork.gradle:gradle-node-plugin:$gradle_node_version"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
+        classpath "ru.vyarus:gradle-animalsniffer-plugin:1.5.3" // Android API check
 
         // JMH plugins
         classpath "com.github.jengelman.gradle.plugins:shadow:5.1.0"
@@ -96,7 +89,7 @@ allprojects {
         kotlin_version = rootProject.properties['kotlin_snapshot_version']
     }
 
-    ext.unpublished = unpublished
+    ext.unpublished = Projects.unpublished
 
     // This project property is set during nightly stress test
     def stressTest = project.properties['stressTest']
@@ -108,6 +101,8 @@ allprojects {
 }
 
 apply plugin: "binary-compatibility-validator"
+apply plugin: 'base'
+
 apiValidation {
     ignoredProjects += unpublished + ["kotlinx-coroutines-bom"]
     if (build_snapshot_train) {
@@ -131,20 +126,20 @@ allprojects {
 }
 
 // Add dependency to core source sets. Core is configured in kx-core/build.gradle
-configure(subprojects.findAll { !sourceless.contains(it.name) && it.name != coreModule }) {
-    evaluationDependsOn(":$coreModule")
+configure(subprojects.findAll { !Projects.sourceless.contains(it.name) && it.name != Projects.coreModule }) {
+    evaluationDependsOn(":$Projects.coreModule")
     def platform = PlatformKt.platformOf(it)
     apply plugin: "kotlin-${platform}-conventions"
     dependencies {
         // See comment below for rationale, it will be replaced with "project" dependency
-        api project(":$coreModule")
+        api project(":$Projects.coreModule")
         // the only way IDEA can resolve test classes
-        testImplementation project(":$coreModule").kotlin.targets.jvm.compilations.test.output.allOutputs
+        testImplementation project(":$Projects.coreModule").kotlin.targets.jvm.compilations.test.output.allOutputs
     }
 }
 
 // Configure subprojects with Kotlin sources
-configure(subprojects.findAll { !sourceless.contains(it.name) }) {
+configure(subprojects.findAll { !Projects.sourceless.contains(it.name) }) {
     // Use atomicfu plugin, it also adds all the necessary dependencies
     apply plugin: 'kotlinx-atomicfu'
 
@@ -194,9 +189,9 @@ if (build_snapshot_train) {
 
 // Redefine source sets because we are not using 'kotlin/main/fqn' folder convention
 configure(subprojects.findAll {
-    !sourceless.contains(it.name) &&
+    !Projects.sourceless.contains(it.name) &&
             it.name != "benchmarks" &&
-            it.name != coreModule &&
+            it.name != Projects.coreModule &&
             it.name != "example-frontend-js"
 }) {
     // Pure JS and pure MPP doesn't have this notion and are configured separately
@@ -209,7 +204,7 @@ configure(subprojects.findAll {
     }
 }
 
-def core_docs_url = "https://kotlin.github.io/kotlinx.coroutines/$coreModule/"
+def core_docs_url = "https://kotlin.github.io/kotlinx.coroutines/$Projects.coreModule/"
 def core_docs_file = "$projectDir/kotlinx-coroutines-core/build/dokka/htmlPartial/package-list"
 apply plugin: "org.jetbrains.dokka"
 
@@ -222,7 +217,7 @@ configure(subprojects.findAll { !unpublished.contains(it.name) }) {
 
 configure(subprojects.findAll { !unpublished.contains(it.name) }) {
     if (it.name != "kotlinx-coroutines-bom") {
-        if (it.name != coreModule) {
+        if (it.name != Projects.coreModule) {
             tasks.withType(DokkaTaskPartial.class) {
                 dokkaSourceSets.configureEach {
                     externalDocumentationLink {
@@ -235,7 +230,7 @@ configure(subprojects.findAll { !unpublished.contains(it.name) }) {
     }
 
     def thisProject = it
-    if (thisProject.name in sourceless) {
+    if (thisProject.name in Projects.sourceless) {
         return
     }
 
@@ -284,7 +279,7 @@ def publishTasks = getTasksByName("publish", true) + getTasksByName("publishNpm"
 
 task deploy(dependsOn: publishTasks)
 
-apply plugin: 'base'
+apply plugin: 'animalsniffer-convention'
 
 clean.dependsOn gradle.includedBuilds.collect { it.task(':clean') }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -46,4 +46,5 @@ dependencies {
     implementation(kotlin("gradle-plugin", version("kotlin")))
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${version("dokka")}")
     implementation("org.jetbrains.dokka:dokka-core:${version("dokka")}")
+    implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.3") // Android API check
 }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,8 +1,26 @@
 /*
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+@file:JvmName("Projects")
+import org.gradle.api.*
 
-import org.gradle.api.Project
+const val coreModule = "kotlinx-coroutines-core"
+// Not applicable for Kotlin plugin
+val sourceless = setOf("kotlinx.coroutines", "kotlinx-coroutines-bom", "integration-testing")
+val internal = setOf("kotlinx.coroutines", "benchmarks", "integration-testing")
+// Not published
+val unpublished = internal + setOf("example-frontend-js", "android-unit-tests")
+
+// Projects that we do not check for Android API level 14 check due to various limitations
+val androidNonCompatibleProjects = setOf(
+    "kotlinx-coroutines-debug",
+    "kotlinx-coroutines-swing",
+    "kotlinx-coroutines-javafx",
+    "kotlinx-coroutines-jdk8",
+    "kotlinx-coroutines-jdk9",
+    "kotlinx-coroutines-reactor",
+    "kotlinx-coroutines-test"
+)
 
 fun Project.version(target: String): String =
     property("${target}_version") as String

--- a/buildSrc/src/main/kotlin/animalsniffer-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/animalsniffer-convention.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import ru.vyarus.gradle.plugin.animalsniffer.*
+
+subprojects {
+    // Skip benchmarks and bom -- not interested
+    if (!shouldSniff()) return@subprojects
+    apply(plugin = "ru.vyarus.animalsniffer")
+    configure<AnimalSnifferExtension> {
+        // TODO use project.sourceSets on the newer gradle
+        sourceSets = listOf((project.extensions.getByName("sourceSets") as SourceSetContainer).getByName("main"))
+    }
+    val signature: Configuration by configurations
+    dependencies {
+        signature("net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature")
+        signature("org.codehaus.mojo.signature:java17:1.0@signature")
+    }
+}
+
+fun Project.shouldSniff(): Boolean {
+    // Skip all non-JVM projects
+    if (platformOf(project) != "jvm") return false
+    val name = project.name
+    if (name in unpublished || name in sourceless || name in androidNonCompatibleProjects) return false
+    return true
+}

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
-    targetCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/gradle/compile-jvm-multiplatform.gradle
+++ b/gradle/compile-jvm-multiplatform.gradle
@@ -2,12 +2,16 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 kotlin {
     jvm {}
     sourceSets {
+        jvmMain.dependencies {
+            compileOnly "org.codehaus.mojo:animal-sniffer-annotations:1.20"
+        }
+
         jvmTest.dependencies {
             api "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
             // Workaround to make addSuppressed work in tests

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -81,7 +81,7 @@ kotlin {
         }
         languageSettings {
             progressiveMode = true
-            optInAnnotations.each { useExperimentalAnnotation(it) }
+            optInAnnotations.each { optIn(it) }
         }
     }
 
@@ -100,6 +100,11 @@ kotlin {
                 background { setExecutionSourceFrom(binaries.backgroundDebugTest) }
             }
         }
+    }
+
+    jvm {
+        // For animal sniffer
+        withJava()
     }
 }
 

--- a/kotlinx-coroutines-core/common/src/flow/SharingStarted.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharingStarted.kt
@@ -5,7 +5,7 @@
 package kotlinx.coroutines.flow
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.internal.*
+import kotlinx.coroutines.internal.IgnoreJreRequirement
 import kotlin.time.*
 
 /**
@@ -204,5 +204,6 @@ private class StartedWhileSubscribed(
             stopTimeout == other.stopTimeout &&
             replayExpiration == other.replayExpiration
 
+    @IgnoreJreRequirement // desugared hashcode implementation
     override fun hashCode(): Int = stopTimeout.hashCode() * 31 + replayExpiration.hashCode()
 }

--- a/kotlinx-coroutines-core/common/src/internal/InternalAnnotations.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/InternalAnnotations.common.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+// Ignore JRE requirements for animal-sniffer, compileOnly dependency
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE)
+@OptionalExpectation
+internal expect annotation class IgnoreJreRequirement()

--- a/kotlinx-coroutines-core/common/src/internal/Symbol.kt
+++ b/kotlinx-coroutines-core/common/src/internal/Symbol.kt
@@ -4,12 +4,14 @@
 
 package kotlinx.coroutines.internal
 
+import kotlin.jvm.*
+
 /**
  * A symbol class that is used to define unique constants that are self-explanatory in debugger.
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
-internal class Symbol(val symbol: String) {
+internal class Symbol(@JvmField val symbol: String) {
     override fun toString(): String = "<$symbol>"
 
     @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")

--- a/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
@@ -5,7 +5,6 @@
 package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
-import kotlinx.coroutines.scheduling.*
 import kotlin.coroutines.*
 import kotlin.coroutines.jvm.internal.CoroutineStackFrame
 
@@ -140,6 +139,7 @@ internal actual val CoroutineContext.coroutineName: String? get() {
 
 private const val DEBUG_THREAD_NAME_SEPARATOR = " @"
 
+@IgnoreJreRequirement // desugared hashcode implementation
 internal data class CoroutineId(
     val id: Long
 ) : ThreadContextElement<String>, AbstractCoroutineContextElement(CoroutineId) {

--- a/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/AgentPremain.kt
@@ -6,6 +6,7 @@ package kotlinx.coroutines.debug
 
 import android.annotation.*
 import kotlinx.coroutines.debug.internal.*
+import org.codehaus.mojo.animal_sniffer.*
 import sun.misc.*
 import java.lang.instrument.*
 import java.lang.instrument.ClassFileTransformer
@@ -17,6 +18,7 @@ import java.security.*
  */
 @Suppress("unused")
 @SuppressLint("all")
+@IgnoreJRERequirement // Never touched on Android
 internal object AgentPremain {
 
     private val enableCreationStackTraces = runCatching {

--- a/kotlinx-coroutines-core/jvm/src/internal/InternalAnnotations.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/InternalAnnotations.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.internal
+
+@Suppress("ACTUAL_WITHOUT_EXPECT") // Not the same name to WA the bug in the compiler
+internal actual typealias IgnoreJreRequirement = org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement


### PR DESCRIPTION
… 8 source and binary target, but still avoiding Java 7+ API

    * Do not use deprecated target, language desugaring will handle default interface methods and Math/Long/Int static methods
    * Partially migrate to .gradle.kts