### PR TITLE
Mark context in DiagnosticCoroutineContextException as transient

### DIFF
--- a/integration-testing/src/withGuavaTest/kotlin/ListAllCoroutineThrowableSubclassesTest.kt
+++ b/integration-testing/src/withGuavaTest/kotlin/ListAllCoroutineThrowableSubclassesTest.kt
@@ -7,6 +7,8 @@ package kotlinx.coroutines
 import com.google.common.reflect.*
 import kotlinx.coroutines.*
 import org.junit.Test
+import java.io.Serializable
+import java.lang.reflect.Modifier
 import kotlin.test.*
 
 class ListAllCoroutineThrowableSubclassesTest {
@@ -31,13 +33,21 @@ class ListAllCoroutineThrowableSubclassesTest {
         "kotlinx.coroutines.channels.ClosedReceiveChannelException",
         "kotlinx.coroutines.flow.internal.ChildCancelledException",
         "kotlinx.coroutines.flow.internal.AbortFlowException",
-        )
+    )
 
     @Test
     fun testThrowableSubclassesAreSerializable() {
         val classes = ClassPath.from(this.javaClass.classLoader)
             .getTopLevelClassesRecursive("kotlinx.coroutines");
         val throwables = classes.filter { Throwable::class.java.isAssignableFrom(it.load()) }.map { it.toString() }
+        for (throwable in throwables) {
+            for (field in throwable.javaClass.declaredFields) {
+                if (Modifier.isStatic(field.modifiers)) continue
+                val type = field.type
+                assertTrue(type.isPrimitive || Serializable::class.java.isAssignableFrom(type),
+                "Throwable $throwable has non-serializable field $field")
+            }
+        }
         assertEquals(knownThrowables.sorted(), throwables.sorted())
     }
 }

--- a/integration-testing/src/withGuavaTest/kotlin/ListAllCoroutineThrowableSubclassesTest.kt
+++ b/integration-testing/src/withGuavaTest/kotlin/ListAllCoroutineThrowableSubclassesTest.kt
@@ -45,7 +45,7 @@ class ListAllCoroutineThrowableSubclassesTest {
                 if (Modifier.isStatic(field.modifiers)) continue
                 val type = field.type
                 assertTrue(type.isPrimitive || Serializable::class.java.isAssignableFrom(type),
-                "Throwable $throwable has non-serializable field $field")
+                    "Throwable $throwable has non-serializable field $field")
             }
         }
         assertEquals(knownThrowables.sorted(), throwables.sorted())

--- a/kotlinx-coroutines-core/jvm/src/CoroutineExceptionHandlerImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineExceptionHandlerImpl.kt
@@ -29,7 +29,7 @@ private val handlers: List<CoroutineExceptionHandler> = ServiceLoader.load(
  * The purpose of this exception is to add an otherwise inaccessible diagnostic information and to
  * be able to poke the failing coroutine context in the debugger.
  */
-private class DiagnosticCoroutineContextException(private val context: CoroutineContext) : RuntimeException() {
+private class DiagnosticCoroutineContextException(@Transient private val context: CoroutineContext) : RuntimeException() {
     override fun getLocalizedMessage(): String {
         return context.toString()
     }


### PR DESCRIPTION
Fixes #3328