### PR TITLE
docs: fix internal link in immediate documentation

### DIFF
--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -20,7 +20,7 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
      *
      * Immediate dispatcher is safe from stack overflows and in case of nested invocations forms event-loop similar to [Dispatchers.Unconfined].
      * The event loop is an advanced topic and its implications can be found in [Dispatchers.Unconfined] documentation.
-     * The formed event-loop is shared with [Unconfined] and other immediate dispatchers, potentially overlapping tasks between them.
+     * The formed event-loop is shared with [Dispatchers.Unconfined] and other immediate dispatchers, potentially overlapping tasks between them.
      *
      * Example of usage:
      * ```


### PR DESCRIPTION
Fix a link to an internal object (`Unconfined`) which generates a [404](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-unconfined/) link in the website on the page https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-main-coroutine-dispatcher/immediate.html