### PR TITLE
Properly cancel handles returned by setTimeout in JS dispatchers

### DIFF
--- a/kotlinx-coroutines-core/js/src/JSDispatcher.kt
+++ b/kotlinx-coroutines-core/js/src/JSDispatcher.kt
@@ -47,7 +47,6 @@ internal sealed class SetTimeoutBasedDispatcher: CoroutineDispatcher(), Delay {
 
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         val handle = setTimeout({ with(continuation) { resumeUndispatched(Unit) } }, delayToInt(timeMillis))
-        // Actually on cancellation, but clearTimeout is idempotent
         continuation.invokeOnCancellation(handler = ClearTimeout(handle).asHandler)
     }
 }
@@ -64,7 +63,7 @@ internal object SetTimeoutDispatcher : SetTimeoutBasedDispatcher() {
     }
 }
 
-private class ClearTimeout(private val handle: Int) : CancelHandler(), DisposableHandle {
+private open class ClearTimeout(protected val handle: Int) : CancelHandler(), DisposableHandle {
 
     override fun dispose() {
         clearTimeout(handle)
@@ -83,15 +82,18 @@ internal class WindowDispatcher(private val window: Window) : CoroutineDispatche
     override fun dispatch(context: CoroutineContext, block: Runnable) = queue.enqueue(block)
 
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
-        window.setTimeout({ with(continuation) { resumeUndispatched(Unit) } }, delayToInt(timeMillis))
+        val handle = window.setTimeout({ with(continuation) { resumeUndispatched(Unit) } }, delayToInt(timeMillis))
+        continuation.invokeOnCancellation(handler = WindowClearTimeout(handle).asHandler)
     }
 
     override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
         val handle = window.setTimeout({ block.run() }, delayToInt(timeMillis))
-        return object : DisposableHandle {
-            override fun dispose() {
-                window.clearTimeout(handle)
-            }
+        return WindowClearTimeout(handle)
+    }
+
+    private inner class WindowClearTimeout(handle: Int) : ClearTimeout(handle) {
+        override fun dispose() {
+            window.clearTimeout(handle)
         }
     }
 }


### PR DESCRIPTION
Otherwise, usage of withTimeout lead to excessive memory pressure and OOMs
