### PR TITLE
Improve exception transparency: explicitly allow throwing exceptions …

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -163,7 +163,6 @@ import kotlin.coroutines.*
  * Flow machinery enforces exception transparency at runtime and throws [IllegalStateException] on any attempt to emit a value,
  * if an exception has been thrown on previous attempt.
  *
- *
  * ### Reactive streams
  *
  * Flow is [Reactive Streams](http://www.reactive-streams.org/) compliant, you can safely interop it with

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -131,14 +131,12 @@ import kotlin.coroutines.*
  *
  * ### Exception transparency
  *
- * Flow implementations never explicitly catch and ignore exceptions that occur in downstream flows.
- * From the implementation standpoint, it means that `catch` blocks that wrap calls to [emit][FlowCollector.emit] and [emitAll]
- * are not allowed to complete normally or attempt to call [emit][FlowCollector.emit], they are only allowed
- * to rethrow a caught exception or throw a different exception for diagnostics or application-specific purposes.
+ * When `emit` or `emitAll` throws, the Flow implementations must immediately stop emitting new values and finish with an exception.
+ * For diagnostics or application-specific purposes, the exception may be different from the one thrown by the emit operation,
+ * but then it will be suppressed, as discussed below.
+ * If there is a need to emit values after the downstream failed, please use the [catch][Flow.catch] operator.
  *
- *
- * Exception handling with further emission in flows shall only be performed with
- * [catch][Flow.catch] operator, and it is designed to only catch exceptions coming from upstream flows while passing
+ * The [catch][Flow.catch] operator only catches upstream exceptions, but passes
  * all downstream exceptions. Similarly, terminal operators like [collect][Flow.collect]
  * throw any unhandled exceptions that occur in their code or in upstream flows, for example:
  *

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -153,8 +153,8 @@ import kotlin.coroutines.*
  *
  * If the upstream flow throws an exception during its completion when the downstream exception has been thrown,
  * the downstream exception becomes superseded and suppressed by the upstream exception, being a semantic
- * equivalent of throwing from `finally` block. Exception-handling operators then ignore this exception,
- * still following the downstream failure.
+ * equivalent of throwing from `finally` block. However, this doesn't affect the operation of the exception-handling operators,
+ * which consider the downstream exception to be the root cause and behave as if the upstream didn't throw anything.
  *
  * Failure to adhere to the exception transparency requirement can lead to strange behaviors which make
  * it hard to reason about the code because an exception in the `collect { ... }` could be somehow "caught"

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -133,7 +133,7 @@ import kotlin.coroutines.*
  *
  * When `emit` or `emitAll` throws, the Flow implementations must immediately stop emitting new values and finish with an exception.
  * For diagnostics or application-specific purposes, the exception may be different from the one thrown by the emit operation,
- * but then it will be suppressed, as discussed below.
+ * suppressing the original exception as discussed below.
  * If there is a need to emit values after the downstream failed, please use the [catch][Flow.catch] operator.
  *
  * The [catch][Flow.catch] operator only catches upstream exceptions, but passes
@@ -152,7 +152,9 @@ import kotlin.coroutines.*
  * All exception-handling Flow operators follow the principle of exception suppression:
  *
  * If the upstream flow throws an exception during its completion when the downstream exception has been thrown,
- * the upstream exception becomes superseded and suppressed by the downstream exception.
+ * the downstream exception becomes superseded and suppressed by the upstream exception, being a semantic
+ * equivalent of throwing from `finally` block. Exception-handling operators then ignore this exception,
+ * still following the downstream failure.
  *
  * Failure to adhere to the exception transparency requirement can lead to strange behaviors which make
  * it hard to reason about the code because an exception in the `collect { ... }` could be somehow "caught"

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -220,9 +220,10 @@ internal suspend fun <T> Flow<T>.catchImpl(
                 return e
             }
             /*
-             * We consider "downstream" exception as the superseding one even if the
-             * upstream has failed (unless downstream exception is a cancellation exception, aligned with
-             * our cancellation mechanism), so it effectively suppresses it.
+             * We consider the upstream exception as the superseding one when both upstream and downstream
+             * fail, suppressing the downstream exception, and operating similarly to `finally` block with
+             * the useful addition of adding the original downstream exception to suppressed ones.
+             *
              * That's important for the following scenarios:
              * ```
              * flow {
@@ -230,9 +231,9 @@ internal suspend fun <T> Flow<T>.catchImpl(
              *     try {
              *         ... emit as well ...
              *     } finally {
-             *          resource.close() // Unlucky throw
+             *          resource.close() // Throws in the shutdown sequence when 'collect' already has thrown an exception
              *     }
-             * }.catch { } /* or retry */
+             * }.catch { } // or retry
              * .collect { ... }
              * ```
              * when *the downstream* throws.

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -214,8 +214,7 @@ internal suspend fun <T> Flow<T>.catchImpl(
              * The exception came from the upstream [semi-] independently.
              * For pure failures, when the downstream functions normally, we handle the exception as intended.
              * But if the downstream has failed prior to or concurrently
-             * with the upstream, we forcefully rethrow it, preserving the contextual information and ensuring
-             * that it's not lost.
+             * with the upstream, we forcefully rethrow it, preserving the contextual information and ensuring  that it's not lost.
              */
             if (fromDownstream == null) {
                 return e
@@ -238,12 +237,12 @@ internal suspend fun <T> Flow<T>.catchImpl(
              * ```
              * when *the downstream* throws.
              */
