### PR TITLE
Add references to available implementations in TestDispatcher docs

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/TestDispatcher.kt
@@ -11,8 +11,10 @@ import kotlin.jvm.*
 /**
  * A test dispatcher that can interface with a [TestCoroutineScheduler].
  * 
- * @see StandardTestDispatcher A predictable, controllable dispatcher.
- * @see UnconfinedTestDispatcher A dispatcher that is not confined to any particular thread.
+ * The available implementations are:
+ * * [StandardTestDispatcher] is a dispatcher that places new tasks into a queue.
+ * * [UnconfinedTestDispatcher] is a dispatcher that behaves like [Dispatchers.Unconfined] while allowing to control
+ *   the virtual time.
  */
 @ExperimentalCoroutinesApi
 public abstract class TestDispatcher internal constructor(): CoroutineDispatcher(), Delay {

--- a/kotlinx-coroutines-test/common/src/TestDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/TestDispatcher.kt
@@ -10,6 +10,9 @@ import kotlin.jvm.*
 
 /**
  * A test dispatcher that can interface with a [TestCoroutineScheduler].
+ * 
+ * @see StandardTestDispatcher A predictable, controllable dispatcher.
+ * @see UnconfinedTestDispatcher A dispatcher that is not confined to any particular thread.
  */
 @ExperimentalCoroutinesApi
 public abstract class TestDispatcher internal constructor(): CoroutineDispatcher(), Delay {


### PR DESCRIPTION
Currently, linking to [TestDispatcher](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/index.html) directly leads the user to a page where they can't find the available implementations of this interface. This is mostly caused by the implementations being private classes with factory functions instead of inheritors.

This PR adds references to the two implementations. The description of the implementations here is not very important, feel free to modify it if needed.