### PR TITLE
Make multithreadingSupported a property with a getter

### DIFF
--- a/kotlinx-coroutines-core/native/src/internal/Concurrent.kt
+++ b/kotlinx-coroutines-core/native/src/internal/Concurrent.kt
@@ -32,6 +32,6 @@ internal open class SuppressSupportingThrowableImpl : Throwable() {
     }
 }
 
-@SharedImmutable
 @OptIn(ExperimentalStdlibApi::class)
-internal val multithreadingSupported: Boolean = kotlin.native.isExperimentalMM()
+internal val multithreadingSupported: Boolean
+    get() = kotlin.native.isExperimentalMM()

--- a/kotlinx-coroutines-core/native/src/internal/Concurrent.kt
+++ b/kotlinx-coroutines-core/native/src/internal/Concurrent.kt
@@ -32,6 +32,7 @@ internal open class SuppressSupportingThrowableImpl : Throwable() {
     }
 }
 
+// getter instead of a property due to the bug in the initialization dependencies tracking with '-Xir-property-lazy-initialization=disabled' that Ktor uses 
 @OptIn(ExperimentalStdlibApi::class)
 internal val multithreadingSupported: Boolean
     get() = kotlin.native.isExperimentalMM()


### PR DESCRIPTION
This change fixes an issue with initialization order observed when
lazy initialization is disabled (-Xir-property-lazy-initialization=
disabled compiler flag) and the new MM is used.

The problem is the following: the initialization of DefaultDelay
happens before initialization of multithreadingSupported. Thus
the initialization of DefaultDelay gets an uninitialized value
of multithreadingSupported and behaves as if the old MM is used.

Related issue: #KT-50491.