### PR TITLE
Allow FlowAsPublisher to complete if collecting last element

### DIFF
--- a/reactive/kotlinx-coroutines-reactive/src/ReactiveFlow.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/ReactiveFlow.kt
@@ -234,17 +234,16 @@ public class FlowSubscription<T>(
      */
     private suspend fun consumeFlow() {
         flow.collect { value ->
-            // Emit the value
-            subscriber.onNext(value)
-            // Suspend if needed before requesting the next value
-            if (requested.decrementAndGet() <= 0) {
+            // Suspend if needed before emitting the next value
+            if (requested.getAndDecrement() <= 0) {
                 suspendCancellableCoroutine<Unit> {
                     producer.value = it
                 }
-            } else {
-                // check for cancellation if we don't suspend
-                coroutineContext.ensureActive()
             }
+            // Emit the value
+            subscriber.onNext(value)
+            // check for cancellation if we don't suspend
+            coroutineContext.ensureActive()
         }
     }
 

--- a/reactive/kotlinx-coroutines-reactive/test/FlowAsPublisherTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/FlowAsPublisherTest.kt
@@ -167,7 +167,7 @@ class FlowAsPublisherTest : TestBase() {
     }
 
     @Test
-    fun testSingleElementPublisher() = runTest {
+    fun testSingleRequestOnSingleElementPublisherCompletes() = runTest {
         val publisher = flowOf(1).asPublisher()
         expect(1)
         publisher.subscribe(object : Subscriber<Int> {

--- a/reactive/kotlinx-coroutines-reactive/test/FlowAsPublisherTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/FlowAsPublisherTest.kt
@@ -165,4 +165,30 @@ class FlowAsPublisherTest : TestBase() {
         }
         finish(4)
     }
+
+    @Test
+    fun testSingleElementPublisher() = runTest {
+        val publisher = flowOf(1).asPublisher()
+        expect(1)
+        publisher.subscribe(object : Subscriber<Int> {
+            override fun onSubscribe(s: Subscription) {
+                expect(2)
+                s.request(1)
+            }
+
+            override fun onNext(t: Int) {
+                expect(3)
+                assertEquals(1, t)
+            }
+
+            override fun onComplete() {
+                expect(4)
+            }
+
+            override fun onError(t: Throwable?) {
+                expectUnreached()
+            }
+        })
+        finish(5)
+    }
 }


### PR DESCRIPTION
These are the changes as I proposed in https://github.com/Kotlin/kotlinx.coroutines/issues/3608

By moving the suspension check above the `onNext` call, we allow the collect block to complete if it is the last element in the collection. I left `ensureActive` at the bottom to so that `testCancellationIsNotReported` was passing. 

I added a test `testSingleRequestOnSingleElementPublisherCompletes` which has one element, subscribes to receive exactly one element, and expects it completes. 

~Leaving as draft while I verify non FlowAsPublisher tests.~ all `jvmTest` passed