### PR TITLE
Fix coroutines dump tests

### DIFF
--- a/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
+++ b/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
@@ -23,12 +23,13 @@ class CoroutinesDumpTest : DebugTestBase() {
         val found = DebugProbes.dumpCoroutinesInfo().single { it.job === deferred }
         verifyDump(
             "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: SUSPENDED\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.sleepingNestedMethod(CoroutinesDumpTest.kt:95)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.sleepingOuterMethod(CoroutinesDumpTest.kt:88)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.sleepingNestedMethod(CoroutinesDumpTest.kt)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.sleepingOuterMethod(CoroutinesDumpTest.kt)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
-                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
-                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
-                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n",
+                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable\$default(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt)\n",
             ignoredCoroutine = "BlockingCoroutine"
         ) {
             deferred.cancel()
@@ -48,19 +49,21 @@ class CoroutinesDumpTest : DebugTestBase() {
         verifyDump(
             "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@227d9994, state: RUNNING\n" +
                     "\tat java.lang.Thread.sleep(Native Method)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt:141)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt:133)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest\$testRunningCoroutine\$1$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt:41)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.access\$activeMethod(CoroutinesDumpTest.kt)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest\$testRunningCoroutine\$1\$deferred\$1.invokeSuspend(CoroutinesDumpTest.kt)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
-                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
-                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
-                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
-                    "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)\n" +
+                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable\$default(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt)\n" +
+                    "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt.async(Unknown Source)\n" +
                     "\tat kotlinx.coroutines.BuildersKt__Builders_commonKt.async\$default(Builders.common.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt.async\$default(Unknown Source)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.testRunningCoroutine(CoroutinesDumpTest.kt:49)",
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest\$testRunningCoroutine\$1.invokeSuspend(CoroutinesDumpTest.kt)",
             ignoredCoroutine = "BlockingCoroutine"
         ) {
             deferred.cancel()
@@ -79,18 +82,19 @@ class CoroutinesDumpTest : DebugTestBase() {
         verifyDump(
             "Coroutine \"coroutine#1\":DeferredCoroutine{Active}@1e4a7dd4, state: RUNNING\n" +
                     "\tat java.lang.Thread.sleep(Native Method)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt:111)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt:106)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.nestedActiveMethod(CoroutinesDumpTest.kt)\n" +
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.activeMethod(CoroutinesDumpTest.kt)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
-                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)\n" +
-                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:23)\n" +
-                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:99)\n" +
-                    "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:148)\n" +
+                    "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable\$default(Cancellable.kt)\n" +
+                    "\tat kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt)\n" +
+                    "\tat kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt.async(Unknown Source)\n" +
                     "\tat kotlinx.coroutines.BuildersKt__Builders_commonKt.async\$default(Builders.common.kt)\n" +
                     "\tat kotlinx.coroutines.BuildersKt.async\$default(Unknown Source)\n" +
-                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest.testRunningCoroutineWithSuspensionPoint(CoroutinesDumpTest.kt:71)",
+                    "\tat kotlinx.coroutines.debug.CoroutinesDumpTest\$testRunningCoroutineWithSuspensionPoint\$1.invokeSuspend(CoroutinesDumpTest.kt)",
             ignoredCoroutine = "BlockingCoroutine"
         ) {
             deferred.cancel()
@@ -126,9 +130,12 @@ class CoroutinesDumpTest : DebugTestBase() {
             "kotlinx.coroutines.BuildersKt.async\$default(Unknown Source)\n" +
             "kotlinx.coroutines.debug.CoroutinesDumpTest\$testCreationStackTrace\$1.invokeSuspend(CoroutinesDumpTest.kt)"
         if (!result.startsWith(expected)) {
-            println("=== Actual result")
-            println(result)
-            error("Does not start with expected lines")
+            error("""
+                |Does not start with expected lines
+                |=== Actual result:
+                |$result
+                """.trimMargin()
+            )
         }
 
     }

--- a/kotlinx-coroutines-debug/test/RunningThreadStackMergeTest.kt
+++ b/kotlinx-coroutines-debug/test/RunningThreadStackMergeTest.kt
@@ -20,7 +20,6 @@ class RunningThreadStackMergeTest : DebugTestBase() {
         launchCoroutine()
         awaitCoroutineStarted()
         verifyDump(
-            "Coroutine \"coroutine#1\":BlockingCoroutine{Active}@62230679", // <- this one is ignored
             "Coroutine \"coroutine#2\":StandaloneCoroutine{Active}@50284dc4, state: RUNNING\n" +
                     "\tat jdk.internal.misc.Unsafe.park(Native Method)\n" +
                     "\tat java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)\n" +
@@ -34,7 +33,7 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\tat kotlinx.coroutines.debug.RunningThreadStackMergeTest\$launchCoroutine\$1.invokeSuspend(RunningThreadStackMergeTest.kt:68)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
-            ignoredCoroutine = ":BlockingCoroutine"
+            ignoredCoroutine = "BlockingCoroutine"
         ) {
             coroutineBlocker.await()
         }
@@ -75,7 +74,6 @@ class RunningThreadStackMergeTest : DebugTestBase() {
         awaitCoroutineStarted()
         Thread.sleep(10)
         verifyDump(
-            "Coroutine \"coroutine#1\":BlockingCoroutine{Active}@62230679", // <- this one is ignored
             "Coroutine \"coroutine#2\":StandaloneCoroutine{Active}@3aea3c67, state: RUNNING\n" +
                     "\tat jdk.internal.misc.Unsafe.park(Native Method)\n" +
                     "\tat java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)\n" +
@@ -89,7 +87,7 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\tat kotlinx.coroutines.debug.RunningThreadStackMergeTest\$launchEscapingCoroutine\$1.invokeSuspend(RunningThreadStackMergeTest.kt:116)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
-            ignoredCoroutine = ":BlockingCoroutine"
+            ignoredCoroutine = "BlockingCoroutine"
         ) {
             coroutineBlocker.await()
         }
@@ -116,7 +114,6 @@ class RunningThreadStackMergeTest : DebugTestBase() {
         launchEscapingCoroutineWithoutContext()
         awaitCoroutineStarted()
         verifyDump(
-            "Coroutine \"coroutine#1\":BlockingCoroutine{Active}@62230679", // <- this one is ignored
             "Coroutine \"coroutine#2\":StandaloneCoroutine{Active}@3aea3c67, state: RUNNING\n" +
                     "\tat jdk.internal.misc.Unsafe.park(Native Method)\n" +
                     "\tat java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)\n" +
@@ -128,7 +125,7 @@ class RunningThreadStackMergeTest : DebugTestBase() {
                     "\tat kotlinx.coroutines.debug.RunningThreadStackMergeTest\$launchEscapingCoroutineWithoutContext\$1.invokeSuspend(RunningThreadStackMergeTest.kt:153)\n" +
                     "\tat _COROUTINE._CREATION._(CoroutineDebugging.kt)\n" +
                     "\tat kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:116)",
-            ignoredCoroutine = ":BlockingCoroutine"
+            ignoredCoroutine = "BlockingCoroutine"
         ) {
             coroutineBlocker.await()
         }

--- a/kotlinx-coroutines-debug/test/StacktraceUtils.kt
+++ b/kotlinx-coroutines-debug/test/StacktraceUtils.kt
@@ -7,13 +7,13 @@ package kotlinx.coroutines.debug
 import java.io.*
 import kotlin.test.*
 
-private val coroutineCreationFrameRegex =
-    Regex("\n\tat _COROUTINE._CREATION._[^\n]*\n")
-
 public fun String.trimStackTrace(): String =
     trimIndent()
+        // Remove source line
         .replace(Regex(":[0-9]+"), "")
+        // Remove coroutine id
         .replace(Regex("#[0-9]+"), "")
+        // Remove trace prefix: "java.base@11.0.16.1/java.lang.Thread.sleep" => "java.lang.Thread.sleep"
         .replace(Regex("(?<=\tat )[^\n]*/"), "")
         .replace(Regex("\t"), "")
         .replace("sun.misc.Unsafe.", "jdk.internal.misc.Unsafe.") // JDK8->JDK11
@@ -74,36 +74,128 @@ private fun cleanBlockHoundTraces(frames: List<String>): List<String> {
     return result
 }
 
-public fun verifyDump(vararg traces: String, ignoredCoroutine: String? = null) {
+private data class CoroutineDump(
+    val header: CoroutineDumpHeader,
+    val coroutineStackTrace: List<String>,
+    val threadStackTrace: List<String>,
+    val originDump: String,
+    val originHeader: String,
+) {
+    companion object {
+        private val COROUTINE_CREATION_FRAME_REGEX =
+            "at _COROUTINE\\._CREATION\\._\\(.*\\)".toRegex()
+
+        fun parse(dump: String, traceCleaner: ((List<String>) -> List<String>)? = null): CoroutineDump {
+            val lines = dump
+                .trimStackTrace()
+                .split("\n")
+            val header = CoroutineDumpHeader.parse(lines[0])
+            val traceLines = lines.slice(1 until lines.size)
+            val cleanedTraceLines = if (traceCleaner != null) {
+                traceCleaner(traceLines)
+            } else {
+                traceLines
+            }
+            val coroutineStackTrace = mutableListOf<String>()
+            val threadStackTrace = mutableListOf<String>()
+            var trace = coroutineStackTrace
+            for (line in cleanedTraceLines) {
+                if (line.isEmpty()) {
+                    continue
+                }
+                if (line.matches(COROUTINE_CREATION_FRAME_REGEX)) {
+                    require(trace !== threadStackTrace) {
+                        "Found more than one coroutine creation frame"
+                    }
+                    trace = threadStackTrace
+                    continue
+                }
+                trace.add(line)
+            }
+            return CoroutineDump(header, coroutineStackTrace, threadStackTrace, dump, lines[0])
+        }
+    }
+
+    fun verify(expected: CoroutineDump) {
+        assertEquals(
+            expected.header, header,
+            "Coroutine stacktrace headers are not matched:\n\t- ${expected.originHeader}\n\t+ ${originHeader}\n"
+        )
+        verifyStackTrace("coroutine stack", coroutineStackTrace, expected.coroutineStackTrace)
+        verifyStackTrace("thread stack", threadStackTrace, expected.threadStackTrace)
+    }
+
+    private fun verifyStackTrace(traceName: String, actualStackTrace: List<String>, expectedStackTrace: List<String>) {
+        // It is possible there are more stack frames in a dump than we check
+        for ((ix, expectedLine) in expectedStackTrace.withIndex()) {
+            val actualLine = actualStackTrace[ix]
+            assertEquals(
+                expectedLine, actualLine,
+                "Following lines from $traceName are not matched:\n\t- ${expectedLine}\n\t+ ${actualLine}\nActual dump:\n$originDump\n\n"
+            )
+        }
+    }
+}
+
+private data class CoroutineDumpHeader(
+    val name: String?,
+    val className: String,
+    val state: String,
+) {
+    companion object {
+        /**
+         * Parses following strings:
+         *
+         * - Coroutine "coroutine#10":DeferredCoroutine{Active}@66d87651, state: RUNNING
+         * - Coroutine DeferredCoroutine{Active}@66d87651, state: RUNNING
+         *
+         * into:
+         *
+         * - `CoroutineDumpHeader(name = "coroutine", className = "DeferredCoroutine", state = "RUNNING")`
+         * - `CoroutineDumpHeader(name = null, className = "DeferredCoroutine", state = "RUNNING")`
+         */
+        fun parse(header: String): CoroutineDumpHeader {
+            val (identFull, stateFull) = header.split(", ", limit = 2)
+            val nameAndClassName = identFull.removePrefix("Coroutine ").split('@', limit = 2)[0]
+            val (name, className) = nameAndClassName.split(':', limit = 2).let { parts ->
+                val (quotedName, classNameWithState) = if (parts.size == 1) {
+                    null to parts[0]
+                } else {
+                    parts[0] to parts[1]
+                }
+                val name = quotedName?.removeSurrounding("\"")?.split('#', limit = 2)?.get(0)
+                val className = classNameWithState.replace("\\{.*\\}".toRegex(), "")
+                name to className
+            }
+            val state = stateFull.removePrefix("state: ")
+            return CoroutineDumpHeader(name, className, state)
+        }
+    }
+}
+
+public fun verifyDump(vararg expectedTraces: String, ignoredCoroutine: String? = null) {
     val baos = ByteArrayOutputStream()
     DebugProbes.dumpCoroutines(PrintStream(baos))
     val wholeDump = baos.toString()
-    val trace = wholeDump.split("\n\n")
-    if (traces.isEmpty()) {
-        val filtered = trace.filter { ignoredCoroutine == null || !it.contains(ignoredCoroutine) }
-        assertEquals(1, filtered.count())
-        assertTrue(filtered[0].startsWith("Coroutines dump"))
-        return
-    }
-    // The first line, "Coroutine dump", is dropped. This is not `zip` because not having enough dumps is an error.
-    trace.drop(1).withIndex().forEach { (index, value) ->
-        if (ignoredCoroutine != null && value.contains(ignoredCoroutine)) {
-            return@forEach
-        }
+    val traces = wholeDump.split("\n\n")
+    assertTrue(traces[0].startsWith("Coroutines dump"))
 
-        val expected = traces[index].split(coroutineCreationFrameRegex, limit = 2)
-        val actual = value.split(coroutineCreationFrameRegex, limit = 2)
-        assertEquals(expected.size, actual.size, "Creation stacktrace should be part of the expected input. Whole dump:\n$wholeDump")
-
-        actual.zip(expected).forEach { (actualTrace, expectedTrace) ->
-            val sanitizedActualTrace = actualTrace.trimStackTrace().sanitizeAddresses()
-            val sanitizedExpectedTrace = expectedTrace.trimStackTrace().sanitizeAddresses()
-            val actualLines = cleanBlockHoundTraces(sanitizedActualTrace.split("\n"))
-            val expectedLines = sanitizedExpectedTrace.split("\n")
-            for (i in expectedLines.indices) {
-                assertEquals(expectedLines[i], actualLines[i], "Whole dump:\n$wholeDump")
+    val dumps = traces
+        // Drop "Coroutine dump" line
+        .drop(1)
+        // Parse dumps and filter out ignored coroutines
+        .mapNotNull { trace ->
+            val dump = CoroutineDump.parse(trace, traceCleaner = ::cleanBlockHoundTraces)
+            if (dump.header.className == ignoredCoroutine) {
+                null
+            } else {
+                dump
             }
         }
+
+    assertEquals(expectedTraces.size, dumps.size)
+    dumps.zip(expectedTraces.map(CoroutineDump::parse)).forEach { (dump, expectedDump) ->
+        dump.verify(expectedDump)
     }
 }
 
@@ -120,11 +212,4 @@ public fun verifyPartialDump(createdCoroutinesCount: Int, vararg frames: String)
 
     assertEquals(createdCoroutinesCount, DebugProbes.dumpCoroutinesInfo().size)
     assertTrue(matches)
-}
-
-private fun String.sanitizeAddresses(): String {
-    val index = indexOf("coroutine\"")
-    val next = indexOf(',', index)
-    if (index == -1 || next == -1) return this
-    return substring(0, index) + substring(next, length)
 }


### PR DESCRIPTION
`CoroutinesDumpTest` tests used `verifyDump` incorrectly because of all coroutine traces contains `BlockingCoroutine` substring. So these tests actually did not check any coroutine stack traces.

To reduce probability of incorrect usage of `verifyDump` added code that parses coroutine stack traces.