-            if (fromDownstream is CancellationException) {
-                e.addSuppressed(fromDownstream)
-                throw e
-            } else {
+            if (e is CancellationException) {
                 fromDownstream.addSuppressed(e)
                 throw fromDownstream
+            } else {
+                e.addSuppressed(fromDownstream)
+                throw e
             }
         }
     }

--- a/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
@@ -160,7 +160,7 @@ class CatchTest : TestBase() {
             throw TestException2()
         }
 
-        assertFailsWith<TestException2>(flow)
+        assertFailsWith<TestException>(flow)
         finish(4)
     }
 

--- a/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
@@ -182,4 +182,23 @@ class CatchTest : TestBase() {
         assertFailsWith<TestException>(flow)
         finish(4)
     }
+
+    @Test
+    fun testUpstreamCancellationIsIgnoredWhenDownstreamFails() = runTest {
+        val flow = flow {
+            try {
+                expect(1)
+                emit(1)
+            } finally {
+                expect(3)
+                throw CancellationException("")
+            }
+        }.catch { expectUnreached() }.onEach {
+            expect(2)
+            throw TestException("")
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
 }

--- a/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/CatchTest.kt
@@ -144,4 +144,42 @@ class CatchTest : TestBase() {
             .collect()
         finish(9)
     }
+
+    @Test
+    fun testUpstreamExceptionConcurrentWithDownstream() = runTest {
+        val flow = flow {
+            try {
+                expect(1)
+                emit(1)
+            } finally {
+                expect(3)
+                throw TestException()
+            }
+        }.catch { expectUnreached() }.onEach {
+            expect(2)
+            throw TestException2()
+        }
+
+        assertFailsWith<TestException2>(flow)
+        finish(4)
+    }
+
+    @Test
+    fun testUpstreamExceptionConcurrentWithDownstreamCancellation() = runTest {
+        val flow = flow {
+            try {
+                expect(1)
+                emit(1)
+            } finally {
+                expect(3)
+                throw TestException()
+            }
+        }.catch { expectUnreached() }.onEach {
+            expect(2)
+            throw CancellationException("")
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
 }

--- a/kotlinx-coroutines-core/common/test/flow/operators/RetryTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/RetryTest.kt
@@ -142,4 +142,23 @@ class RetryTest : TestBase() {
         assertFailsWith<TestException>(flow)
         finish(4)
     }
+
+    @Test
+    fun testUpstreamCancellationIsIgnoredWhenDownstreamFails() = runTest {
+        val flow = flow {
+            try {
+                expect(1)
+                emit(1)
+            } finally {
+                expect(3)
+                throw CancellationException("")
+            }
+        }.retry { expectUnreached(); true }.onEach {
+            expect(2)
+            throw TestException("")
+        }
+
+        assertFailsWith<TestException>(flow)
+        finish(4)
+    }
 }

--- a/kotlinx-coroutines-core/common/test/flow/operators/RetryTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/RetryTest.kt
@@ -120,7 +120,7 @@ class RetryTest : TestBase() {
             throw TestException2()
         }
 
-        assertFailsWith<TestException2>(flow)
+        assertFailsWith<TestException>(flow)
         finish(4)
     }
 

--- a/kotlinx-coroutines-core/jvm/test/exceptions/FlowSuppressionTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/FlowSuppressionTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.exceptions
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import org.junit.*
+import org.junit.Test
+import kotlin.test.*
+
+class FlowSuppressionTest : TestBase() {
+    @Test
+    fun testSuppressionForPrimaryException() = runTest {
+        val flow = flow {
+            try {
+                emit(1)
+            } finally {
+                throw TestException()
+            }
+        }.catch { expectUnreached() }.onEach { throw TestException2() }
+
+        try {
+            flow.collect()
+        } catch (e: Throwable) {
+            assertIs<TestException>(e)
+            assertIs<TestException2>(e.suppressed[0])
+        }
+    }
+
+    @Test
+    fun testSuppressionForPrimaryExceptionRetry() = runTest {
+        val flow = flow {
+            try {
+                emit(1)
+            } finally {
+                throw TestException()
+            }
+        }.retry { expectUnreached(); true }.onEach { throw TestException2() }
+
+        try {
+            flow.collect()
+        } catch (e: Throwable) {
+            assertIs<TestException>(e)
+            assertIs<TestException2>(e.suppressed[0])
+
+        }
+    }
+}


### PR DESCRIPTION
…from the upstream when the downstream has been failed, but also suppress such exceptions by the downstream one

It solves the problem of graceful shutdown: when the upstream fails unwillingly (e.g. file.close() has thrown in 'finally') block, we cannot treat is as an exception transparency violation (hint: 'finally' is a shortcut for 'catch'+body), but we also cannot leave things as is, otherwise it leads to unforeseen consequences such as successful 'retry' and 'catch' operators that may, or may not, then fail with exception on attempt to emit.

Downstream exception supersedes the upstream exception only if it is not an instance of CancellationException, semantically emulating cancellation-friendly 'use' block.

Fixes #2860