### PR TITLE
Allow customization of default scheduler name on JVM

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/SystemProps.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SystemProps.common.kt
@@ -58,6 +58,17 @@ internal fun systemProp(
 
 /**
  * Gets the system property indicated by the specified [property name][propertyName],
+ * or returns [defaultValue] if there is no property with that key.
+ *
+ * **Note: this function should be used in JVM tests only, other platforms use the default value.**
+ */
+internal fun systemProp(
+    propertyName: String,
+    defaultValue: String
+): String = systemProp(propertyName) ?: defaultValue
+
+/**
+ * Gets the system property indicated by the specified [property name][propertyName],
  * or returns `null` if there is no property with that key.
  *
  * **Note: this function should be used in JVM tests only, other platforms use the default value.**

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
@@ -10,13 +10,7 @@ import java.util.concurrent.*
 
 
 /**
- * Name of the default scheduler.
- *
- * Customization provided for when there's no control over used dispatchers/schedulers (i.e when
- * [Dispatchers.Default] is used within third-party libraries), or when overall default configuration
- * is acceptable and only the default scheduler name needs to be changed.
- *
- * Useful for filtering log messages.
+ * The name of the default scheduler. The names of the worker threads of [Dispatchers.Default] have it as their prefix.
  */
 @JvmField
 internal val DEFAULT_SCHEDULER_NAME = systemProp(

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
@@ -9,8 +9,19 @@ import kotlinx.coroutines.internal.*
 import java.util.concurrent.*
 
 
-// Internal debuggability name + thread name prefixes
-internal const val DEFAULT_SCHEDULER_NAME = "DefaultDispatcher"
+/**
+ * Name of the default scheduler.
+ *
+ * Customization provided for when there's no control over used dispatchers/schedulers (i.e when
+ * [Dispatchers.Default] is used within third-party libraries), or when overall default configuration
+ * is acceptable and only the default scheduler name needs to be changed.
+ *
+ * Useful for filtering log messages.
+ */
+@JvmField
+internal val DEFAULT_SCHEDULER_NAME = systemProp(
+    "kotlinx.coroutines.scheduler.default.name", "DefaultDispatcher"
+)
 
 // 100us as default
 @JvmField


### PR DESCRIPTION
Fixes #3231