### PR TITLE
Introduce a separate slot for stealing tasks into in CoroutineScheduler

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -265,7 +265,7 @@ internal class CoroutineScheduler(
 
     /**
      * Long describing state of workers in this pool.
-     * Currently includes created, CPU-acquired and blocking workers each occupying [BLOCKING_SHIFT] bits.
+     * Currently, includes created, CPU-acquired and blocking workers each occupying [BLOCKING_SHIFT] bits.
      */
     private val controlState = atomic(corePoolSize.toLong() shl CPU_PERMITS_SHIFT)
     private val createdWorkers: Int inline get() = (controlState.value and CREATED_MASK).toInt()
@@ -273,7 +273,7 @@ internal class CoroutineScheduler(
 
     private inline fun createdWorkers(state: Long): Int = (state and CREATED_MASK).toInt()
     private inline fun blockingTasks(state: Long): Int = (state and BLOCKING_MASK shr BLOCKING_SHIFT).toInt()
-    public inline fun availableCpuPermits(state: Long): Int = (state and CPU_PERMITS_MASK shr CPU_PERMITS_SHIFT).toInt()
+    inline fun availableCpuPermits(state: Long): Int = (state and CPU_PERMITS_MASK shr CPU_PERMITS_SHIFT).toInt()
 
     // Guarded by synchronization
     private inline fun incrementCreatedWorkers(): Int = createdWorkers(controlState.incrementAndGet())
@@ -927,9 +927,9 @@ internal class CoroutineScheduler(
                 if (worker !== null && worker !== this) {
                     assert { localQueue.size == 0 }
                     val stealResult = if (blockingOnly) {
-                        localQueue.tryStealBlockingFrom(victim = worker.localQueue, stolenTask)
+                        worker.localQueue.tryStealBlocking(stolenTask)
                     } else {
-                        localQueue.tryStealFrom(victim = worker.localQueue, stolenTask)
+                        worker.localQueue.trySteal(stolenTask)
                     }
                     if (stealResult == TASK_STOLEN) {
                         val result = stolenTask.element

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -265,7 +265,7 @@ internal class CoroutineScheduler(
 
     /**
      * Long describing state of workers in this pool.
-     * Currently, includes created, CPU-acquired and blocking workers each occupying [BLOCKING_SHIFT] bits.
+     * Currently includes created, CPU-acquired, and blocking workers, each occupying [BLOCKING_SHIFT] bits.
      */
     private val controlState = atomic(corePoolSize.toLong() shl CPU_PERMITS_SHIFT)
     private val createdWorkers: Int inline get() = (controlState.value and CREATED_MASK).toInt()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -264,7 +264,7 @@ internal class CoroutineScheduler(
     val workers = ResizableAtomicArray<Worker>(corePoolSize + 1)
 
     /**
-     * Long describing state of workers in this pool.
+     * The `Long` value describing the state of workers in this pool.
      * Currently includes created, CPU-acquired, and blocking workers, each occupying [BLOCKING_SHIFT] bits.
      */
     private val controlState = atomic(corePoolSize.toLong() shl CPU_PERMITS_SHIFT)

--- a/kotlinx-coroutines-core/jvm/src/scheduling/WorkQueue.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/WorkQueue.kt
@@ -121,7 +121,7 @@ internal class WorkQueue {
         var start = consumerIndex.value
         val end = producerIndex.value
 
-        while (start != end) {
+        while (start != end && blockingTasksInBuffer.value > 0) {
             stolenTaskRef.element = tryExtractBlockingTask(start++) ?: continue
             return TASK_STOLEN
         }
@@ -141,7 +141,7 @@ internal class WorkQueue {
         val start = consumerIndex.value
         var end = producerIndex.value
 
-        while (start != end) {
+        while (start != end && blockingTasksInBuffer.value > 0) {
             val task = tryExtractBlockingTask(--end)
             if (task != null) {
                 return task
@@ -151,7 +151,6 @@ internal class WorkQueue {
     }
 
     private fun tryExtractBlockingTask(index: Int): Task? {
-        if (blockingTasksInBuffer.value == 0) return null
         val arrayIndex = index and MASK
         val value = buffer[arrayIndex]
         if (value != null && value.isBlocking && buffer.compareAndSet(arrayIndex, value, null)) {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/WorkQueue.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/WorkQueue.kt
@@ -122,16 +122,8 @@ internal class WorkQueue {
         val end = producerIndex.value
 
         while (start != end) {
-            val index = start and MASK
-            if (blockingTasksInBuffer.value == 0) break
-            val value = buffer[index]
-            if (value != null && value.isBlocking && buffer.compareAndSet(index, value, null)) {
-                blockingTasksInBuffer.decrementAndGet()
-                stolenTaskRef.element = value
-                return TASK_STOLEN
-            } else {
-                ++start
-            }
+            stolenTaskRef.element = tryExtractBlockingTask(start++) ?: continue
+            return TASK_STOLEN
         }
         return tryStealLastScheduled(stolenTaskRef, blockingOnly = true)
     }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CoroutineSchedulerOversubscriptionTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CoroutineSchedulerOversubscriptionTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.*
+import org.junit.Test
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+
+class CoroutineSchedulerOversubscriptionTest : TestBase() {
+
+    private val inDefault = AtomicInteger(0)
+
+    private fun CountDownLatch.runAndCheck() {
+        if (inDefault.incrementAndGet() > CORE_POOL_SIZE) {
+            error("Oversubscription detected")
+        }
+
+        await()
+        inDefault.decrementAndGet()
+    }
+
+    @Test
+    fun testOverSubscriptionDeterministic() = runTest {
+        val barrier = CountDownLatch(1)
+        val threadsOccupiedBarrier = CyclicBarrier(CORE_POOL_SIZE)
+        // All threads but one
+        repeat(CORE_POOL_SIZE - 1) {
+            launch(Dispatchers.Default) {
+                threadsOccupiedBarrier.await()
+                barrier.runAndCheck()
+            }
+        }
+        threadsOccupiedBarrier.await()
+        withContext(Dispatchers.Default) {
+            // Put a task in a local queue, it will be stolen
+            launch(Dispatchers.Default) {
+                barrier.runAndCheck()
+            }
+            // Put one more task to trick the local queue check
+            launch(Dispatchers.Default) {
+                barrier.runAndCheck()
+            }
+
+            withContext(Dispatchers.IO) {
+                try {
+                    // Release the thread
+                    delay(100)
+                } finally {
+                    barrier.countDown()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testOverSubscriptionStress() = repeat(1000 * stressTestMultiplierSqrt) {
+        inDefault.set(0)
+        runTest {
+            val barrier = CountDownLatch(1)
+            val threadsOccupiedBarrier = CyclicBarrier(CORE_POOL_SIZE)
+            // All threads but one
+            repeat(CORE_POOL_SIZE - 1) {
+                launch(Dispatchers.Default) {
+                    threadsOccupiedBarrier.await()
+                    barrier.runAndCheck()
+                }
+            }
+            threadsOccupiedBarrier.await()
+            withContext(Dispatchers.Default) {
+                // Put a task in a local queue
+                launch(Dispatchers.Default) {
+                    barrier.runAndCheck()
+                }
+                // Put one more task to trick the local queue check
+                launch(Dispatchers.Default) {
+                    barrier.runAndCheck()
+                }
+
+                withContext(Dispatchers.IO) {
+                    yield()
+                    barrier.countDown()
+                }
+            }
+        }
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
@@ -41,7 +41,7 @@ class WorkQueueStressTest : TestBase() {
         threads += thread(name = "producer") {
             startLatch.await()
             for (i in 1..offerIterations) {
-                while (producerQueue.bufferSize > BUFFER_CAPACITY / 2) {
+                while (producerQueue.size > BUFFER_CAPACITY / 2) {
                     Thread.yield()
                 }
 
@@ -79,7 +79,7 @@ class WorkQueueStressTest : TestBase() {
         threads += thread(name = "producer") {
             startLatch.await()
             for (i in 1..offerIterations) {
-                while (producerQueue.bufferSize == BUFFER_CAPACITY - 1) {
+                while (producerQueue.size == BUFFER_CAPACITY - 1) {
                     Thread.yield()
                 }
 

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
@@ -9,6 +9,7 @@ import org.junit.*
 import org.junit.Test
 import java.util.concurrent.*
 import kotlin.concurrent.*
+import kotlin.jvm.internal.*
 import kotlin.test.*
 
 class WorkQueueStressTest : TestBase() {
@@ -52,17 +53,18 @@ class WorkQueueStressTest : TestBase() {
 
         for (i in 0 until stealersCount) {
             threads += thread(name = "stealer $i") {
+                val ref = Ref.ObjectRef<Task?>()
                 val myQueue = WorkQueue()
                 startLatch.await()
                 while (!producerFinished || producerQueue.size != 0) {
-                    stolenTasks[i].addAll(myQueue.drain().map { task(it) })
-                    myQueue.tryStealFrom(victim = producerQueue)
+                    stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
+                    myQueue.tryStealFrom(victim = producerQueue, ref)
                 }
 
                 // Drain last element which is not counted in buffer
-                stolenTasks[i].addAll(myQueue.drain().map { task(it) })
-                myQueue.tryStealFrom(producerQueue)
-                stolenTasks[i].addAll(myQueue.drain().map { task(it) })
+                stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
+                myQueue.tryStealFrom(producerQueue, ref)
+                stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
             }
         }
 
@@ -89,13 +91,14 @@ class WorkQueueStressTest : TestBase() {
         val stolen = GlobalQueue()
         threads += thread(name = "stealer") {
             val myQueue = WorkQueue()
+            val ref = Ref.ObjectRef<Task?>()
             startLatch.await()
             while (stolen.size != offerIterations) {
-                if (myQueue.tryStealFrom(producerQueue) != NOTHING_TO_STEAL) {
-                    stolen.addAll(myQueue.drain().map { task(it) })
+                if (myQueue.tryStealFrom(producerQueue, ref) != NOTHING_TO_STEAL) {
+                    stolen.addAll(myQueue.drain(ref).map { task(it) })
                 }
             }
-            stolen.addAll(myQueue.drain().map { task(it) })
+            stolen.addAll(myQueue.drain(ref).map { task(it) })
         }
 
         startLatch.countDown()

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueStressTest.kt
@@ -58,12 +58,12 @@ class WorkQueueStressTest : TestBase() {
                 startLatch.await()
                 while (!producerFinished || producerQueue.size != 0) {
                     stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
-                    myQueue.tryStealFrom(victim = producerQueue, ref)
+                    producerQueue.trySteal(ref)
                 }
 
                 // Drain last element which is not counted in buffer
                 stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
-                myQueue.tryStealFrom(producerQueue, ref)
+                producerQueue.trySteal(ref)
                 stolenTasks[i].addAll(myQueue.drain(ref).map { task(it) })
             }
         }
@@ -94,7 +94,7 @@ class WorkQueueStressTest : TestBase() {
             val ref = Ref.ObjectRef<Task?>()
             startLatch.await()
             while (stolen.size != offerIterations) {
-                if (myQueue.tryStealFrom(producerQueue, ref) != NOTHING_TO_STEAL) {
+                if (producerQueue.trySteal(ref) != NOTHING_TO_STEAL) {
                     stolen.addAll(myQueue.drain(ref).map { task(it) })
                 }
             }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
@@ -63,10 +63,10 @@ class WorkQueueTest : TestBase() {
 
         val stealer = WorkQueue()
         val ref = ObjectRef<Task?>()
-        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim, ref))
+        assertEquals(TASK_STOLEN, victim.trySteal(ref))
         assertEquals(arrayListOf(1L), stealer.drain(ref))
 
-        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim, ref))
+        assertEquals(TASK_STOLEN, victim.trySteal(ref))
         assertEquals(arrayListOf(2L), stealer.drain(ref))
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
@@ -69,9 +69,20 @@ class WorkQueueTest : TestBase() {
         assertEquals(TASK_STOLEN, victim.trySteal(ref))
         assertEquals(arrayListOf(2L), stealer.drain(ref))
     }
+
+    @Test
+    fun testPollBlocking() {
+        val queue = WorkQueue()
+        assertNull(queue.pollBlocking())
+        val blockingTask = blockingTask(1L)
+        queue.add(blockingTask)
+        queue.add(task(1L))
+        assertSame(blockingTask, queue.pollBlocking())
+    }
 }
 
 internal fun task(n: Long) = TaskImpl(Runnable {}, n, NonBlockingContext)
+internal fun blockingTask(n: Long) = TaskImpl(Runnable {}, n, BlockingContext)
 
 internal fun WorkQueue.drain(ref: ObjectRef<Task?>): List<Long> {
     var task: Task? = poll()

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
@@ -7,6 +7,7 @@ package kotlinx.coroutines.scheduling
 import kotlinx.coroutines.*
 import org.junit.*
 import org.junit.Test
+import kotlin.jvm.internal.Ref.ObjectRef
 import kotlin.test.*
 
 class WorkQueueTest : TestBase() {
@@ -27,7 +28,7 @@ class WorkQueueTest : TestBase() {
     fun testLastScheduledComesFirst() {
         val queue = WorkQueue()
         (1L..4L).forEach { queue.add(task(it)) }
-        assertEquals(listOf(4L, 1L, 2L, 3L), queue.drain())
+        assertEquals(listOf(4L, 1L, 2L, 3L), queue.drain(ObjectRef()))
     }
 
     @Test
@@ -38,9 +39,9 @@ class WorkQueueTest : TestBase() {
         (0 until size).forEach { queue.add(task(it))?.let { t -> offload.addLast(t) } }
 
         val expectedResult = listOf(129L) + (0L..126L).toList()
-        val actualResult = queue.drain()
+        val actualResult = queue.drain(ObjectRef())
         assertEquals(expectedResult, actualResult)
-        assertEquals((0L until size).toSet().minus(expectedResult), offload.drain().toSet())
+        assertEquals((0L until size).toSet().minus(expectedResult.toSet()), offload.drain().toSet())
     }
 
     @Test
@@ -61,22 +62,27 @@ class WorkQueueTest : TestBase() {
         timeSource.step(3)
 
         val stealer = WorkQueue()
-        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim))
-        assertEquals(arrayListOf(1L), stealer.drain())
+        val ref = ObjectRef<Task?>()
+        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim, ref))
+        assertEquals(arrayListOf(1L), stealer.drain(ref))
 
-        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim))
-        assertEquals(arrayListOf(2L), stealer.drain())
+        assertEquals(TASK_STOLEN, stealer.tryStealFrom(victim, ref))
+        assertEquals(arrayListOf(2L), stealer.drain(ref))
     }
 }
 
 internal fun task(n: Long) = TaskImpl(Runnable {}, n, NonBlockingContext)
 
-internal fun WorkQueue.drain(): List<Long> {
+internal fun WorkQueue.drain(ref: ObjectRef<Task?>): List<Long> {
     var task: Task? = poll()
     val result = arrayListOf<Long>()
     while (task != null) {
         result += task.submissionTime
         task = poll()
+    }
+    if (ref.element != null) {
+        result += ref.element!!.submissionTime
+        ref.element = null
     }
     return result
 }


### PR DESCRIPTION
It solves two problems:

* Stealing into exclusively owned local queue does no longer require and CAS'es or atomic operations where they were previously not needed. It should save a few cycles on the stealing code path
* The overall timing perturbations should be slightly better now: previously it was possible for the stolen task to be immediately got stolen again from the stealer thread because it was actually published to owner's queue, but its submission time was never updated

Fixes #3416