### PR TITLE
Use AtomicBoolean instead of AtomicRef<Boolean> for LockWaiter

### DIFF
--- a/kotlinx-coroutines-core/common/src/sync/Mutex.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Mutex.kt
@@ -369,7 +369,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
     private abstract inner class LockWaiter(
         @JvmField val owner: Any?
     ) : LockFreeLinkedListNode(), DisposableHandle {
-        private val isTaken = atomic<Boolean>(false)
+        private val isTaken = atomic(false)
         fun take(): Boolean = isTaken.compareAndSet(false, true)
         final override fun dispose() { remove() }
         abstract fun tryResumeLockWaiter(): Boolean


### PR DESCRIPTION
AtomicBoolean can eliminate extra allocations, and should be faster. 

Also, this fixes deadlock in build with current dev version of Kotlin/Native compiler (e.g. 1.6.20-dev-4157) in new-native-memory-model branch. 

The reason is, using AtomicReference<Boolean> assumes, that true will be always same object, when casted to Any, which is now sometimes wrong. Probably, this should be fixed in compiler, but anyway, it such assumption seams to be dangerous in general.  