### PR TITLE
Fix flakiness of TimeoutTest

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
@@ -99,16 +99,19 @@ class TimeoutTest : TestBase() {
     @Test
     fun testUpstreamErrorTimeoutException() = testUpstreamError(TimeoutCancellationException(0, Job()))
 
+    @Test
+    fun testUpstreamErrorCancellationException() = testUpstreamError(CancellationException(""))
+
     private inline fun <reified T: Throwable> testUpstreamError(cause: T) = runTest {
         try {
             // Workaround for JS legacy bug
             flow {
                 emit(1)
                 throw cause
-            }.timeout(1.milliseconds).collect()
+            }.timeout(1000.milliseconds).collect()
             expectUnreached()
         } catch (e: Throwable) {
-            assertTrue { e is T }
+            assertIs<T>(e)
             finish(1)
         }
     }


### PR DESCRIPTION
Increase timeout, so it's never triggered as these tests do not require it to race or trigger with the upstream