### PR TITLE
Fix example code

### DIFF
--- a/docs/topics/coroutines-and-channels.md
+++ b/docs/topics/coroutines-and-channels.md
@@ -905,7 +905,7 @@ the parent coroutine.
         req: RequestData
     ): List<User> = coroutineScope {
         // ...
-        GlobalScope.async {
+        async {
             log("starting loading for ${repo.name}")
             delay(3000)
             // load repo contributors


### PR DESCRIPTION
GlobalScope should not be in loadContributorsConcurrent if you want the function to be cancellable by using the cancel button.