### PR TITLE
Fix atomicfu plugin application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ def configureKotlinJvmPlatform(configuration) {
     configuration.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
 }
 
+// Configure subprojects with Kotlin sources
+apply plugin: "configure-compilation-conventions"
+
 allprojects {
     // the only place where HostManager could be instantiated
     project.ext.hostManager = new HostManager()
@@ -166,9 +169,6 @@ configure(subprojects.findAll { !sourceless.contains(it.name) && it.name != core
 }
 
 apply plugin: "bom-conventions"
-
-// Configure subprojects with Kotlin sources
-apply plugin: "configure-compilation-conventions"
 
 if (build_snapshot_train) {
     println "Hacking test tasks, removing stress and flaky tests"


### PR DESCRIPTION
The new way of atomicfu compiler plugin applicaition takes 3 steps: 
- first the compiler plugin `AtomicfuKotlinGradleSubplugin` is [applied](https://github.com/Kotlin/kotlinx-atomicfu/blob/70dd7aaa2c51d5ca2556e981581830c5696fcbd3/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt#L119). It adds an extension `AtomicfuKotlinGradleExtension` with properties for turning on jvm and js transformation.
- Then these extension properties are [set](https://github.com/Kotlin/kotlinx-atomicfu/blob/70dd7aaa2c51d5ca2556e981581830c5696fcbd3/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt#L121) in the AtomicfuGradlePlugin.
- When `AtomicfuKotlinGradleSubplugin$isApplicable` is invoked, the values of the extension properties are already set and the plugin is applied accordingly.

When we apply the atomicfu plugin too late in the configuration -- the `AtomicfuKotlinGradleSubplugin$isApplicable` may be called earlier, when the properties are not set yet and the compiler plugin is not applied.

[The Train build](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_BuildPlayground_MilkyWayMargaritaBobova_kotlinxtraincoroutines/224222229?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true) with these changes + atomicfu JVM compiler plugin support
