### PR TITLE
Update the code example for Dispatchers.Unconfined

### DIFF
--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -56,7 +56,7 @@ public expect object Dispatchers {
      * ```
      * withContext(Dispatchers.Unconfined) {
      *    println(1)
-     *    withContext(Dispatchers.Unconfined) { // Nested unconfined
+     *    launch(Dispatchers.Unconfined) { // Nested unconfined
      *        println(2)
      *    }
      *    println(3)


### PR DESCRIPTION
The previous example used `withContext` which is guaranteed to complete before the code after it runs. The updated example uses `launch` which I think was originally intended.

This fixes #3605 and [KT-47032](https://youtrack.jetbrains.com/issue/KT-47032/Incorrect-code-example-for-Dispatchers.Unconfined-in-kotlinx.coroutines-docs)