### PR TITLE
Remove confusing comma in Coroutines Hands-on

### DIFF
--- a/docs/topics/coroutines-and-channels.md
+++ b/docs/topics/coroutines-and-channels.md
@@ -215,7 +215,7 @@ is to use _callbacks_.
 Instead of calling the code that should be invoked right after the operation is completed, you can extract it
 into a separate callback, often a lambda, and pass that lambda to the caller in order for it to be called later.
 
-To make the UI responsive, you can either move the whole computation to a separate thread or switch to the Retrofit API,
+To make the UI responsive, you can either move the whole computation to a separate thread or switch to the Retrofit API
 which uses callbacks instead of blocking calls.
 
 ### Use a background thread


### PR DESCRIPTION
This change makes sure the sentence reflects the actual meaning: We're switching to the type of API that uses callbacks, rather than switching to the API, which incidentally happens to use callbacks.