### PR TITLE
Docs: change volatile example to use IO, not Default

### DIFF
--- a/docs/topics/shared-mutable-state-and-concurrency.md
+++ b/docs/topics/shared-mutable-state-and-concurrency.md
@@ -110,7 +110,7 @@ suspend fun massiveRun(action: suspend () -> Unit) {
 var counter = 0
 
 fun main() = runBlocking {
-    withContext(Dispatchers.Default) {
+    withContext(Dispatchers.IO) {
         massiveRun {
             counter++
         }


### PR DESCRIPTION
The Default dispatcher regularly returns the exact amount, 100000. https://old.reddit.com/r/Kotlin/comments/v4j01h/volatile_works_in_coroutine/

This seems to happen more often when I run the code on my mobile... but that's a guess.

When I change `Dispatchers.Default` to `Dispatchers.IO` it appears to demonstrate the problem more reliably.

- [ ] Should the Dispatcher in the other examples also be changed?