### PR TITLE
Gradle 7.4.2, Kotlin 1.6.21 and other plugin updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 out
 target
 local.properties
+/kotlin-js-store

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -8,7 +8,6 @@ import me.champeau.gradle.*
 import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
-    id("net.ltgt.apt")
     id("com.github.johnrengelman.shadow")
     id("me.champeau.gradle.jmh") apply false
 }
@@ -31,8 +30,6 @@ tasks.named<KotlinCompile>("compileJmhKotlin") {
     }
 }
 
-
-
 // It is better to use the following to run benchmarks, otherwise you may get unexpected errors:
 // ./gradlew --no-daemon cleanJmhJar jmh -Pjmh="MyBenchmark"
 extensions.configure<JMHPluginExtension>("jmh") {
@@ -54,6 +51,12 @@ val jmhJarTask = tasks.named<Jar>("jmhJar") {
 }
 
 tasks {
+    // For some reason the DuplicatesStrategy from jmh is not enough
+    // and errors with duplicates appear unless I force it to WARN only:
+    withType<Copy> {
+        duplicatesStrategy = DuplicatesStrategy.WARN
+    }
+
     build {
         dependsOn(jmhJarTask)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -54,13 +54,13 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicfu_version"
         classpath "org.jetbrains.kotlinx:kotlinx-knit:$knit_version"
-        classpath "com.moowork.gradle:gradle-node-plugin:$gradle_node_version"
+        classpath "com.github.node-gradle:gradle-node-plugin:$gradle_node_version"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
-        classpath "ru.vyarus:gradle-animalsniffer-plugin:1.5.3" // Android API check
+        classpath "ru.vyarus:gradle-animalsniffer-plugin:1.5.4" // Android API check
         classpath "org.jetbrains.kotlinx:kover:$kover_version"
 
         // JMH plugins
-        classpath "com.github.jengelman.gradle.plugins:shadow:5.1.0"
+        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
     }
 
     CacheRedirector.configureBuildScript(buildscript, rootProject)
@@ -129,6 +129,9 @@ allprojects {
         maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
     }
 }
+
+// needs to be before evaluationDependsOn due to weird Gradle ordering
+apply plugin: "animalsniffer-conventions"
 
 // Add dependency to core source sets. Core is configured in kx-core/build.gradle
 configure(subprojects.findAll { !sourceless.contains(it.name) && it.name != coreModule }) {
@@ -232,7 +235,7 @@ def core_docs_url = "https://kotlin.github.io/kotlinx.coroutines/$coreModule/"
 def core_docs_file = "$projectDir/kotlinx-coroutines-core/build/dokka/htmlPartial/package-list"
 apply plugin: "org.jetbrains.dokka"
 
-configure(subprojects.findAll { !unpublished.contains(it.name) }) {
+configure(subprojects.findAll { !unpublished.contains(it.name) && it.name != coreModule }) {
     if (it.name != 'kotlinx-coroutines-bom') {
         apply from: rootProject.file('gradle/dokka.gradle.kts')
     }
@@ -302,8 +305,6 @@ allprojects {
 def publishTasks = getTasksByName("publish", true) + getTasksByName("publishNpm", true)
 
 task deploy(dependsOn: publishTasks)
-
-apply plugin: "animalsniffer-conventions"
 
 clean.dependsOn gradle.includedBuilds.collect { it.task(':clean') }
 

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -7,6 +7,7 @@
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.*
 import org.gradle.api.publish.maven.*
+import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.signing.*
 import java.net.*
 
@@ -55,6 +56,11 @@ fun configureMavenPublication(rh: RepositoryHandler, project: Project) {
             username = project.getSensitiveProperty("libs.sonatype.user")
             password = project.getSensitiveProperty("libs.sonatype.password")
         }
+    }
+
+    // Something that's easy to "clean" for development, not mavenLocal
+    rh.maven("${project.rootProject.buildDir}/repo") {
+        name = "buildRepo"
     }
 }
 

--- a/buildSrc/src/main/kotlin/animalsniffer-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/animalsniffer-conventions.gradle.kts
@@ -4,17 +4,19 @@
 
 import ru.vyarus.gradle.plugin.animalsniffer.*
 
-subprojects {
+configure(subprojects) {
     // Skip JDK 8 projects or unpublished ones
-    if (!shouldSniff()) return@subprojects
+    if (!shouldSniff()) return@configure
     apply(plugin = "ru.vyarus.animalsniffer")
-    configure<AnimalSnifferExtension> {
-        sourceSets = listOf((project.extensions.getByName("sourceSets") as SourceSetContainer).getByName("main"))
-    }
-    val signature: Configuration by configurations
-    dependencies {
-        signature("net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature")
-        signature("org.codehaus.mojo.signature:java17:1.0@signature")
+    project.plugins.withType(JavaPlugin::class.java) {
+        configure<AnimalSnifferExtension> {
+            sourceSets = listOf((project.extensions.getByName("sourceSets") as SourceSetContainer).getByName("main"))
+        }
+        val signature: Configuration by configurations
+        dependencies {
+            signature("net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature")
+            signature("org.codehaus.mojo.signature:java17:1.0@signature")
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 # Kotlin
 version=1.6.1-SNAPSHOT
 group=org.jetbrains.kotlinx
-kotlin_version=1.6.20
+kotlin_version=1.6.21
 
 # Dependencies
 junit_version=4.12
@@ -35,7 +35,7 @@ baksmali_version=2.2.7
 
 # JS
 kotlin.js.compiler=both
-gradle_node_version=1.2.0
+gradle_node_version=3.1.1
 node_version=10.0.0
 npm_version=5.7.1
 mocha_version=6.2.2

--- a/gradle/compile-js-multiplatform.gradle
+++ b/gradle/compile-js-multiplatform.gradle
@@ -60,7 +60,7 @@ compileTestJsLegacy.configure {
 task populateNodeModules(type: Copy, dependsOn: compileTestJsLegacy) {
     // we must copy output that is transformed by atomicfu
     from(kotlin.js().compilations.main.output.allOutputs)
-    into "$node.nodeModulesDir/node_modules"
+    into node.nodeProjectDir.dir("node_modules")
 
     def configuration = configurations.hasProperty("jsLegacyTestRuntimeClasspath")
             ? configurations.jsLegacyTestRuntimeClasspath

--- a/gradle/dokka.gradle.kts
+++ b/gradle/dokka.gradle.kts
@@ -39,10 +39,6 @@ tasks.withType(DokkaTaskPartial::class).configureEach {
 
         if (!project.isMultiplatform) {
             dependsOn(project.configurations["compileClasspath"])
-            doFirst {
-                // resolve classpath only during execution
-                classpath.from(project.configurations["compileClasspath"].files)// + project.sourceSets.main.output.files)
-            }
         }
     }
 }

--- a/gradle/node-js.gradle
+++ b/gradle/node-js.gradle
@@ -2,13 +2,13 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-apply plugin: 'com.moowork.node'
+apply plugin: 'com.github.node-gradle.node'
 
 node {
     version = "$node_version"
     npmVersion = "$npm_version"
     download = true
-    nodeModulesDir = file(buildDir)
+    nodeProjectDir = file(buildDir)
 }
 
 // Configures testing for JS modules
@@ -25,7 +25,7 @@ task prepareNodePackage(type: Copy) {
     from("npm") {
         exclude 'package.json'
     }
-    into "$node.nodeModulesDir"
+    into node.nodeProjectDir
 }
 
 npmInstall.dependsOn prepareNodePackage

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -6,7 +6,6 @@ import org.gradle.util.VersionNumber
 
 // Configures publishing of Maven artifacts to Maven Central
 
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
@@ -16,7 +15,9 @@ def isMultiplatform = project.name == "kotlinx-coroutines-core" || project.name 
 def isBom = project.name == "kotlinx-coroutines-bom"
 
 if (!isBom) {
-    apply plugin: "com.github.johnrengelman.shadow"
+    if (project.name == "kotlinx-coroutines-debug") {
+        apply plugin: "com.github.johnrengelman.shadow"
+    }
 
     // empty xxx-javadoc.jar
     task javadocJar(type: Jar) {

--- a/gradle/test-mocha-js.gradle
+++ b/gradle/test-mocha-js.gradle
@@ -9,7 +9,7 @@ task installDependenciesMochaNode(type: NpmTask, dependsOn: [npmInstall]) {
             "mocha@$mocha_version",
             "source-map-support@$source_map_support_version",
             '--no-save']
-    if (project.hasProperty("teamcity")) args += ["mocha-teamcity-reporter@$mocha_teamcity_reporter_version"]
+    if (project.hasProperty("teamcity")) args.addAll(["mocha-teamcity-reporter@$mocha_teamcity_reporter_version"])
 }
 
 def compileJsLegacy = tasks.hasProperty("compileKotlinJsLegacy")
@@ -22,9 +22,9 @@ def compileTestJsLegacy = tasks.hasProperty("compileTestKotlinJsLegacy")
 
 // todo: use atomicfu-transformed test files here (not critical)
 task testMochaNode(type: NodeTask, dependsOn: [compileTestJsLegacy, installDependenciesMochaNode]) {
-    script = file("$node.nodeModulesDir/node_modules/mocha/bin/mocha")
-    args = [compileTestJsLegacy.outputFile, '--require', 'source-map-support/register']
-    if (project.hasProperty("teamcity")) args += ['--reporter', 'mocha-teamcity-reporter']
+    script = file("${node.nodeProjectDir.getAsFile().get()}/node_modules/mocha/bin/mocha")
+    args = [compileTestJsLegacy.outputFile.path, '--require', 'source-map-support/register']
+    if (project.hasProperty("teamcity")) args.addAll(['--reporter', 'mocha-teamcity-reporter'])
 }
 
 def jsLegacyTestTask = project.tasks.findByName('jsLegacyTest') ? jsLegacyTest : jsTest
@@ -40,8 +40,8 @@ task installDependenciesMochaChrome(type: NpmTask, dependsOn: [npmInstall]) {
             "kotlin@$kotlin_version",
             "kotlin-test@$kotlin_version",
             '--no-save']
-    if (project.hasProperty("teamcity")) args += [
-            "mocha-teamcity-reporter@$mocha_teamcity_reporter_version"]
+    if (project.hasProperty("teamcity")) args.addAll([
+            "mocha-teamcity-reporter@$mocha_teamcity_reporter_version"])
 }
 
 def mochaChromeTestPage = file("$buildDir/test-page.html")
@@ -51,19 +51,20 @@ task prepareMochaChrome(dependsOn: [compileTestJsLegacy, installDependenciesMoch
 }
 
 prepareMochaChrome.doLast {
+    def nodeProjDir = node.nodeProjectDir.getAsFile().get()
     mochaChromeTestPage.text = """<!DOCTYPE html>
         <html>
         <head>
             <title>Mocha Tests</title>
             <meta charset="utf-8">
-            <link rel="stylesheet" href="$node.nodeModulesDir/node_modules/mocha/mocha.css">
+            <link rel="stylesheet" href="$nodeProjDir/node_modules/mocha/mocha.css">
         </head>
         <body>
         <div id="mocha"></div>
-        <script src="$node.nodeModulesDir/node_modules/mocha/mocha.js"></script>
+        <script src="$nodeProjDir/node_modules/mocha/mocha.js"></script>
         <script>mocha.setup('bdd');</script>
-        <script src="$node.nodeModulesDir/node_modules/kotlin/kotlin.js"></script>
-        <script src="$node.nodeModulesDir/node_modules/kotlin-test/kotlin-test.js"></script>
+        <script src="$nodeProjDir/node_modules/kotlin/kotlin.js"></script>
+        <script src="$nodeProjDir/node_modules/kotlin-test/kotlin-test.js"></script>
         <script src="$compileJsLegacy.outputFile"></script>
         <script src="$compileTestJsLegacy.outputFile"></script>
         <script>mocha.run();</script>
@@ -73,9 +74,9 @@ prepareMochaChrome.doLast {
 }
 
 task testMochaChrome(type: NodeTask, dependsOn: prepareMochaChrome) {
-    script = file("$node.nodeModulesDir/node_modules/mocha-headless-chrome/bin/start")
-    args = [compileTestJsLegacy.outputFile, '--file', mochaChromeTestPage]
-    if (project.hasProperty("teamcity")) args += ['--reporter', 'mocha-teamcity-reporter']
+    script = file("${node.nodeProjectDir.getAsFile().get()}/node_modules/mocha-headless-chrome/bin/start")
+    args = [compileTestJsLegacy.outputFile.path, '--file', mochaChromeTestPage]
+    if (project.hasProperty("teamcity")) args.addAll(['--reporter', 'mocha-teamcity-reporter'])
 }
 
 // todo: Commented out because mocha-headless-chrome does not work on TeamCity
@@ -90,13 +91,13 @@ task installDependenciesMochaJsdom(type: NpmTask, dependsOn: [npmInstall]) {
             "jsdom-global@$jsdom_global_version",
             "source-map-support@$source_map_support_version",
             '--no-save']
-    if (project.hasProperty("teamcity")) args += ["mocha-teamcity-reporter@$mocha_teamcity_reporter_version"]
+    if (project.hasProperty("teamcity")) args.addAll(["mocha-teamcity-reporter@$mocha_teamcity_reporter_version"])
 }
 
 task testMochaJsdom(type: NodeTask, dependsOn: [compileTestJsLegacy, installDependenciesMochaJsdom]) {
-    script = file("$node.nodeModulesDir/node_modules/mocha/bin/mocha")
-    args = [compileTestJsLegacy.outputFile, '--require', 'source-map-support/register', '--require', 'jsdom-global/register']
-    if (project.hasProperty("teamcity")) args += ['--reporter', 'mocha-teamcity-reporter']
+    script = file("${node.nodeProjectDir.getAsFile().get()}/node_modules/mocha/bin/mocha")
+    args = [compileTestJsLegacy.outputFile.path, '--require', 'source-map-support/register', '--require', 'jsdom-global/register']
+    if (project.hasProperty("teamcity")) args.addAll(['--reporter', 'mocha-teamcity-reporter'])
 }
 
 jsLegacyTestTask.dependsOn testMochaJsdom

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,6 +4,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -98,9 +98,9 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     npmTestImplementation 'org.apache.commons:commons-compress:1.18'
     npmTestImplementation 'com.google.code.gson:gson:2.8.5'
-    debugAgentTestCompile project(':kotlinx-coroutines-core')
-    debugAgentTestCompile project(':kotlinx-coroutines-debug')
-    coreAgentTestCompile project(':kotlinx-coroutines-core')
+    debugAgentTestImplementation project(':kotlinx-coroutines-core')
+    debugAgentTestImplementation project(':kotlinx-coroutines-debug')
+    coreAgentTestImplementation project(':kotlinx-coroutines-core')
 }
 
 compileTestKotlin {

--- a/integration/kotlinx-coroutines-guava/build.gradle.kts
+++ b/integration/kotlinx-coroutines-guava/build.gradle.kts
@@ -5,7 +5,7 @@
 val guavaVersion = "31.0.1-jre"
 
 dependencies {
-    compile("com.google.guava:guava:$guavaVersion")
+    api("com.google.guava:guava:$guavaVersion")
 }
 
 java {

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -14,6 +14,8 @@ if (rootProject.ext.native_targets_enabled) {
 apply from: rootProject.file("gradle/compile-js-multiplatform.gradle")
 apply from: rootProject.file('gradle/publish-npm-js.gradle')
 
+apply from: rootProject.file('gradle/dokka.gradle.kts')
+apply from: rootProject.file('gradle/publish.gradle')
 /* ==========================================================================
   Configure source sets structure for kotlinx-coroutines-core:
 

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -21,8 +21,8 @@ configurations {
 dependencies {
     compileOnly "junit:junit:$junit_version"
     compileOnly "org.junit.jupiter:junit-jupiter-api:$junit5_version"
-    testCompile "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
-    testCompile "org.junit.platform:junit-platform-testkit:1.7.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
+    testImplementation "org.junit.platform:junit-platform-testkit:1.7.0"
     shadowDeps "net.bytebuddy:byte-buddy:$byte_buddy_version"
     shadowDeps "net.bytebuddy:byte-buddy-agent:$byte_buddy_version"
     compileOnly "io.projectreactor.tools:blockhound:$blockhound_version"

--- a/reactive/kotlinx-coroutines-reactive/build.gradle.kts
+++ b/reactive/kotlinx-coroutines-reactive/build.gradle.kts
@@ -5,8 +5,8 @@
 val reactiveStreamsVersion = property("reactive_streams_version")
 
 dependencies {
-    compile("org.reactivestreams:reactive-streams:$reactiveStreamsVersion")
-    testCompile("org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion")
+    api("org.reactivestreams:reactive-streams:$reactiveStreamsVersion")
+    testImplementation("org.reactivestreams:reactive-streams-tck:$reactiveStreamsVersion")
 }
 
 val testNG by tasks.registering(Test::class) {

--- a/reactive/kotlinx-coroutines-reactor/build.gradle.kts
+++ b/reactive/kotlinx-coroutines-reactor/build.gradle.kts
@@ -5,8 +5,8 @@
 val reactorVersion = version("reactor")
 
 dependencies {
-    compile("io.projectreactor:reactor-core:$reactorVersion")
-    compile(project(":kotlinx-coroutines-reactive"))
+    api("io.projectreactor:reactor-core:$reactorVersion")
+    api(project(":kotlinx-coroutines-reactive"))
 }
 
 java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,6 @@ pluginManagement {
 }
 
 rootProject.name = 'kotlinx.coroutines'
-enableFeaturePreview('GRADLE_METADATA')
 
 def module(String path) {
     int i = path.lastIndexOf('/')

--- a/ui/kotlinx-coroutines-swing/build.gradle.kts
+++ b/ui/kotlinx-coroutines-swing/build.gradle.kts
@@ -3,5 +3,5 @@
  */
 
 dependencies {
-    testCompile(project(":kotlinx-coroutines-jdk8"))
+    testImplementation(project(":kotlinx-coroutines-jdk8"))
 }


### PR DESCRIPTION
Upgrading to Gradle 7.4.2 also includes updating or removing plugins that were outdated or incompatible with Gradle 7.x

Kotlin 1.6.21 update is not required but bumping anyway since tests pass.

One difference that I noticed is that dokka now generates absolute paths for links, and not `../../`, if this is a problem it's something that should be looked into. 

`./gradlew build` passes, and I also verified (more or less) that all files are generated in the right paths in the maven publication.