### PR TITLE
Fixed a typo in `GlobalScope` documentation

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -178,7 +178,7 @@ public val CoroutineScope.isActive: Boolean
  * ```
  * // concurrently load configuration and data
  * suspend fun loadConfigurationAndData() {
- *     coroutinesScope {
+ *     coroutineScope {
  *         launch { loadConfiguration() }
  *         launch { loadData() }
  *     }


### PR DESCRIPTION
Fixed a typo in the documentation of `GlobalScope`. Changed `coroutinesScope` to `coroutineScope`