### PR TITLE
Introduce new `CancellableContinuation.resume` with `onCancellation` lambda that takes the resumption value

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -39,22 +39,24 @@ public abstract interface class kotlinx/coroutines/CancellableContinuation : kot
 	public abstract fun isCancelled ()Z
 	public abstract fun isCompleted ()Z
 	public abstract fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)V
 	public abstract fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public abstract fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)Ljava/lang/Object;
 	public abstract fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;
 }
 
 public final class kotlinx/coroutines/CancellableContinuation$DefaultImpls {
 	public static synthetic fun cancel$default (Lkotlinx/coroutines/CancellableContinuation;Ljava/lang/Throwable;ILjava/lang/Object;)Z
+	public static fun resume (Lkotlinx/coroutines/CancellableContinuation;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun tryResume$default (Lkotlinx/coroutines/CancellableContinuation;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/jvm/internal/CoroutineStackFrame, kotlinx/coroutines/CancellableContinuation {
 	public fun <init> (Lkotlin/coroutines/Continuation;I)V
 	public final fun callCancelHandler (Lkotlinx/coroutines/CancelHandler;Ljava/lang/Throwable;)V
-	public final fun callOnCancellation (Lkotlin/jvm/functions/Function1;Ljava/lang/Throwable;)V
+	public final fun callOnCancellation (Lkotlinx/coroutines/OnCancellation;Ljava/lang/Object;Ljava/lang/Throwable;)V
 	public fun cancel (Ljava/lang/Throwable;)Z
 	public fun completeResume (Ljava/lang/Object;)V
 	public fun getCallerFrame ()Lkotlin/coroutines/jvm/internal/CoroutineStackFrame;
@@ -69,12 +71,13 @@ public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/
 	public fun isCompleted ()Z
 	protected fun nameString ()Ljava/lang/String;
 	public fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)V
 	public fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public fun resumeWith (Ljava/lang/Object;)V
 	public fun toString ()Ljava/lang/String;
 	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)Ljava/lang/Object;
 	public fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;
 }
 
@@ -508,6 +511,10 @@ public final class kotlinx/coroutines/NonDisposableHandle : kotlinx/coroutines/C
 }
 
 public abstract interface annotation class kotlinx/coroutines/ObsoleteCoroutinesApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class kotlinx/coroutines/OnCancellation {
+	public abstract fun invoke (Ljava/lang/Object;Ljava/lang/Throwable;Lkotlin/coroutines/CoroutineContext;)V
 }
 
 public abstract interface class kotlinx/coroutines/ParentJob : kotlinx/coroutines/Job {

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -39,11 +39,11 @@ public abstract interface class kotlinx/coroutines/CancellableContinuation : kot
 	public abstract fun isCancelled ()Z
 	public abstract fun isCompleted ()Z
 	public abstract fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
-	public abstract fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)V
+	public abstract fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellationHandler;)V
 	public abstract fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public abstract fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)Ljava/lang/Object;
+	public abstract fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellationHandler;)Ljava/lang/Object;
 	public abstract fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;
 }
 
