### PR TITLE
Use the TestCoroutineDispatcher from Dispatchers.Main by default

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -149,10 +149,12 @@ public expect class TestResult
  *
  * ### Task scheduling
  *
- * Delay-skipping is achieved by using virtual time. [TestCoroutineScheduler] is automatically created (if it wasn't
- * passed in some way in [context]) and can be used to control the virtual time, advancing it, running the tasks
- * scheduled at a specific time etc. Some convenience methods are available on [TestCoroutineScope] to control the
- * scheduler.
+ * Delay-skipping is achieved by using virtual time.
+ * If [Dispatchers.Main] is set to a [TestDispatcher] via [Dispatchers.setMain] before the test,
+ * then its [TestCoroutineScheduler] is used;
+ * otherwise, a new one is automatically created (or taken from [context] in some way) and can be used to control
+ * the virtual time, advancing it, running the tasks scheduled at a specific time etc.
+ * Some convenience methods are available on [TestCoroutineScope] to control the scheduler.
  *
  * Delays in code that runs inside dispatchers that don't use a [TestCoroutineScheduler] don't get skipped:
  * ```

--- a/kotlinx-coroutines-test/common/src/TestDispatchers.kt
+++ b/kotlinx-coroutines-test/common/src/TestDispatchers.kt
@@ -18,7 +18,7 @@ import kotlin.jvm.*
 @ExperimentalCoroutinesApi
 public fun Dispatchers.setMain(dispatcher: CoroutineDispatcher) {
     require(dispatcher !is TestMainDispatcher) { "Dispatchers.setMain(Dispatchers.Main) is prohibited, probably Dispatchers.resetMain() should be used instead" }
-    getTestMainDispatcher().setDispatcher(dispatcher)
+    getTestMainDispatcher().delegate = dispatcher
 }
 
 /**

--- a/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.*
  * The testable main dispatcher used by kotlinx-coroutines-test.
  * It is a [MainCoroutineDispatcher] that delegates all actions to a settable delegate.
  */
-internal class TestMainDispatcher(private var delegate: CoroutineDispatcher):
+internal class TestMainDispatcher(var delegate: CoroutineDispatcher):
     MainCoroutineDispatcher(),
     Delay by (delegate as? Delay ?: defaultDelay)
 {
@@ -24,10 +24,6 @@ internal class TestMainDispatcher(private var delegate: CoroutineDispatcher):
     override fun isDispatchNeeded(context: CoroutineContext): Boolean = delegate.isDispatchNeeded(context)
 
     override fun dispatchYield(context: CoroutineContext, block: Runnable) = delegate.dispatchYield(context, block)
-
-    fun setDispatcher(dispatcher: CoroutineDispatcher) {
-        delegate = dispatcher
-    }
 
     fun resetDispatcher() {
         delegate = mainDispatcher


### PR DESCRIPTION
This change eliminates the common pattern that is currently needed to be able to use `Dispatchers.Main` in code under test:
```kotlin
val dispatcher = TestCoroutineDispatcher()
val scope = TestCoroutineScope(dispatcher)

@BeforeTest
fun setMain() {
  Dispatchers.setMain(dispatcher)
}

@AfterTest
fun resetMain() {
  Dispatcher.resetMain()
  scope.cleanupTestCoroutines()
}

@Test
fun testFoo() = scope.runBlockingTest { ... }
```

Now this becomes just
```kotlin
@BeforeTest
fun setMain() {
  Dispatchers.setMain(TestCoroutineDispatcher())
}

@AfterTest
fun resetMain() {
  Dispatcher.resetMain()
}

@Test
fun testFoo() = runTest { ... }
```
This is done by querying `Dispatchers.Main` for its `TestCoroutineScheduler`.