### PR TITLE
Kotlin 1.8.0: Fix java targetCompatibility was unset in :kotlinx-coroutines-jdk9

### DIFF
--- a/reactive/kotlinx-coroutines-jdk9/build.gradle.kts
+++ b/reactive/kotlinx-coroutines-jdk9/build.gradle.kts
@@ -6,6 +6,11 @@ dependencies {
     implementation(project(":kotlinx-coroutines-reactive"))
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_9
+    targetCompatibility = JavaVersion.VERSION_1_9
+}
+
 tasks {
     compileKotlin {
         kotlinOptions.jvmTarget = "9"


### PR DESCRIPTION
By default Java targetCompatibility is equal to current Gradle JDK version which could be different from specified in this module Kotlin 'jvmTarget' and depend on current user JDK version.
Also Java targetCompatability controls Gradle "org.gradle.jvm.version" publication attribute, which is wrongly set to '8' in '1.6.4' release module file. Setting it explicetly fixes publication issue.

This change fixes compatibility with Kotlin 1.8.0 release changes from
this issue: https://youtrack.jetbrains.com/issue/KT-54993