### PR TITLE
docs: Update Coroutine context and dispatchers doc

### DIFF
--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -334,8 +334,8 @@ fun main() = runBlocking<Unit> {
     }
     delay(500)
     request.cancel() // cancel processing of the request
-    delay(1000) // delay a second to see what happens
     println("main: Who has survived request cancellation?")
+    delay(1000) // delay a second to keep main alive and see what happens
 //sampleEnd
 }
 ```
@@ -350,8 +350,8 @@ The output of this code is:
 ```text
 job1: I run in my own Job and execute independently!
 job2: I am a child of the request coroutine
-job1: I am not affected by cancellation of the request
 main: Who has survived request cancellation?
+job1: I am not affected by cancellation of the request
 ```
 
 <!--- TEST -->


### PR DESCRIPTION
I think flipping the order of the print and delay makes it more clear that one coroutine is canceled while the other lives on.  Also I added a note that explains why the delay is necessary.  The need for the second delay wasn't immediately clear to me on first read of the coroutine guide.