### PR TITLE
Prepare coroutines for including to the community projects composite build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        CommunityProjectsBuild.addDevRepositoryIfEnabled(delegate, project)
         mavenLocal()
     }
 
@@ -130,7 +130,7 @@ allprojects {
          */
         google()
         mavenCentral()
-        maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        CommunityProjectsBuild.addDevRepositoryIfEnabled(delegate, project)
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 val cacheRedirectorEnabled = System.getenv("CACHE_REDIRECTOR")?.toBoolean() == true
 val buildSnapshotTrain = properties["build_snapshot_train"]?.toString()?.toBoolean() == true
+val kotlinDevUrl = project.rootProject.properties["kotlin_repo_url"] as? String
 
 repositories {
     mavenCentral()
@@ -18,7 +19,9 @@ repositories {
     } else {
         maven("https://plugins.gradle.org/m2")
     }
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+    if (!kotlinDevUrl.isNullOrEmpty()) {
+        maven(kotlinDevUrl)
+    }
     if (buildSnapshotTrain) {
         mavenLocal()
     }

--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+@file:JvmName("CommunityProjectsBuild")
+
+import org.gradle.api.*
+import org.gradle.api.artifacts.dsl.*
+import java.net.*
+import java.util.logging.*
+
+private val LOGGER: Logger = Logger.getLogger("Kotlin settings logger")
+
+
+/**
+ * Functions in this file are responsible for configuring kotlinx.coroutines build against a custom dev version
+ * of Kotlin compiler.
+ * Such configuration is used in a composite community build of Kotlin in order to check whether not-yet-released changes
+ * are compatible with our libraries (aka "integration testing that substitues lack of unit testing").
+ */
+
+/**
+ * Should be used for running against of non-released Kotlin compiler on a system test level
+ * Kotlin compiler artifacts are expected to be downloaded from maven central by default.
+ * In case of compiling with not-published into the MC kotlin compiler artifacts, a kotlin_repo_url gradle parameter should be specified.
+ * To reproduce a build locally, a kotlin/dev repo should be passed
+ *
+ * @return an url for a kotlin compiler repository parametrized from command line nor gradle.properties, empty string otherwise
+ */
+fun getKotlinDevRepositoryUrl(project: Project): URI? {
+    val url: String? = project.rootProject.properties["kotlin_repo_url"] as? String
+    if (url != null) {
+        LOGGER.info("""Configured Kotlin Compiler repository url: '$url' for project ${project.name}""")
+        return URI.create(url)
+    }
+    return null
+}
+
+/**
+ * Adds a kotlin-dev space repository with dev versions of Kotlin if Kotlin aggregate build is enabled
+ */
+fun addDevRepositoryIfEnabled(rh: RepositoryHandler, project: Project) {
+    val devRepoUrl = getKotlinDevRepositoryUrl(project) ?: return
+    rh.maven {
+        url = devRepoUrl
+    }
+}


### PR DESCRIPTION
 //KTI-1051

Support passing an url for a kotlin compiler repository, drop space kotlin/dev repo from dependencies: Kotlin compiler artifacts should be downloaded from maven central by default. In case of compiling with not-published into the MC kotlin compiler artifacts, a kotlin_repo_url should be specified as a gradle parameter(E.g. space kotlin/dev repo).