### PR TITLE
Await comply with reactive streams Subscriber rule 2.7

### DIFF
--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -204,13 +204,11 @@ private suspend fun <T> Publisher<T>.awaitOne(
                 return
             }
             subscription = sub
-
             cont.invokeOnCancellation {
                 withSubscriptionLock {
                     sub.cancel()
                 }
             }
-
             withSubscriptionLock {
                 sub.request(if (mode == Mode.FIRST || mode == Mode.FIRST_OR_DEFAULT) 1 else Long.MAX_VALUE)
             }

--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -202,8 +202,9 @@ private suspend fun <T> Publisher<T>.awaitOne(
                 return
             }
             subscription = sub
-            cont.invokeOnCancellation { sub.cancel() }
             sub.request(if (mode == Mode.FIRST || mode == Mode.FIRST_OR_DEFAULT) 1 else Long.MAX_VALUE)
+            // Due to rule 2.7 ensuring that Subscription request is finished before registering cancellation handler
+            cont.invokeOnCancellation { sub.cancel() }
         }
 
         override fun onNext(t: T) {

--- a/reactive/kotlinx-coroutines-reactive/src/Await.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Await.kt
@@ -198,13 +198,22 @@ private suspend fun <T> Publisher<T>.awaitOne(
             /** cancelling the new subscription due to rule 2.5, though the publisher would either have to
              * subscribe more than once, which would break 2.12, or leak this [Subscriber]. */
             if (subscription != null) {
-                sub.cancel()
+                withSubscriptionLock {
+                    sub.cancel()
+                }
                 return
             }
             subscription = sub
-            sub.request(if (mode == Mode.FIRST || mode == Mode.FIRST_OR_DEFAULT) 1 else Long.MAX_VALUE)
-            // Due to rule 2.7 ensuring that Subscription request is finished before registering cancellation handler
-            cont.invokeOnCancellation { sub.cancel() }
+
+            cont.invokeOnCancellation {
+                withSubscriptionLock {
+                    sub.cancel()
+                }
+            }
+
+            withSubscriptionLock {
+                sub.request(if (mode == Mode.FIRST || mode == Mode.FIRST_OR_DEFAULT) 1 else Long.MAX_VALUE)
+            }
         }
 
         override fun onNext(t: T) {
@@ -229,12 +238,16 @@ private suspend fun <T> Publisher<T>.awaitOne(
                         return
                     }
                     seenValue = true
-                    sub.cancel()
+                    withSubscriptionLock {
+                        sub.cancel()
+                    }
                     cont.resume(t)
                 }
                 Mode.LAST, Mode.SINGLE, Mode.SINGLE_OR_DEFAULT -> {
                     if ((mode == Mode.SINGLE || mode == Mode.SINGLE_OR_DEFAULT) && seenValue) {
-                        sub.cancel()
+                        withSubscriptionLock {
+                            sub.cancel()
+                        }
                         /* the check for `cont.isActive` is needed in case `sub.cancel() above calls `onComplete` or
                          `onError` on its own. */
                         if (cont.isActive) {
@@ -289,6 +302,14 @@ private suspend fun <T> Publisher<T>.awaitOne(
             }
             inTerminalState = true
             return true
+        }
+
+        /**
+         * Enforce rule 2.7: [Subscription.request] and [Subscription.cancel] must be executed serially
+         */
+        @Synchronized
+        private fun withSubscriptionLock(block: () -> Unit) {
+            block()
         }
     })
 }

--- a/reactive/kotlinx-coroutines-reactive/test/AwaitCancellationStressTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/AwaitCancellationStressTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.reactive
+
+import kotlinx.coroutines.*
+import org.junit.*
+import org.reactivestreams.*
+import java.util.concurrent.atomic.*
+
+/**
+ * This test checks implementation of rule 2.7 for await methods - serial execution of subscription methods
+ */
+class AwaitCancellationStressTest : TestBase() {
+    private val jobsToRun = 1000 * stressTestMultiplier
+
+    @Test
+    fun testRequestStress() = runTest {
+        val jobs = (1..jobsToRun).map {
+            launch(Dispatchers.Default) {
+                testPublisher().awaitFirst()
+            }
+        }
+        jobs.forEach { it.cancel() }
+        jobs.joinAll()
+    }
+
+    private fun testPublisher() = Publisher<Int> { s ->
+        val counter = AtomicInteger()
+        s.onSubscribe(object : Subscription {
+            override fun request(n: Long) {
+                check(counter.getAndIncrement() == 0)
+                Thread.sleep(10)
+                counter.decrementAndGet()
+            }
+
+            override fun cancel() {
+                check(counter.getAndIncrement() == 0)
+                counter.decrementAndGet()
+            }
+        })
+    }
+}

--- a/reactive/kotlinx-coroutines-reactive/test/AwaitCancellationStressTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/AwaitCancellationStressTest.kt
@@ -16,7 +16,7 @@ class AwaitCancellationStressTest : TestBase() {
     private val jobsToRun = 1000 * stressTestMultiplier
 
     @Test
-    fun testRequestStress() = runTest {
+    fun testAwaitCancellationOrder() = runTest {
         val jobs = (1..jobsToRun).map {
             launch(Dispatchers.Default) {
                 testPublisher().awaitFirst()

--- a/reactive/kotlinx-coroutines-reactive/test/AwaitTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/AwaitTest.kt
@@ -39,4 +39,5 @@ class AwaitTest: TestBase() {
         job.cancelAndJoin()
         finish(7)
     }
+
 }

--- a/reactive/kotlinx-coroutines-reactive/test/AwaitTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/AwaitTest.kt
@@ -60,7 +60,7 @@ class AwaitTest: TestBase() {
                 }
             })
         }
-        val job = launch(Dispatchers.IO) {
+        val job = launch(Dispatchers.Default) {
             try {
                 publisher.awaitFirst()
             } catch (e: CancellationException) {
@@ -71,7 +71,10 @@ class AwaitTest: TestBase() {
         subscriptionStarted.lock()
         expect(3)
 
-        job.cancel()
+        launch(Dispatchers.Default) {
+            job.cancel()
+        }
+        delay(10)
         requestCompletion.unlock()
         job.join()
 


### PR DESCRIPTION
Rule [2.7](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.3/README.md#2-subscriber-code) requires Subscription methods to be executed serially.

There is a possibility of race between Subscription.request and Subscription.cancel methods since cancellation handler could be executed in a separate thread.

In particular this bug leads to database connection leaks if used with [jooq subscription](https://github.com/jOOQ/jOOQ/blob/9423e7b6a2e25e136217e431b1780b737e6078fd/jOOQ/src/main/java/org/jooq/impl/R2DBC.java#L138) as cancel can happen while request being initialized and hence it misses to close connection.