### PR TITLE
Indicate the use of virtual time in withTimeout in TestScope

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -561,6 +561,7 @@ public final class kotlinx/coroutines/ThreadPoolDispatcherKt {
 }
 
 public final class kotlinx/coroutines/TimeoutCancellationException : java/util/concurrent/CancellationException, kotlinx/coroutines/CopyableThrowable {
+	public fun <init> (Ljava/lang/String;Lkotlinx/coroutines/Job;)V
 	public synthetic fun createCopy ()Ljava/lang/Throwable;
 	public fun createCopy ()Lkotlinx/coroutines/TimeoutCancellationException;
 }

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -165,7 +165,7 @@ private class TimeoutCoroutine<U, in T: U>(
 /**
  * This exception is thrown by [withTimeout] to indicate timeout.
  */
-public class TimeoutCancellationException internal constructor(
+public class TimeoutCancellationException @PublishedApi internal constructor(
     message: String,
     @JvmField @Transient internal val coroutine: Job?
 ) : CancellationException(message), CopyableThrowable<TimeoutCancellationException> {

--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
@@ -120,6 +120,8 @@ public final class kotlinx/coroutines/test/TestScopeKt {
 	public static final fun getCurrentTime (Lkotlinx/coroutines/test/TestScope;)J
 	public static final fun getTestTimeSource (Lkotlinx/coroutines/test/TestScope;)Lkotlin/time/TimeSource;
 	public static final fun runCurrent (Lkotlinx/coroutines/test/TestScope;)V
+	public static final fun withTimeout (Lkotlinx/coroutines/test/TestScope;JLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withTimeout-dWUq8MI (Lkotlinx/coroutines/test/TestScope;JLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class kotlinx/coroutines/test/UncaughtExceptionCaptor {

--- a/kotlinx-coroutines-test/common/test/TestScopeTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestScopeTest.kt
@@ -476,6 +476,20 @@ class TestScopeTest {
         }
     }
 
+    /**
+     * Tests that [TestScope.withTimeout] notifies the programmer about using the virtual time.
+     */
+    @Test
+    fun testTimingOutWithVirtualTimeMessage() = runTest {
+        try {
+            withTimeout(1_000_000) {
+                Channel<Unit>().receive()
+            }
+        } catch (e: TimeoutCancellationException) {
+            assertContains(e.message!!, "virtual")
+        }
+    }
+
     companion object {
         internal val invalidContexts = listOf(
             Dispatchers.Default, // not a [TestDispatcher]


### PR DESCRIPTION
Fixes https://github.com/Kotlin/kotlinx.coroutines/issues/3588