### PR TITLE
Validate that throwing tryCopy does not crash with an internal error

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryCustomExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryCustomExceptionsTest.kt
@@ -124,4 +124,22 @@ class StackTraceRecoveryCustomExceptionsTest : TestBase() {
         assertTrue(ex is CopyableWithCustomMessage)
         assertEquals("Recovered: [OK]", ex.message)
     }
+
+    @Test
+    fun testTryCopyThrows() = runTest {
+        class FailingException : Exception(), CopyableThrowable<FailingException> {
+            override fun createCopy(): FailingException? {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val e = FailingException()
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw e
+            }
+        }
+
+        assertSame(e, result.exceptionOrNull())
+    }
 }


### PR DESCRIPTION
Motivated by #3031

