### PR TITLE
Introduce private DiagnosticCoroutineContextException and add it to t…

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/exceptions/CoroutineExceptionHandlerJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/CoroutineExceptionHandlerJvmTest.kt
@@ -39,4 +39,16 @@ class CoroutineExceptionHandlerJvmTest : TestBase() {
 
         finish(3)
     }
+
+    @Test
+    fun testLastDitchHandlerContainsContextualInformation() = runBlocking {
+        expect(1)
+        GlobalScope.launch(CoroutineName("last-ditch")) {
+            expect(2)
+            throw TestException()
+        }.join()
+        assertTrue(caughtException is TestException)
+        assertContains(caughtException.suppressed[0].toString(), "last-ditch")
+        finish(3)
+    }
 }


### PR DESCRIPTION
…he original exception prior to passing it to the Thread.currentThread().uncaughtExceptionHandler()

Fixes #3153