### PR TITLE
Removed experimental annotation from old APIs

### DIFF
--- a/kotlinx-coroutines-test/src/DelayController.kt
+++ b/kotlinx-coroutines-test/src/DelayController.kt
@@ -12,14 +12,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  *
  * Testing libraries may expose this interface to tests instead of [TestCoroutineDispatcher].
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public interface DelayController {
     /**
      * Returns the current virtual clock-time as it is known to this Dispatcher.
      *
      * @return The virtual clock-time
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public val currentTime: Long
 
     /**
@@ -57,7 +55,6 @@ public interface DelayController {
      * @param delayTimeMillis The amount of time to move the CoroutineContext's clock forward.
      * @return The amount of delay-time that this Dispatcher's clock has been forwarded.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun advanceTimeBy(delayTimeMillis: Long): Long
 
     /**
@@ -68,7 +65,6 @@ public interface DelayController {
      *
      * @return the amount of delay-time that this Dispatcher's clock has been forwarded in milliseconds.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun advanceUntilIdle(): Long
 
     /**
@@ -76,7 +72,6 @@ public interface DelayController {
      *
      * Calling this function will never advance the clock.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun runCurrent()
 
     /**
@@ -85,7 +80,6 @@ public interface DelayController {
      * @throws UncompletedCoroutinesError if any pending tasks are active, however it will not throw for suspended
      * coroutines.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     @Throws(UncompletedCoroutinesError::class)
     public fun cleanupTestCoroutines()
 
@@ -98,7 +92,6 @@ public interface DelayController {
      * This is useful when testing functions that start a coroutine. By pausing the dispatcher assertions or
      * setup may be done between the time the coroutine is created and started.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public suspend fun pauseDispatcher(block: suspend () -> Unit)
 
     /**
@@ -107,7 +100,6 @@ public interface DelayController {
      * When paused, the dispatcher will not execute any coroutines automatically, and you must call [runCurrent] or
      * [advanceTimeBy], or [advanceUntilIdle] to execute coroutines.
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun pauseDispatcher()
 
     /**
@@ -117,7 +109,6 @@ public interface DelayController {
      * time and execute coroutines scheduled in the future use, one of [advanceTimeBy],
      * or [advanceUntilIdle].
      */
-    @ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
     public fun resumeDispatcher()
 }
 
@@ -125,5 +116,4 @@ public interface DelayController {
  * Thrown when a test has completed and there are tasks that are not completed or cancelled.
  */
 // todo: maybe convert into non-public class in 1.3.0 (need use-cases for a public exception type)
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public class UncompletedCoroutinesError(message: String, cause: Throwable? = null): AssertionError(message, cause)

--- a/kotlinx-coroutines-test/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/src/TestBuilders.kt
@@ -41,7 +41,6 @@ import kotlin.coroutines.*
  *        then they must implement [DelayController] and [TestCoroutineExceptionHandler] respectively.
  * @param testBody The code of the unit-test.
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public fun runBlockingTest(context: CoroutineContext = EmptyCoroutineContext, testBody: suspend TestCoroutineScope.() -> Unit) {
     val (safeContext, dispatcher) = context.checkArguments()
     val startingJobs = safeContext.activeJobs()
@@ -68,14 +67,12 @@ private fun CoroutineContext.activeJobs(): Set<Job> {
  * Convenience method for calling [runBlockingTest] on an existing [TestCoroutineScope].
  */
 // todo: need documentation on how this extension is supposed to be used
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public fun TestCoroutineScope.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit): Unit =
     runBlockingTest(coroutineContext, block)
 
 /**
  * Convenience method for calling [runBlockingTest] on an existing [TestCoroutineDispatcher].
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public fun TestCoroutineDispatcher.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit): Unit =
     runBlockingTest(this, block)
 

--- a/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineDispatcher.kt
@@ -24,7 +24,6 @@ import kotlin.math.*
  *
  * @see DelayController
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public class TestCoroutineDispatcher: CoroutineDispatcher(), Delay, DelayController {
     private var dispatchImmediately = true
         set(value) {

--- a/kotlinx-coroutines-test/src/TestCoroutineExceptionHandler.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineExceptionHandler.kt
@@ -10,7 +10,6 @@ import kotlin.coroutines.*
 /**
  * Access uncaught coroutine exceptions captured during test execution.
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public interface UncaughtExceptionCaptor {
     /**
      * List of uncaught coroutine exceptions.
@@ -34,7 +33,6 @@ public interface UncaughtExceptionCaptor {
 /**
  * An exception handler that captures uncaught exceptions in tests.
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public class TestCoroutineExceptionHandler :
     AbstractCoroutineContextElement(CoroutineExceptionHandler), UncaughtExceptionCaptor, CoroutineExceptionHandler
 {

--- a/kotlinx-coroutines-test/src/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/src/TestCoroutineScope.kt
@@ -10,7 +10,6 @@ import kotlin.coroutines.*
 /**
  * A scope which provides detailed control over the execution of coroutines for tests.
  */
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public interface TestCoroutineScope: CoroutineScope, UncaughtExceptionCaptor, DelayController {
     /**
      * Call after the test completes.
@@ -45,7 +44,6 @@ private class TestCoroutineScopeImpl (
  * @param context an optional context that MAY provide [UncaughtExceptionCaptor] and/or [DelayController]
  */
 @Suppress("FunctionName")
-@ExperimentalCoroutinesApi // Since 1.2.1, tentatively till 1.3.0
 public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext): TestCoroutineScope {
     var safeContext = context
     if (context[ContinuationInterceptor] == null) safeContext += TestCoroutineDispatcher()

--- a/kotlinx-coroutines-test/src/TestDispatchers.kt
+++ b/kotlinx-coroutines-test/src/TestDispatchers.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.test.internal.*
  *
  * It is unsafe to call this method if alive coroutines launched in [Dispatchers.Main] exist.
  */
-@ExperimentalCoroutinesApi
 public fun Dispatchers.setMain(dispatcher: CoroutineDispatcher) {
     require(dispatcher !is TestMainDispatcher) { "Dispatchers.setMain(Dispatchers.Main) is prohibited, probably Dispatchers.resetMain() should be used instead" }
     val mainDispatcher = Dispatchers.Main
@@ -30,7 +29,6 @@ public fun Dispatchers.setMain(dispatcher: CoroutineDispatcher) {
  *
  * It is unsafe to call this method if alive coroutines launched in [Dispatchers.Main] exist.
  */
-@ExperimentalCoroutinesApi
 public fun Dispatchers.resetMain() {
     val mainDispatcher = Dispatchers.Main
     require(mainDispatcher is TestMainDispatcher) { "TestMainDispatcher is not set as main dispatcher, have $mainDispatcher instead." }


### PR DESCRIPTION
Removes the need to add the ExperimentalCoroutinesApi annotation when testing coroutine based code. 