### PR TITLE
Eliminate unneeded `LimitedDispatcher` instances on `Dispatchers.Default` and `Dispatchers.IO`

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -50,7 +50,7 @@ private object UnlimitedIoScheduler : CoroutineDispatcher() {
     @ExperimentalCoroutinesApi
     override fun limitedParallelism(parallelism: Int): CoroutineDispatcher {
         parallelism.checkParallelism()
-        if (parallelism == Int.MAX_VALUE) return this
+        if (parallelism >= MAX_POOL_SIZE) return this
         return super.limitedParallelism(parallelism)
     }
 }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -38,6 +38,13 @@ private object UnlimitedIoScheduler : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         DefaultScheduler.dispatchWithContext(block, BlockingContext, false)
     }
+
+    @ExperimentalCoroutinesApi
+    override fun limitedParallelism(parallelism: Int): CoroutineDispatcher {
+        parallelism.checkParallelism()
+        if (parallelism == Int.MAX_VALUE) return this
+        return super.limitedParallelism(parallelism)
+    }
 }
 
 // Dispatchers.IO

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -14,6 +14,14 @@ internal object DefaultScheduler : SchedulerCoroutineDispatcher(
     CORE_POOL_SIZE, MAX_POOL_SIZE,
     IDLE_WORKER_KEEP_ALIVE_NS, DEFAULT_SCHEDULER_NAME
 ) {
+
+    @ExperimentalCoroutinesApi
+    override fun limitedParallelism(parallelism: Int): CoroutineDispatcher {
+        parallelism.checkParallelism()
+        if (parallelism >= CORE_POOL_SIZE) return this
+        return super.limitedParallelism(parallelism)
+    }
+
     // Shuts down the dispatcher, used only by Dispatchers.shutdown()
     internal fun shutdown() {
         super.close()


### PR DESCRIPTION
Before the change `LimitedDispatcher(parallelism)` was returned. While it does work as expected, any submitted task 
goes through its queue and `parallelism` number of workers. The change allows to eliminate the `LimitedDispatcher` 
instance and its queue in case the requested parallelism is greater or equal to the effective parallelism of `Dispatchers.Default` and/or `Dispatchers.IO`