### PR TITLE
Fix data-race in Mutex owner when mutex is locked/released inconsiste…

### DIFF
--- a/kotlinx-coroutines-core/common/src/sync/Mutex.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Mutex.kt
@@ -361,7 +361,7 @@ internal class MutexImpl(locked: Boolean) : Mutex, SelectClause2<Any?, Mutex> {
     }
 
     private class LockedQueue(
-        @JvmField var owner: Any
+        @Volatile @JvmField var owner: Any
     ) : LockFreeLinkedListHead() {
         override fun toString(): String = "LockedQueue[$owner]"
     }


### PR DESCRIPTION
…ntly

Fixes #3250


There is no test, because we both can't really reproduce it on x86 with TSO and because it's tough to write -- the race is only reproducible when the mutex is used incorrectly.
Yet it's nice to have it fixed until 1.7.0 where new mutex arrives