### PR TITLE
TestTimeSource: Expose comparable timemarks

### DIFF
--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
@@ -68,7 +68,7 @@ public final class kotlinx/coroutines/test/TestCoroutineScheduler : kotlin/corou
 	public final fun advanceTimeBy (J)V
 	public final fun advanceUntilIdle ()V
 	public final fun getCurrentTime ()J
-	public final fun getTimeSource ()Lkotlin/time/TimeSource;
+	public final fun getTimeSource ()Lkotlin/time/TimeSource$WithComparableMarks;
 	public final fun runCurrent ()V
 }
 
@@ -118,7 +118,7 @@ public final class kotlinx/coroutines/test/TestScopeKt {
 	public static final fun advanceTimeBy (Lkotlinx/coroutines/test/TestScope;J)V
 	public static final fun advanceUntilIdle (Lkotlinx/coroutines/test/TestScope;)V
 	public static final fun getCurrentTime (Lkotlinx/coroutines/test/TestScope;)J
-	public static final fun getTestTimeSource (Lkotlinx/coroutines/test/TestScope;)Lkotlin/time/TimeSource;
+	public static final fun getTestTimeSource (Lkotlinx/coroutines/test/TestScope;)Lkotlin/time/TimeSource$WithComparableMarks;
 	public static final fun runCurrent (Lkotlinx/coroutines/test/TestScope;)V
 }
 

--- a/kotlinx-coroutines-test/common/src/TestCoroutineScheduler.kt
+++ b/kotlinx-coroutines-test/common/src/TestCoroutineScheduler.kt
@@ -205,7 +205,7 @@ public class TestCoroutineScheduler : AbstractCoroutineContextElement(TestCorout
      */
     @ExperimentalCoroutinesApi
     @ExperimentalTime
-    public val timeSource: TimeSource = object : AbstractLongTimeSource(DurationUnit.MILLISECONDS) {
+    public val timeSource: TimeSource.WithComparableMarks = object : AbstractLongTimeSource(DurationUnit.MILLISECONDS) {
         override fun read(): Long = currentTime
     }
 }

--- a/kotlinx-coroutines-test/common/src/TestScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestScope.kt
@@ -129,7 +129,7 @@ public fun TestScope.advanceTimeBy(delayTimeMillis: Long): Unit = testScheduler.
  */
 @ExperimentalCoroutinesApi
 @ExperimentalTime
-public val TestScope.testTimeSource: TimeSource get() = testScheduler.timeSource
+public val TestScope.testTimeSource: TimeSource.WithComparableMarks get() = testScheduler.timeSource
 
 /**
  * Creates a [TestScope].

--- a/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
@@ -314,10 +314,13 @@ class TestCoroutineSchedulerTest {
     @ExperimentalTime
     fun testAdvanceTimeSource() = runTest {
         val expected = 1.seconds
+        val before = testTimeSource.markNow()
         val actual = testTimeSource.measureTime {
             delay(expected)
         }
         assertEquals(expected, actual)
+        val after = testTimeSource.markNow()
+        assertTrue(before < after)
     }
 
     private fun forTestDispatchers(block: (TestDispatcher) -> Unit): Unit =


### PR DESCRIPTION
Kotlin 1.8 added `ComparableTimeMarks` and `AbstractLongTimeSource` implements this interface, so it could be exposed too. 