### PR TITLE
Insert missing "(" in CoroutineScheduler's KDoc

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -69,7 +69,7 @@ import kotlin.random.*
  *
  * When a new task arrives in the scheduler (whether it is local or global queue),
  * either an idle worker is being signalled, or a new worker is attempted to be created.
- * Only [corePoolSize] workers can be created for regular CPU tasks)
+ * (Only [corePoolSize] workers can be created for regular CPU tasks)
  *
  * ### Support for blocking tasks
  * The scheduler also supports the notion of [blocking][TASK_PROBABLY_BLOCKING] tasks.


### PR DESCRIPTION
In CoroutineScheduler's KDoc, missing `(` was added. Considering the keyboard distance between `)` and `.`, `)` was judged as missing a `(` in front of the sentence instead of a typo of `.`.