### PR TITLE
Remove some broken tests

### DIFF
--- a/kotlinx-coroutines-test/common/test/RunTestTest.kt
+++ b/kotlinx-coroutines-test/common/test/RunTestTest.kt
@@ -69,20 +69,6 @@ class RunTestTest {
         deferred.await()
     }
 
-    /** Tests that a dispatch timeout of `0` will fail the test if there are some dispatches outside the scheduler. */
-    @Test
-    fun testRunTestWithZeroTimeoutWithUncontrolledDispatches() = testResultMap({ fn ->
-        assertFailsWith<UncompletedCoroutinesError> { fn() }
-    }) {
-        runTest(dispatchTimeoutMs = 0) {
-            withContext(Dispatchers.Default) {
-                delay(10)
-                3
-            }
-            fail("shouldn't be reached")
-        }
-    }
-
     /** Tests that too low of a dispatch timeout causes crashes. */
     @Test
     fun testRunTestWithSmallTimeout() = testResultMap({ fn ->

--- a/kotlinx-coroutines-test/jvm/test/migration/RunTestLegacyScopeTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/RunTestLegacyScopeTest.kt
@@ -67,19 +67,6 @@ class RunTestLegacyScopeTest {
     }
 
     @Test
-    fun testRunTestWithZeroTimeoutWithUncontrolledDispatches() = testResultMap({ fn ->
-        assertFailsWith<UncompletedCoroutinesError> { fn() }
-    }) {
-        runTestWithLegacyScope(dispatchTimeoutMs = 0) {
-            withContext(Dispatchers.Default) {
-                delay(10)
-                3
-            }
-            fail("shouldn't be reached")
-        }
-    }
-
-    @Test
     fun testRunTestWithSmallTimeout() = testResultMap({ fn ->
         assertFailsWith<UncompletedCoroutinesError> { fn() }
     }) {


### PR DESCRIPTION
These tests haven't been reliable for a very long time for some reason. We could ensure that they pass with a manual check, but it feels like nobody actually relies on this behavior, and it's not clear who even would want to.

https://github.com/search?p=3&q=%22dispatchTimeoutMs+%3D+0%22&type=Code https://grep.app/search?q=dispatchTimeoutMs%20%3D%200