### PR TITLE
Fix documentation for `DEBUG_PROPERTY_VALUE_OFF`

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Debug.kt
+++ b/kotlinx-coroutines-core/jvm/src/Debug.kt
@@ -59,7 +59,7 @@ public const val DEBUG_PROPERTY_VALUE_AUTO: String = "auto"
 public const val DEBUG_PROPERTY_VALUE_ON: String = "on"
 
 /**
- * Debug turned on value for [DEBUG_PROPERTY_NAME].
+ * Debug turned off value for [DEBUG_PROPERTY_NAME].
  */
 public const val DEBUG_PROPERTY_VALUE_OFF: String = "off"
 


### PR DESCRIPTION
Based against `master` as this PR only fixes documentation and doesn't change line numbers.