### PR TITLE
Update Node version to 10.0.0 because Promise.finally since this version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ baksmali_version=2.2.7
 # JS
 kotlin.js.compiler=both
 gradle_node_version=1.2.0
-node_version=8.9.3
+node_version=10.0.0
 npm_version=5.7.1
 mocha_version=6.2.2
 mocha_headless_chrome_version=1.8.2


### PR DESCRIPTION
To make work [KT-49738](https://youtrack.jetbrains.com/issue/KT-49738) with async `@AfterTest`, necessary to upgrade Node.JS version, because `Promise.finally` exists since 10.0.0