### PR TITLE
Eagerly enter `launch` and `async` blocks with unconfined dispatcher.

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
@@ -12,6 +12,7 @@ import kotlin.coroutines.*
  */
 public expect fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext
 
+@PublishedApi
 @Suppress("PropertyName")
 internal expect val DefaultDelay: Delay
 

--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -219,7 +219,7 @@ public fun runTest(
     return createTestResult {
         /** TODO: moving this [AbstractCoroutine.start] call outside [createTestResult] fails on Native with
          * [TestCoroutineDispatcher], because the event loop is not started. */
-        testScope.start(CoroutineStart.DEFAULT, testScope) {
+        testScope.start(CoroutineStart.UNDISPATCHED, testScope) {
             testBody()
         }
         var completed = false

--- a/kotlinx-coroutines-test/common/src/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestCoroutineScope.kt
@@ -6,8 +6,6 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
-import kotlinx.coroutines.test.internal.*
-import kotlinx.coroutines.test.internal.TestMainDispatcher
 import kotlin.coroutines.*
 
 /**
@@ -172,12 +170,7 @@ public fun createTestCoroutineScope(context: CoroutineContext = EmptyCoroutineCo
             }
             dispatcher
         }
-        null -> {
-            val mainDispatcherScheduler =
-                ((Dispatchers.Main as? TestMainDispatcher)?.delegate as? TestDispatcher)?.scheduler
-            scheduler = context[TestCoroutineScheduler] ?: mainDispatcherScheduler ?: TestCoroutineScheduler()
-            StandardTestDispatcher(scheduler)
-        }
+        null -> StandardTestDispatcher(context[TestCoroutineScheduler]).also { scheduler = it.scheduler }
         else -> throw IllegalArgumentException("Dispatcher must implement TestDispatcher: $dispatcher")
     }
     var scope: TestCoroutineScopeImpl? = null

--- a/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
@@ -12,9 +12,12 @@ import kotlin.coroutines.*
  */
 internal class TestMainDispatcher(var delegate: CoroutineDispatcher):
     MainCoroutineDispatcher(),
-    Delay by (delegate as? Delay ?: defaultDelay)
+    Delay
 {
     private val mainDispatcher = delegate // the initial value passed to the constructor
+
+    private val delay
+        get() = delegate as? Delay ?: defaultDelay
 
     override val immediate: MainCoroutineDispatcher
         get() = (delegate as? MainCoroutineDispatcher)?.immediate ?: this
@@ -28,6 +31,12 @@ internal class TestMainDispatcher(var delegate: CoroutineDispatcher):
     fun resetDispatcher() {
         delegate = mainDispatcher
     }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) =
+        delay.scheduleResumeAfterDelay(timeMillis, continuation)
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
+        delay.invokeOnTimeout(timeMillis, block, context)
 }
 
 @Suppress("INVISIBLE_MEMBER")

--- a/kotlinx-coroutines-test/common/test/Helpers.kt
+++ b/kotlinx-coroutines-test/common/test/Helpers.kt
@@ -66,3 +66,9 @@ open class OrderedExecutionTestBase {
 }
 
 internal fun <T> T.void() { }
+
+@OptionalExpectation
+expect annotation class NoJs()
+
+@OptionalExpectation
+expect annotation class NoNative()

--- a/kotlinx-coroutines-test/common/test/StandardTestDispatcherTest.kt
+++ b/kotlinx-coroutines-test/common/test/StandardTestDispatcherTest.kt
@@ -54,4 +54,17 @@ class StandardTestDispatcherTest: OrderedExecutionTestBase() {
         expect(5)
     }.void()
 
+    /** Tests that the [TestCoroutineScheduler] used for [Dispatchers.Main] gets used by default. */
+    @Test
+    fun testSchedulerReuse() {
+        val dispatcher1 = StandardTestDispatcher()
+        Dispatchers.setMain(dispatcher1)
+        try {
+            val dispatcher2 = StandardTestDispatcher()
+            assertSame(dispatcher1.scheduler, dispatcher2.scheduler)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
 }

--- a/kotlinx-coroutines-test/common/test/TestDispatchersTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestDispatchersTest.kt
@@ -20,8 +20,8 @@ class TestDispatchersTest: OrderedExecutionTestBase() {
         Dispatchers.resetMain()
     }
 
-    /** Tests that asynchronous execution of tests does not happen concurrently with [AfterTest] (in fact, it does). */
-    @Ignore // fails on JS.
+    /** Tests that asynchronous execution of tests does not happen concurrently with [AfterTest]. */
+    @NoJs
     @Test
     fun testMainMocking() = runTest {
         val mainAtStart = mainTestDispatcher

--- a/kotlinx-coroutines-test/common/test/TestDispatchersTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestDispatchersTest.kt
@@ -4,6 +4,7 @@
 package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.internal.*
 import kotlin.coroutines.*
 import kotlin.test.*
 
@@ -11,9 +12,48 @@ class TestDispatchersTest: OrderedExecutionTestBase() {
 
     @BeforeTest
     fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
         Dispatchers.resetMain()
     }
 
+    /** Tests that asynchronous execution of tests does not happen concurrently with [AfterTest] (in fact, it does). */
+    @Ignore // fails on JS.
+    @Test
+    fun testMainMocking() = runTest {
+        val mainAtStart = mainTestDispatcher
+        assertNotNull(mainAtStart)
+        withContext(Dispatchers.Main) {
+            delay(10)
+        }
+        withContext(Dispatchers.Default) {
+            delay(10)
+        }
+        withContext(Dispatchers.Main) {
+            delay(10)
+        }
+        assertSame(mainAtStart, mainTestDispatcher)
+    }
+
+    /** Tests that the mocked [Dispatchers.Main] correctly forwards [Delay] methods. */
+    @Test
+    fun testMockedMainImplementsDelay() = runTest {
+        val main = Dispatchers.Main
+        withContext(main) {
+            delay(10)
+        }
+        withContext(Dispatchers.Default) {
+            delay(10)
+        }
+        withContext(main) {
+            delay(10)
+        }
+    }
+
+    /** Tests that [Distpachers.setMain] fails when called with [Dispatchers.Main]. */
     @Test
     fun testSelfSet() {
         assertFailsWith<IllegalArgumentException> { Dispatchers.setMain(Dispatchers.Main) }
@@ -56,3 +96,5 @@ class TestDispatchersTest: OrderedExecutionTestBase() {
         }
     }
 }
+
+private val mainTestDispatcher get() = ((Dispatchers.Main as? TestMainDispatcher)?.delegate as? TestDispatcher)

--- a/kotlinx-coroutines-test/js/test/FailingTests.kt
+++ b/kotlinx-coroutines-test/js/test/FailingTests.kt
@@ -1,0 +1,37 @@
+package kotlinx.coroutines.test
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.internal.*
+import kotlin.test.*
+
+/** These are tests that we want to fail. They are here so that, when the issue is fixed, their failure indicates that
+ * everything is better now. */
+class FailingTests {
+
+    private var tearDownEntered = false
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        tearDownEntered = true
+    }
+
+    /** [TestDispatchersTest.testMainMocking]. */
+    @Test
+    fun testAfterTestIsConcurrent() = runTest {
+        try {
+            val mainAtStart = (Dispatchers.Main as? TestMainDispatcher)?.delegate as? TestDispatcher ?: return@runTest
+            withContext(Dispatchers.Default) {
+                // context switch
+            }
+            assertNotSame(mainAtStart, (Dispatchers.Main as TestMainDispatcher).delegate)
+        } finally {
+            assertTrue(tearDownEntered)
+        }
+    }
+}

--- a/kotlinx-coroutines-test/js/test/Helpers.kt
+++ b/kotlinx-coroutines-test/js/test/Helpers.kt
@@ -4,6 +4,8 @@
 
 package kotlinx.coroutines.test
 
+import kotlin.test.*
+
 actual fun testResultMap(block: (() -> Unit) -> Unit, test: () -> TestResult): TestResult =
     test().then(
         {
@@ -14,3 +16,5 @@ actual fun testResultMap(block: (() -> Unit) -> Unit, test: () -> TestResult): T
                 throw it
             }
         })
+
+actual typealias NoJs = Ignore

--- a/kotlinx-coroutines-test/native/test/FailingTests.kt
+++ b/kotlinx-coroutines-test/native/test/FailingTests.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.test
+
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+/** These are tests that we want to fail. They are here so that, when the issue is fixed, their failure indicates that
+ * everything is better now. */
+class FailingTests {
+    @Test
+    fun testRunTestLoopShutdownOnTimeout() = testResultMap({ fn ->
+        assertFailsWith<IllegalStateException> { fn() }
+    }) {
+        runTest(dispatchTimeoutMs = 1) {
+            withContext(Dispatchers.Default) {
+                delay(10000)
+            }
+            fail("shouldn't be reached")
+        }
+    }
+
+}

--- a/kotlinx-coroutines-test/native/test/Helpers.kt
+++ b/kotlinx-coroutines-test/native/test/Helpers.kt
@@ -3,8 +3,12 @@
  */
 package kotlinx.coroutines.test
 
+import kotlin.test.*
+
 actual fun testResultMap(block: (() -> Unit) -> Unit, test: () -> TestResult) {
     block {
         test()
     }
 }
+
+actual typealias NoNative = Ignore


### PR DESCRIPTION
@qwwdfsad found a convenient migration path for most tests that rely on `launch` and `async` blocks being entered eagerly. Implemented it here.

Also, I fixed `Dispatchers.Main` not delegating `Delay` methods and discovered that, on JS, `Dispatchers.Main` gets reset during the test if it is reset in `AfterTest`.