### PR TITLE
Updated SLF4J Dependencies In SLF4J Integration Module To 1.7.32

### DIFF
--- a/integration/kotlinx-coroutines-slf4j/build.gradle.kts
+++ b/integration/kotlinx-coroutines-slf4j/build.gradle.kts
@@ -3,10 +3,10 @@
  */
 
 dependencies {
-    compile("org.slf4j:slf4j-api:1.7.25")
-    testCompile("io.github.microutils:kotlin-logging:1.5.4")
-    testRuntime("ch.qos.logback:logback-classic:1.2.3")
-    testRuntime("ch.qos.logback:logback-core:1.2.3")
+    implementation("org.slf4j:slf4j-api:1.7.32")
+    testImplementation("io.github.microutils:kotlin-logging:2.1.0")
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.7")
+    testRuntimeOnly("ch.qos.logback:logback-core:1.2.7")
 }
 
 externalDocumentationLink(

--- a/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
+++ b/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
@@ -43,6 +43,7 @@ public class MDCContext(
     /**
      * The value of [MDC] context map.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     public val contextMap: MDCContextMap = MDC.getCopyOfContextMap()
 ) : ThreadContextElement<MDCContextMap>, AbstractCoroutineContextElement(Key) {
     /**


### PR DESCRIPTION
The SLF4J integration module now also no longer uses the deprecated Gradle dependency declaration keywords