### PR TITLE
Remove docs about Dispatchers.kt that replicate the common code

### DIFF
--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -15,7 +15,7 @@ public expect object Dispatchers {
      * [launch][CoroutineScope.launch], [async][CoroutineScope.async], etc
      * if neither a dispatcher nor any other [ContinuationInterceptor] is specified in their context.
      *
-     * It is backed by a shared pool of threads on JVM. By default, the maximum number of threads used
+     * It is backed by a shared pool of threads on JVM and Native. By default, the maximum number of threads used
      * by this dispatcher is equal to the number of CPU cores, but is at least two.
      */
     public val Default: CoroutineDispatcher
@@ -27,7 +27,7 @@ public expect object Dispatchers {
      * Access to this property may throw an [IllegalStateException] if no main dispatchers are present in the classpath.
      *
      * Depending on platform and classpath, it can be mapped to different dispatchers:
-     * - On JVM it is either the Android main thread dispatcher, JavaFx or Swing EDT dispatcher. It is chosen by the
+     * - On JVM it is either the Android main thread dispatcher, JavaFx, or Swing EDT dispatcher. It is chosen by the
      *   [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
      * - On JS it is equivalent to the [Default] dispatcher with [immediate][MainCoroutineDispatcher.immediate] support.
      * - On Native Darwin-based targets, it is a dispatcher backed by Darwin's main queue.
@@ -37,6 +37,7 @@ public expect object Dispatchers {
      *  - `kotlinx-coroutines-android` &mdash; for Android Main thread dispatcher
      *  - `kotlinx-coroutines-javafx` &mdash; for JavaFx Application thread dispatcher
      *  - `kotlinx-coroutines-swing` &mdash; for Swing EDT dispatcher
+     *  - `kotlinx-coroutines-test` &mdash; for mocking the `Main` dispatcher in tests via `Dispatchers.setMain`
      */
     public val Main: MainCoroutineDispatcher
 

--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -19,76 +19,12 @@ public const val IO_PARALLELISM_PROPERTY_NAME: String = "kotlinx.coroutines.io.p
  * Groups various implementations of [CoroutineDispatcher].
  */
 public actual object Dispatchers {
-    /**
-     * The default [CoroutineDispatcher] that is used by all standard builders like
-     * [launch][CoroutineScope.launch], [async][CoroutineScope.async], etc.
-     * if no dispatcher nor any other [ContinuationInterceptor] is specified in their context.
-     *
-     * It is backed by a shared pool of threads on JVM. By default, the maximal level of parallelism used
-     * by this dispatcher is equal to the number of CPU cores, but is at least two.
-     * Level of parallelism X guarantees that no more than X tasks can be executed in this dispatcher in parallel.
-     */
     @JvmStatic
     public actual val Default: CoroutineDispatcher = DefaultScheduler
 
-    /**
-     * A coroutine dispatcher that is confined to the Main thread operating with UI objects.
-     * This dispatcher can be used either directly or via [MainScope] factory.
-     * Usually such dispatcher is single-threaded.
-     *
-     * Access to this property may throw [IllegalStateException] if no main thread dispatchers are present in the classpath.
-     *
-     * Depending on platform and classpath it can be mapped to different dispatchers:
-     * - On JS and Native it is equivalent of [Default] dispatcher.
-     * - On JVM it is either Android main thread dispatcher, JavaFx or Swing EDT dispatcher. It is chosen by
-     *   [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
-     *
-     * In order to work with `Main` dispatcher, the following artifacts should be added to project runtime dependencies:
-     *  - `kotlinx-coroutines-android` for Android Main thread dispatcher
-     *  - `kotlinx-coroutines-javafx` for JavaFx Application thread dispatcher
-     *  - `kotlinx-coroutines-swing` for Swing EDT dispatcher
-     *
-     * In order to set a custom `Main` dispatcher for testing purposes, add the `kotlinx-coroutines-test` artifact to 
-     * project test dependencies.
-     *
-     * Implementation note: [MainCoroutineDispatcher.immediate] is not supported on Native and JS platforms.
-     */
     @JvmStatic
     public actual val Main: MainCoroutineDispatcher get() = MainDispatcherLoader.dispatcher
 
-    /**
-     * A coroutine dispatcher that is not confined to any specific thread.
-     * It executes initial continuation of the coroutine in the current call-frame
-     * and lets the coroutine resume in whatever thread that is used by the corresponding suspending function, without
-     * mandating any specific threading policy. Nested coroutines launched in this dispatcher form an event-loop to avoid
-     * stack overflows.
-     *
-     * ### Event loop
-     * Event loop semantics is a purely internal concept and have no guarantees on the order of execution
-     * except that all queued coroutines will be executed on the current thread in the lexical scope of the outermost
-     * unconfined coroutine.
-     *
-     * For example, the following code:
-     * ```
-     * withContext(Dispatchers.Unconfined) {
-     *    println(1)
-     *    withContext(Dispatchers.Unconfined) { // Nested unconfined
-     *        println(2)
-     *    }
-     *    println(3)
-     * }
-     * println("Done")
-     * ```
-     * Can print both "1 2 3" and "1 3 2", this is an implementation detail that can be changed.
-     * But it is guaranteed that "Done" will be printed only when both `withContext` are completed.
-     *
-     *
-     * Note that if you need your coroutine to be confined to a particular thread or a thread-pool after resumption,
-     * but still want to execute it in the current call-frame until its first suspension, then you can use
-     * an optional [CoroutineStart] parameter in coroutine builders like
-     * [launch][CoroutineScope.launch] and [async][CoroutineScope.async] setting it to
-     * the value of [CoroutineStart.UNDISPATCHED].
-     */
     @JvmStatic
     public actual val Unconfined: CoroutineDispatcher = kotlinx.coroutines.Unconfined
 


### PR DESCRIPTION
We update the docs in Dispatchers.common.kt, but JVM's Dispatchers.kt also has its own version of it, which is accessible via the "JVM" tab of the docs:
<https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-unconfined.html> The docs there are outdated, so we should remove them.