### PR TITLE
Fix crashes with the test module on the JVM: take #1

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -61,7 +61,9 @@ public fun MainDispatcherFactory.tryCreateDispatcher(factories: List<MainDispatc
 
 /** @suppress */
 @InternalCoroutinesApi
-public fun MainCoroutineDispatcher.isMissing(): Boolean = this is MissingMainCoroutineDispatcher
+public fun MainCoroutineDispatcher.isMissing(): Boolean =
+    // not checking `this`, as it may be wrapped in a `TestMainDispatcher`, whereas `immediate` never is.
+    this.immediate is MissingMainCoroutineDispatcher
 
 // R8 optimization hook, not const on purpose to enable R8 optimizations via "assumenosideeffects"
 @Suppress("MayBeConstant")


### PR DESCRIPTION
Now the test module correctly exposes that initially, the Main dispatcher is missing, so the default delay mechanism is not rewritten.

This is option №1.