### PR TITLE
Fix Dispatchers.Main not being fully initialized on Android and Swing

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/MainDispatcherFactory.kt
+++ b/kotlinx-coroutines-core/common/src/internal/MainDispatcherFactory.kt
@@ -14,6 +14,11 @@ public interface MainDispatcherFactory {
     /**
      * Creates the main dispatcher. [allFactories] parameter contains all factories found by service loader.
      * This method is not guaranteed to be idempotent.
+     *
+     * It is required that this method fails with an exception instead of returning an instance that doesn't work
+     * correctly as a [Delay].
+     * The reason for this is that, on the JVM, [DefaultDelay] will use [Dispatchers.Main] for most delays by default
+     * if this method returns an instance without throwing.
      */
     public fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher
 

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -51,9 +51,9 @@ public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
 
 internal class AndroidDispatcherFactory : MainDispatcherFactory {
 
-    override fun createDispatcher(allFactories: List<MainDispatcherFactory>) {
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
         val mainLooper = Looper.getMainLooper() ?: throw IllegalStateException("The main looper is not available")
-        HandlerContext(mainLooper.asHandler(async = true))
+        return HandlerContext(mainLooper.asHandler(async = true))
     }
 
     override fun hintOnError(): String = "For tests Dispatchers.setMain from kotlinx-coroutines-test module can be used"

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -51,8 +51,10 @@ public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
 
 internal class AndroidDispatcherFactory : MainDispatcherFactory {
 
-    override fun createDispatcher(allFactories: List<MainDispatcherFactory>) =
-        HandlerContext(Looper.getMainLooper()!!.asHandler(async = true))
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>) {
+        val mainLooper = Looper.getMainLooper() ?: throw IllegalStateException("The main looper is not available")
+        HandlerContext(mainLooper.asHandler(async = true))
+    }
 
     override fun hintOnError(): String = "For tests Dispatchers.setMain from kotlinx-coroutines-test module can be used"
 

--- a/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
+++ b/ui/kotlinx-coroutines-android/src/HandlerDispatcher.kt
@@ -52,7 +52,7 @@ public sealed class HandlerDispatcher : MainCoroutineDispatcher(), Delay {
 internal class AndroidDispatcherFactory : MainDispatcherFactory {
 
     override fun createDispatcher(allFactories: List<MainDispatcherFactory>) =
-        HandlerContext(Looper.getMainLooper().asHandler(async = true))
+        HandlerContext(Looper.getMainLooper()!!.asHandler(async = true))
 
     override fun hintOnError(): String = "For tests Dispatchers.setMain from kotlinx-coroutines-test module can be used"
 

--- a/ui/kotlinx-coroutines-swing/src/SwingDispatcher.kt
+++ b/ui/kotlinx-coroutines-swing/src/SwingDispatcher.kt
@@ -74,6 +74,16 @@ private object ImmediateSwingDispatcher : SwingDispatcher() {
  * Dispatches execution onto Swing event dispatching thread and provides native [delay] support.
  */
 internal object Swing : SwingDispatcher() {
+
+    /* A workaround so that the dispatcher's initialization crashes with an exception if running in a headless
+    environment. This is needed so that this broken dispatcher is not used as the source of delays. */
+    init {
+        Timer(1) { }.apply {
+            isRepeats = false
+            start()
+        }
+    }
+
     override val immediate: MainCoroutineDispatcher
         get() = ImmediateSwingDispatcher
 


### PR DESCRIPTION

* If `unitTests.returnDefaultValues=true` is set on Android, then
`Looper.getMainLooper()` may return `null`. The type system of
Kotlin is tricked to believe that the method can't ever return
`null`, so doesn't check for it anywhere. As a result, despite not
being fully initialized, `Dispatchers.Main` is considered
non-missing.
* When running in a headless environment, Swing crashes, but
the dispatcher successfully initializes nonetheless.

This was not an issue before, as it only surfaced when
`Dispatchers.Main` was used. However, now `Main` is the source of
time for delays, so any delay will throw something
incomprehensible if this happens.