### PR TITLE
Fix RunTestTest.testRunTestWithLargeTimeout KDoc

### DIFF
--- a/kotlinx-coroutines-test/common/test/RunTestTest.kt
+++ b/kotlinx-coroutines-test/common/test/RunTestTest.kt
@@ -97,7 +97,7 @@ class RunTestTest {
         }
     }
 
-    /** Tests that too low of a dispatch timeout causes crashes. */
+    /** Tests that real delays can be accounted for with a large enough dispatch timeout. */
     @Test
     fun testRunTestWithLargeTimeout() = runTest(dispatchTimeoutMs = 5000) {
         withContext(Dispatchers.Default) {


### PR DESCRIPTION
Simple duplicated KDoc issue I noticed while browsing the tests: The `testRunTestWithLargeTimeout` used the KDoc from `testRunTestWithSmallTimeout`, which didn't make sense.

Feel free to reword the new KDoc however you'd like.