### PR TITLE
Use Dispatchers.Main as default delay source where applicable

### DIFF
--- a/kotlinx-coroutines-core/common/src/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/Delay.kt
@@ -51,8 +51,6 @@ public interface Delay {
      * Schedules invocation of a specified [block] after a specified delay [timeMillis].
      * The resulting [DisposableHandle] can be used to [dispose][DisposableHandle.dispose] of this invocation
      * request if it is not needed anymore.
-     *
-     * This implementation uses a built-in single-threaded scheduled executor service.
      */
     public fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
         DefaultDelay.invokeOnTimeout(timeMillis, block, context)

--- a/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
+++ b/ui/kotlinx-coroutines-javafx/src/JavaFxDispatcher.kt
@@ -34,22 +34,18 @@ public sealed class JavaFxDispatcher : MainCoroutineDispatcher(), Delay {
 
     /** @suppress */
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
-        val timeline = schedule(timeMillis, TimeUnit.MILLISECONDS, EventHandler {
+        val timeline = schedule(timeMillis, TimeUnit.MILLISECONDS) {
             with(continuation) { resumeUndispatched(Unit) }
-        })
+        }
         continuation.invokeOnCancellation { timeline.stop() }
     }
 
     /** @suppress */
     override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
-        val timeline = schedule(timeMillis, TimeUnit.MILLISECONDS, EventHandler {
+        val timeline = schedule(timeMillis, TimeUnit.MILLISECONDS) {
             block.run()
-        })
-        return object : DisposableHandle {
-            override fun dispose() {
-                timeline.stop()
-            }
         }
+        return DisposableHandle { timeline.stop() }
     }
 
     private fun schedule(time: Long, unit: TimeUnit, handler: EventHandler<ActionEvent>): Timeline =


### PR DESCRIPTION
It reduces the number of redundant threads in the system and makes time source predictable across Android/JavaFx applications

Fixes #2972