### PR TITLE
Add TimeSource implementation to TestCoroutineScheduler

### DIFF
--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
@@ -65,6 +65,7 @@ public final class kotlinx/coroutines/test/TestCoroutineScheduler : kotlin/corou
 	public final fun advanceTimeBy (J)V
 	public final fun advanceUntilIdle ()V
 	public final fun getCurrentTime ()J
+	public final fun getTimeSource ()Lkotlin/time/TimeSource;
 	public final fun runCurrent ()V
 }
 
@@ -113,6 +114,7 @@ public final class kotlinx/coroutines/test/TestScopeKt {
 	public static final fun advanceTimeBy (Lkotlinx/coroutines/test/TestScope;J)V
 	public static final fun advanceUntilIdle (Lkotlinx/coroutines/test/TestScope;)V
 	public static final fun getCurrentTime (Lkotlinx/coroutines/test/TestScope;)J
+	public static final fun getTestTimeSource (Lkotlinx/coroutines/test/TestScope;)Lkotlin/time/TimeSource;
 	public static final fun runCurrent (Lkotlinx/coroutines/test/TestScope;)V
 }
 

--- a/kotlinx-coroutines-test/common/src/TestScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestScope.kt
@@ -7,6 +7,7 @@ package kotlinx.coroutines.test
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
 import kotlin.coroutines.*
+import kotlin.time.*
 
 /**
  * A coroutine scope that for launching test coroutines.
@@ -83,6 +84,14 @@ public fun TestScope.runCurrent(): Unit = testScheduler.runCurrent()
  */
 @ExperimentalCoroutinesApi
 public fun TestScope.advanceTimeBy(delayTimeMillis: Long): Unit = testScheduler.advanceTimeBy(delayTimeMillis)
+
+/**
+ * The [test scheduler][TestScope.testScheduler] as a [TimeSource].
+ * @see TestCoroutineScheduler.timeSource
+ */
+@ExperimentalCoroutinesApi
+@ExperimentalTime
+public val TestScope.testTimeSource: TimeSource get() = testScheduler.timeSource
 
 /**
  * Creates a [TestScope].

--- a/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
@@ -6,6 +6,8 @@ package kotlinx.coroutines.test
 
 import kotlinx.coroutines.*
 import kotlin.test.*
+import kotlin.time.*
+import kotlin.time.Duration.Companion.seconds
 
 class TestCoroutineSchedulerTest {
     /** Tests that `TestCoroutineScheduler` attempts to detect if there are several instances of it. */
@@ -306,6 +308,16 @@ class TestCoroutineSchedulerTest {
         scope.checkTimeout(false) {
             deferred.await()
         }
+    }
+
+    @Test
+    @ExperimentalTime
+    fun testAdvanceTimeSource() = runTest {
+        val expected = 1.seconds
+        val actual = testTimeSource.measureTime {
+            delay(expected)
+        }
+        assertEquals(expected, actual)
     }
 
     private fun forTestDispatchers(block: (TestDispatcher) -> Unit): Unit =


### PR DESCRIPTION
Fixes #3086 

I didn't inherit `TestCoroutineScheduler` from `TimeSource`, because you rarely use `TestCoroutineScheduler.markNow()` but rather use its `timeSource` to inject it in your time based components.
Also the method `elapsedNow` from `TimeSource` is quite confusing in a `Scheduler`. What happened when calling `elapsedNow` with its job? (Nothing...)