### PR TITLE
Rollback #2972, but leave a compatibility option with 1.6.0

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.internal.*
 import java.util.concurrent.*
 import kotlin.coroutines.*
 
-private val defaultMainDelayOptIn = systemProp("kotlinx.coroutines.main.delay", true)
+private val defaultMainDelayOptIn = systemProp("kotlinx.coroutines.main.delay", false)
 
 internal actual val DefaultDelay: Delay = initializeDefaultDelay()
 

--- a/ui/kotlinx-coroutines-android/test/HandlerDispatcherTest.kt
+++ b/ui/kotlinx-coroutines-android/test/HandlerDispatcherTest.kt
@@ -163,20 +163,19 @@ class HandlerDispatcherTest : TestBase() {
     }
 
     @Test
-    fun testDelayIsDelegatedToMain() = runTest {
+    fun testDelayIsNotDelegatedToMain() = runTest {
         val mainLooper = shadowOf(Looper.getMainLooper())
         mainLooper.pause()
         val mainMessageQueue = shadowOf(Looper.getMainLooper().queue)
         assertNull(mainMessageQueue.head)
         val job = launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
             expect(1)
-            delay(10_000_000)
-            expect(3)
+            delay(Long.MAX_VALUE)
+            expectUnreached()
         }
         expect(2)
-        assertNotNull(mainMessageQueue.head)
-        mainLooper.runOneTask()
-        job.join()
-        finish(4)
+        assertNull(mainMessageQueue.head)
+        job.cancelAndJoin()
+        finish(3)
     }
 }


### PR DESCRIPTION
The approach from 1.6.0 has proven itself as unstable and multiple hard-to-understand bugs have been reported:

* JavaFx timer doesn't really work outside the main thread
* The frequent initialization pattern "runBlocking { doSomethingThatMayCallDelay() }" used on the main thread during startup now silently deadlocks
* The latter issue was reported both by Android and internal JB Compose users
* The provided workaround with system property completely switches off the desired behaviour that e.g. Compose may rely on, potentially introducing new sources of invalid behaviour

The original benefits does not outweigh these pitfalls, so the decision is to revert this changes in the minor release

Fixes #3113
Fixes #3106