### PR TITLE
Remove unnecessary -keep rule for AndroidDispatcherFactory, AndroidEx…

### DIFF
--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
@@ -3,3 +3,4 @@
 # - META-INF/proguard/coroutines.pro
 
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
+-keep class kotlinx.coroutines.android.AndroidExceptionPreHandler {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/proguard/coroutines.pro
@@ -1,5 +1,5 @@
 # When editing this file, update the following files as well:
-# - META-INF/com.android.tools/r8-upto-1.6.0/coroutines.pro
+# - META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
 # - META-INF/proguard/coroutines.pro
 
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
@@ -9,8 +9,6 @@
     boolean ANDROID_DETECTED return true;
 }
 
--keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
-
 # Disable support for "Missing Main Dispatcher", since we always have Android main dispatcher
 -assumenosideeffects class kotlinx.coroutines.internal.MainDispatchersKt {
     boolean SUPPORT_MISSING return false;

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-1.6.0/coroutines.pro
@@ -1,9 +1,0 @@
-# When editing this file, update the following files as well:
-# - META-INF/com.android.tools/proguard/coroutines.pro
-# - META-INF/proguard/coroutines.pro
-
--keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
-
--assumenosideeffects class kotlinx.coroutines.internal.FastServiceLoader {
-    boolean ANDROID_DETECTED return true;
-}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
@@ -1,0 +1,6 @@
+# After R8 3.0.0 (or probably sometime before that), R8 learned how to optimize
+# classes mentioned in META-INF/services files, and explicitly -keeping them
+# disables these optimizations.
+# https://github.com/Kotlin/kotlinx.coroutines/issues/3111
+-keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
+-keep class kotlinx.coroutines.android.AndroidExceptionPreHandler {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
@@ -1,3 +1,7 @@
+# When editing this file, update the following files as well for AGP 3.6.0+:
+# - META-INF/com.android.tools/proguard/coroutines.pro
+# - META-INF/proguard/coroutines.pro
+
 # After R8 3.0.0 (or probably sometime before that), R8 learned how to optimize
 # classes mentioned in META-INF/services files, and explicitly -keeping them
 # disables these optimizations.

--- a/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
@@ -5,3 +5,4 @@
 # - META-INF/com.android.tools/r8-upto-1.6.0/coroutines.pro
 
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
+-keep class kotlinx.coroutines.android.AndroidExceptionPreHandler {*;}

--- a/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/proguard/coroutines.pro
@@ -2,7 +2,7 @@
 
 # When editing this file, update the following files as well for AGP 3.6.0+:
 # - META-INF/com.android.tools/proguard/coroutines.pro
-# - META-INF/com.android.tools/r8-upto-1.6.0/coroutines.pro
+# - META-INF/com.android.tools/r8-upto-3.0.0/coroutines.pro
 
 -keep class kotlinx.coroutines.android.AndroidDispatcherFactory {*;}
 -keep class kotlinx.coroutines.android.AndroidExceptionPreHandler {*;}

--- a/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
+++ b/ui/kotlinx-coroutines-android/src/AndroidExceptionPreHandler.kt
@@ -5,12 +5,10 @@
 package kotlinx.coroutines.android
 
 import android.os.*
-import androidx.annotation.*
 import kotlinx.coroutines.*
 import java.lang.reflect.*
 import kotlin.coroutines.*
 
-@Keep
 internal class AndroidExceptionPreHandler :
     AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler
 {


### PR DESCRIPTION
R8 supports keeping and/or optimizing classes found in META-INF/services:
https://b.corp.google.com/issues/120436373#comment7

The last R8 commit I can find related to ServerLoader is
https://r8-review.googlesource.com/53824 (Sept 2020),
so I think R8 1.6 still needs the -keep rule, but 3.0+ should not.

I tested with `./gradlew test`, but if failed in the same way with & without my change on javafx tests.

Fixes: 3111