### PR TITLE
Fix debug module publication with shadow plugin

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -45,11 +45,7 @@ publishing {
         // Configure java publications for regular non-MPP modules
         publications {
             maven(MavenPublication) {
-                if (project.name == "kotlinx-coroutines-debug") {
-                    project.shadow.component(it)
-                } else {
-                    from components.java
-                }
+                from components.java
                 artifact sourcesJar
             }
         }

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -53,6 +53,18 @@ sourceSets {
             implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutines_version"
         }
     }
+
+    debugDynamicAgentTest {
+        kotlin
+        compileClasspath += sourceSets.test.runtimeClasspath
+        runtimeClasspath += sourceSets.test.runtimeClasspath
+
+        dependencies {
+            implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+            implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutines_version"
+        }
+    }
+
     coreAgentTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath
@@ -93,6 +105,14 @@ task debugAgentTest(type: Test) {
     systemProperties project.properties.subMap(["overwrite.probes"])
 }
 
+task debugDynamicAgentTest(type: Test) {
+    environment "version", coroutines_version
+    def sourceSet = sourceSets.debugDynamicAgentTest
+    testClassesDirs = sourceSet.output.classesDirs
+    classpath = sourceSet.runtimeClasspath
+}
+
+
 task coreAgentTest(type: Test) {
     def sourceSet = sourceSets.coreAgentTest
     def coroutinesCoreJar = sourceSet.runtimeClasspath.filter {it.name == "kotlinx-coroutines-core-jvm-${coroutines_version}.jar" }.singleFile
@@ -106,5 +126,5 @@ compileTestKotlin {
 }
 
 check {
-    dependsOn([withGuavaTest, mavenTest, debugAgentTest, coreAgentTest, 'smokeTest:build'])
+    dependsOn([withGuavaTest, debugDynamicAgentTest, mavenTest, debugAgentTest, coreAgentTest, 'smokeTest:build'])
 }

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 }
 
 sourceSets {
+    // Test that relies on Guava to reflectively check all Throwable subclasses in coroutines
     withGuavaTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath
@@ -33,6 +34,7 @@ sourceSets {
             implementation 'com.google.guava:guava:31.1-jre'
         }
     }
+    // Checks correctness of Maven publication (JAR resources) and absence of atomicfu symbols
     mavenTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath
@@ -43,6 +45,7 @@ sourceSets {
             implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
         }
     }
+    // Checks that kotlinx-coroutines-debug can be used as -javaagent parameter
     debugAgentTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath
@@ -54,6 +57,7 @@ sourceSets {
         }
     }
 
+    // Checks that kotlinx-coroutines-debug agent can self-attach dynamically to JVM as standalone dependency
     debugDynamicAgentTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath
@@ -65,6 +69,7 @@ sourceSets {
         }
     }
 
