### PR TITLE
Update the wording for Dispatchers.Unconfined

### DIFF
--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -64,7 +64,7 @@ public expect object Dispatchers {
      * println("Done")
      * ```
      * Can print both "1 2 3" and "1 3 2". This is an implementation detail that can be changed.
-     * However, it is guaranteed that "Done" will be printed only when both `withContext` calls are completed.
+     * However, it is guaranteed that "Done" will be printed only the `withContext` call is completed.
      *
      * If you need your coroutine to be confined to a particular thread or a thread-pool after resumption,
      * but still want to execute it in the current call-frame until its first suspension, you can use


### PR DESCRIPTION
In my recent PR (#3607) I changed the example for `Dispatchers.Unconfined` but the rest of the documentation still mentions two `withContext` which isn't correct any longer.