@@ -56,7 +56,7 @@ public final class kotlinx/coroutines/CancellableContinuation$DefaultImpls {
 public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/jvm/internal/CoroutineStackFrame, kotlinx/coroutines/CancellableContinuation {
 	public fun <init> (Lkotlin/coroutines/Continuation;I)V
 	public final fun callCancelHandler (Lkotlinx/coroutines/CancelHandler;Ljava/lang/Throwable;)V
-	public final fun callOnCancellation (Lkotlinx/coroutines/OnCancellation;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public final fun callOnCancellation (Lkotlinx/coroutines/OnCancellationHandler;Ljava/lang/Object;Ljava/lang/Throwable;)V
 	public fun cancel (Ljava/lang/Throwable;)Z
 	public fun completeResume (Ljava/lang/Object;)V
 	public fun getCallerFrame ()Lkotlin/coroutines/jvm/internal/CoroutineStackFrame;
@@ -71,13 +71,13 @@ public class kotlinx/coroutines/CancellableContinuationImpl : kotlin/coroutines/
 	public fun isCompleted ()Z
 	protected fun nameString ()Ljava/lang/String;
 	public fun resume (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
-	public fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)V
+	public fun resume (Ljava/lang/Object;Lkotlinx/coroutines/OnCancellationHandler;)V
 	public fun resumeUndispatched (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Object;)V
 	public fun resumeUndispatchedWithException (Lkotlinx/coroutines/CoroutineDispatcher;Ljava/lang/Throwable;)V
 	public fun resumeWith (Ljava/lang/Object;)V
 	public fun toString ()Ljava/lang/String;
 	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellation;)Ljava/lang/Object;
+	public fun tryResume (Ljava/lang/Object;Ljava/lang/Object;Lkotlinx/coroutines/OnCancellationHandler;)Ljava/lang/Object;
 	public fun tryResumeWithException (Ljava/lang/Throwable;)Ljava/lang/Object;
 }
 
@@ -513,7 +513,7 @@ public final class kotlinx/coroutines/NonDisposableHandle : kotlinx/coroutines/C
 public abstract interface annotation class kotlinx/coroutines/ObsoleteCoroutinesApi : java/lang/annotation/Annotation {
 }
 
-public abstract interface class kotlinx/coroutines/OnCancellation {
+public abstract interface class kotlinx/coroutines/OnCancellationHandler {
 	public abstract fun invoke (Ljava/lang/Object;Ljava/lang/Throwable;Lkotlin/coroutines/CoroutineContext;)V
 }
 

--- a/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
@@ -87,7 +87,7 @@ public interface CancellableContinuation<in T> : Continuation<T> {
      * @suppress  **This is unstable API and it is subject to change.**
      */
     @InternalCoroutinesApi
-    public fun tryResume(value: T, idempotent: Any?, onCancellation: OnCancellation<@UnsafeVariance T>?): Any?
+    public fun tryResume(value: T, idempotent: Any?, onCancellation: OnCancellationHandler<@UnsafeVariance T>?): Any?
 
     /**
      * Tries to resume this continuation with the specified [exception] and returns a non-null object token if successful,
@@ -209,7 +209,7 @@ public interface CancellableContinuation<in T> : Continuation<T> {
             resume(value)
             return
         }
-        val onCancellationNew = OnCancellation<T> { _, cause, _ ->
+        val onCancellationNew = OnCancellationHandler<T> { _, cause, _ ->
             onCancellation(cause ?: CancellationException("Cancelled"))
         }
         resume(value, onCancellationNew)
@@ -245,10 +245,10 @@ public interface CancellableContinuation<in T> : Continuation<T> {
      */
     @ExperimentalCoroutinesApi
     @InternalCoroutinesApi
-    public fun resume(value: T, onCancellation: OnCancellation<@UnsafeVariance T>?)
+    public fun resume(value: T, onCancellation: OnCancellationHandler<@UnsafeVariance T>?)
 }
 
-public fun interface OnCancellation<in T> {
+public fun interface OnCancellationHandler<in T> {
     public fun invoke(value: T, cause: Throwable?, context: CoroutineContext)
 }
 

--- a/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
@@ -213,7 +213,7 @@ internal open class CancellableContinuationImpl<in T>(
     fun callCancelHandler(handler: CancelHandler, cause: Throwable?) =
         callCancelHandlerSafely { handler.invoke(cause) }
 
-    fun callOnCancellation(onCancellation: OnCancellation<@UnsafeVariance T>, value: T, cause: Throwable) {
+    fun callOnCancellation(onCancellation: OnCancellationHandler<@UnsafeVariance T>, value: T, cause: Throwable) {
         try {
             onCancellation.invoke(value, cause, context)
         } catch (ex: Throwable) {
@@ -326,7 +326,7 @@ internal open class CancellableContinuationImpl<in T>(
     override fun resumeWith(result: Result<T>) =
         resumeImpl(result.toState(this), resumeMode)
 
-    override fun resume(value: T, onCancellation: OnCancellation<@UnsafeVariance T>?) {
+    override fun resume(value: T, onCancellation: OnCancellationHandler<@UnsafeVariance T>?) {
         resumeImpl(value, resumeMode, onCancellation)
     }
 
@@ -401,7 +401,7 @@ internal open class CancellableContinuationImpl<in T>(
         state: NotCompleted,
         proposedUpdate: Any?,
         resumeMode: Int,
-        onCancellation: OnCancellation<T>?,
+        onCancellation: OnCancellationHandler<T>?,
         idempotent: Any?
     ): Any? = when {
         proposedUpdate is CompletedExceptionally -> {
@@ -420,7 +420,7 @@ internal open class CancellableContinuationImpl<in T>(
     private fun resumeImpl(
         proposedUpdate: Any?,
         resumeMode: Int,
-        onCancellation: OnCancellation<T>? = null
+        onCancellation: OnCancellationHandler<T>? = null
     ) {
         _state.loop { state ->
             when (state) {
@@ -456,7 +456,7 @@ internal open class CancellableContinuationImpl<in T>(
     private fun tryResumeImpl(
         proposedUpdate: Any?,
         idempotent: Any?,
-        onCancellation: OnCancellation<T>?
+        onCancellation: OnCancellationHandler<T>?
     ): Symbol? {
         _state.loop { state ->
             when (state) {
@@ -502,7 +502,7 @@ internal open class CancellableContinuationImpl<in T>(
     override fun tryResume(value: T, idempotent: Any?): Any? =
         tryResumeImpl(value, idempotent, onCancellation = null)
 
-    override fun tryResume(value: T, idempotent: Any?, onCancellation: OnCancellation<@UnsafeVariance T>?): Any? =
+    override fun tryResume(value: T, idempotent: Any?, onCancellation: OnCancellationHandler<@UnsafeVariance T>?): Any? =
         tryResumeImpl(value, idempotent, onCancellation)
 
     override fun tryResumeWithException(exception: Throwable): Any? =
@@ -580,7 +580,7 @@ private class InvokeOnCancel( // Clashes with InvokeOnCancellation
 private data class CompletedContinuation<T>(
     @JvmField val result: T,
     @JvmField val cancelHandler: CancelHandler? = null, // installed via invokeOnCancellation
-    @JvmField val onCancellation: OnCancellation<T>? = null, // installed via resume block
+    @JvmField val onCancellation: OnCancellationHandler<T>? = null, // installed via resume block
     @JvmField val idempotentResume: Any? = null,
     @JvmField val cancelCause: Throwable? = null
 ) {

--- a/kotlinx-coroutines-core/common/src/sync/Mutex.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Mutex.kt
@@ -191,7 +191,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
                         val update = if (owner == null) EMPTY_LOCKED else Empty(owner)
                         if (_state.compareAndSet(state, update)) { // locked
                             // TODO implement functional type in LockCont as soon as we get rid of legacy JS
-                            cont.resume(Unit) { unlock(owner) }
+                            cont.resume(Unit) { _, _, _-> unlock(owner) }
                             return@sc
                         }
                     }
@@ -376,7 +376,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
 
         override fun tryResumeLockWaiter(): Boolean {
             if (!take()) return false
-            return cont.tryResume(Unit, idempotent = null) {
+            return cont.tryResume(Unit, idempotent = null) { _, _, _ ->
                 // if this continuation gets cancelled during dispatch to the caller, then release the lock
                 unlock(owner)
             } != null

--- a/kotlinx-coroutines-core/common/src/sync/Semaphore.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Semaphore.kt
@@ -88,7 +88,7 @@ public suspend inline fun <T> Semaphore.withPermit(action: () -> T): T {
     }
 }
 
-private class SemaphoreImpl(private val permits: Int, acquiredPermits: Int) : Semaphore, OnCancellation<Unit> {
+private class SemaphoreImpl(private val permits: Int, acquiredPermits: Int) : Semaphore, OnCancellationHandler<Unit> {
     /*
        The queue of waiting acquirers is essentially an infinite array based on the list of segments
        (see `SemaphoreSegment`); each segment contains a fixed number of slots. To determine a slot for each enqueue


### PR DESCRIPTION
Introduce new `CancellableContinuation.resume` with `onCancellation` lambda that takes the resumption value, cause, and the coroutine context as arguments