+    // Checks that kotlinx-coroutines-core can be used as -javaagent parameter
     coreAgentTest {
         kotlin
         compileClasspath += sourceSets.test.runtimeClasspath

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -111,12 +111,10 @@ task debugAgentTest(type: Test) {
 }
 
 task debugDynamicAgentTest(type: Test) {
-    environment "version", coroutines_version
     def sourceSet = sourceSets.debugDynamicAgentTest
     testClassesDirs = sourceSet.output.classesDirs
     classpath = sourceSet.runtimeClasspath
 }
-
 
 task coreAgentTest(type: Test) {
     def sourceSet = sourceSets.coreAgentTest

--- a/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
+++ b/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 import org.junit.*
 import kotlinx.coroutines.*

--- a/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
+++ b/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+import org.junit.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.*
+import org.junit.Test
+import java.io.*
+import java.lang.IllegalStateException
+
+class DynamicAttachDebugTest {
+
+    @Test
+    fun testAgentDumpsCoroutines() =
+        DebugProbes.withDebugProbes {
+            runBlocking {
+                val baos = ByteArrayOutputStream()
+                DebugProbes.dumpCoroutines(PrintStream(baos))
+                // if the agent works, then dumps should contain something,
+                // at least the fact that this test is running.
+                Assert.assertTrue(baos.toString().contains("testAgentDumpsCoroutines"))
+            }
+        }
+
+    @Test(expected = IllegalStateException::class)
+    fun testAgentIsNotInstalled() {
+        DebugProbes.dumpCoroutines(PrintStream(ByteArrayOutputStream()))
+    }
+}

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -34,6 +34,18 @@ jar {
     setEnabled(false)
 }
 
+// This is a rough estimation of what shadow plugin has been doing with our default configuration prior to
+// 1.6.2: https://github.com/johnrengelman/shadow/blob/1ff12fc816629ae5bc331fa3889c8ecfcaee7b27/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy#L72-L82
+// We just emulate it here for backwards compatibility
+shadowJar.configure {
+    def classpath = project.objects.fileCollection().from { ->
+        project.configurations.findByName('runtimeClasspath')
+    }
+    doFirst {
+        manifest.attributes 'Class-Path': classpath.collect { "${it.name}" }.findAll { it }.join(' ')
+    }
+}
+
 def shadowJarTask = shadowJar {
     classifier null
     // Shadow only byte buddy, do not package kotlin stdlib

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -32,10 +32,6 @@ java {
 
 jar {
     setEnabled(false)
-    manifest {
-        attributes "Premain-Class": "kotlinx.coroutines.debug.AgentPremain"
-        attributes "Can-Redefine-Classes": "true"
-    }
 }
 
 def shadowJarTask = shadowJar {
@@ -43,6 +39,11 @@ def shadowJarTask = shadowJar {
     // Shadow only byte buddy, do not package kotlin stdlib
     configurations = [project.configurations.shadowDeps]
     relocate('net.bytebuddy', 'kotlinx.coroutines.repackaged.net.bytebuddy')
+
+    manifest {
+        attributes "Premain-Class": "kotlinx.coroutines.debug.AgentPremain"
+        attributes "Can-Redefine-Classes": "true"
+    }
 }
 
 configurations {

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -8,14 +8,6 @@ configurations {
     shadowDeps // shaded dependencies, not included into the resulting .pom file
     compileOnly.extendsFrom(shadowDeps)
     runtimeOnly.extendsFrom(shadowDeps)
-
-    /*
-     * It is possible to extend a particular configuration with shadow,
-     * but in that case it changes dependency type to "runtime" and resolves it
-     * (so it cannot be further modified). Otherwise, shadow just ignores all dependencies.
-     */
-    shadow.extendsFrom(api) // shadow - resulting configuration with shaded jar file
-    configureKotlinJvmPlatform(shadow)
 }
 
 dependencies {
@@ -39,17 +31,25 @@ java {
 }
 
 jar {
+    setEnabled(false)
     manifest {
         attributes "Premain-Class": "kotlinx.coroutines.debug.AgentPremain"
         attributes "Can-Redefine-Classes": "true"
     }
 }
 
-shadowJar {
+def shadowJarTask = shadowJar {
     classifier null
     // Shadow only byte buddy, do not package kotlin stdlib
     configurations = [project.configurations.shadowDeps]
     relocate('net.bytebuddy', 'kotlinx.coroutines.repackaged.net.bytebuddy')
+}
+
+configurations {
+    artifacts {
+        add("apiElements", shadowJarTask)
+        add("runtimeElements", shadowJarTask)
+    }
 }
 
 def commonKoverExcludes =


### PR DESCRIPTION
It seems like Maven's BOM has never worked with shadow plugin in our previous releases: added `api` dependency was just too late.
It has been changed in the latest shadow plugin release and it automatically promoted all `api` dependencies to `runtime` (https://github.com/johnrengelman/shadow/issues/321), triggering #3345. Gradle builds were never affected though because they were primarily parsing Gradle metadata.


<details>
<summary>Resulting debug module POM</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.jetbrains.kotlinx</groupId>
  <artifactId>kotlinx-coroutines-debug</artifactId>
  <version>1.6.3-SNAPSHOT</version>
  <packaging>pom</packaging>
  <name>kotlinx-coroutines-debug</name>
  <description>Coroutines support libraries for Kotlin</description>
  <url>https://github.com/Kotlin/kotlinx.coroutines</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>JetBrains</id>
      <name>JetBrains Team</name>
      <organization>JetBrains</organization>
      <organizationUrl>https://www.jetbrains.com</organizationUrl>
    </developer>
  </developers>
  <scm>
    <url>https://github.com/Kotlin/kotlinx.coroutines</url>
  </scm>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.jetbrains.kotlinx</groupId>
        <artifactId>kotlinx-coroutines-bom</artifactId>
        <version>1.6.3-SNAPSHOT</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlinx</groupId>
      <artifactId>kotlinx-coroutines-core-jvm</artifactId>
      <version>1.6.3-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>net.java.dev.jna</groupId>
      <artifactId>jna</artifactId>
      <version>5.9.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>net.java.dev.jna</groupId>
      <artifactId>jna-platform</artifactId>
      <version>5.9.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib-jdk8</artifactId>
      <version>1.6.21</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>net.bytebuddy</groupId>
      <artifactId>byte-buddy</artifactId>
      <version>1.10.9</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>net.bytebuddy</groupId>
      <artifactId>byte-buddy-agent</artifactId>
      <version>1.10.9</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>

```