### PR TITLE
Provide a way for customization Dokka's HTML output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,3 +355,7 @@ allprojects { subProject ->
                 }
             }
 }
+
+tasks.named("dokkaHtmlMultiModule") {
+    pluginsMapConfiguration.set(["org.jetbrains.dokka.base.DokkaBase": """{ "templatesDir": "${projectDir.toString().replace('\\', '/')}/dokka-templates" }"""])
+}

--- a/dokka-templates/README.md
+++ b/dokka-templates/README.md
@@ -1,0 +1,4 @@
+# Customize Dokka's HTML. 
+To customize Dokka's HTML output, place a file in this folder.
+Dokka will find a template file there. If the file is not found, a default one will be used.
+This folder is defined by the templatesDir property.

--- a/gradle/dokka.gradle.kts
+++ b/gradle/dokka.gradle.kts
@@ -27,6 +27,8 @@ tasks.withType(DokkaTaskPartial::class).configureEach {
 
 tasks.withType(DokkaTaskPartial::class).configureEach {
     suppressInheritedMembers.set(true)
+    pluginsMapConfiguration.set(mapOf("org.jetbrains.dokka.base.DokkaBase" to """{ "templatesDir" : "${rootProject.projectDir.toString().replace('\\', '/')}/dokka-templates" }"""))
+
     dokkaSourceSets.configureEach {
         jdkVersion.set(11)
         includes.from("README.md")


### PR DESCRIPTION
We want to customize the header and the footer in coroutines API reference on kotlinlang.org to provide a better user experience and consistency between all parts of kotlinlang.org. 

Starting from the 1.6.20 version, Dokka supports customization of HTML output. You can read about it [here](https://kotlin.github.io/dokka/1.6.20/user_guide/base-specific/frontend/#custom-html-pages).
To use this opportunity, we need a small preparation on your side.
These changes allow HTML customization. 
The rest we will do on our side. 