### PR TITLE
Update code to prepare for nullness annotations in Guava.

### DIFF
--- a/integration/kotlinx-coroutines-guava/README.md
+++ b/integration/kotlinx-coroutines-guava/README.md
@@ -62,6 +62,6 @@ Integration with Guava [ListenableFuture](https://github.com/google/guava/wiki/L
 
 <!--- INDEX com.google.common.util.concurrent -->
 
-[com.google.common.util.concurrent.ListenableFuture]: https://kotlin.github.io/kotlinx.coroutines/https://google.github.io/guava/releases/28.0-jre/api/docs/com/google/common/util/concurrent/ListenableFuture.html
+[com.google.common.util.concurrent.ListenableFuture]: https://kotlin.github.io/kotlinx.coroutines/https://google.github.io/guava/releases/31.0.1-jre/api/docs/com/google/common/util/concurrent/ListenableFuture.html
 
 <!--- END -->

--- a/integration/kotlinx-coroutines-guava/build.gradle.kts
+++ b/integration/kotlinx-coroutines-guava/build.gradle.kts
@@ -2,10 +2,15 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-val guavaVersion = "28.0-jre"
+val guavaVersion = "31.0.1-jre"
 
 dependencies {
     compile("com.google.guava:guava:$guavaVersion")
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 externalDocumentationLink(


### PR DESCRIPTION
Guava's current nullness annotations don't yet trigger Kotlin compile
errors. However, Guava did recently remove the misleading `@Nullable`
annotation from the parameter of `FutureCallback.onSuccess`:

Before:
https://github.com/google/guava/blob/v28.0/guava/src/com/google/common/util/concurrent/FutureCallback.java#L34

After:
https://github.com/google/guava/blob/v31.0.1/guava/src/com/google/common/util/concurrent/FutureCallback.java#L35

That means that a `FutureCallback<T>` can now implement `onSuccess(T)`
instead of `onSuccess(T?)`. And with a future change to Guava, it will
_have to_.

(For background, see the section on "Nullness annotations" in
https://github.com/google/guava/releases/tag/v31.0)

In order to make that change, this commit updates from from Guava 28.0
to Guava 31.0.1.

When I performed that update, I found that that pulled in a newer
version of the Checker Framework nullness annotations. That version was
build with a newer version of Gradle, so it generates Gradle module
metadata:
https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html

That metadata declares that the Checker Framework annotations require
Java 1.8. Even the old version had in fact required Java 1.8 -- and so
had even the old version of Guava -- just without having that encoded in
its metadata. So I fixed this by setting targetCompatibility and
sourceCompatibility to 1.8 for kotlinx-coroutines-guava, too.