### PR TITLE
Bugfix: mapNotNull missing NonNullable objects with null value.

### DIFF
--- a/docs/topics/coroutines-and-channels.md
+++ b/docs/topics/coroutines-and-channels.md
@@ -215,7 +215,7 @@ is to use _callbacks_.
 Instead of calling the code that should be invoked right after the operation is completed, you can extract it
 into a separate callback, often a lambda, and pass that lambda to the caller in order for it to be called later.
 
-To make the UI responsive, you can either move the whole computation to a separate thread or switch to the Retrofit API,
+To make the UI responsive, you can either move the whole computation to a separate thread or switch to the Retrofit API
 which uses callbacks instead of blocking calls.
 
 ### Use a background thread

--- a/docs/topics/coroutines-guide.md
+++ b/docs/topics/coroutines-guide.md
@@ -1,15 +1,15 @@
 [//]: # (title: Coroutines guide)
 
-Kotlin, as a language, provides only minimal low-level APIs in its standard library to enable various other 
+Kotlin provides only minimal low-level APIs in its standard library to enable other 
 libraries to utilize coroutines. Unlike many other languages with similar capabilities, `async` and `await`
 are not keywords in Kotlin and are not even part of its standard library. Moreover, Kotlin's concept
 of _suspending function_ provides a safer and less error-prone abstraction for asynchronous 
 operations than futures and promises.  
 
 `kotlinx.coroutines` is a rich library for coroutines developed by JetBrains. It contains a number of high-level 
-coroutine-enabled primitives that this guide covers, including `launch`, `async` and others. 
+coroutine-enabled primitives that this guide covers, including `launch`, `async`, and others. 
 
-This is a guide on core features of `kotlinx.coroutines` with a series of examples, divided up into different topics.
+This is a guide about the core features of `kotlinx.coroutines` with a series of examples, divided up into different topics.
 
 In order to use coroutines as well as follow the examples in this guide, you need to add a dependency on the `kotlinx-coroutines-core` module as explained 
 [in the project README](https://github.com/Kotlin/kotlinx.coroutines/blob/master/README.md#using-in-your-projects).

--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -64,7 +64,7 @@ public expect object Dispatchers {
      * println("Done")
      * ```
      * Can print both "1 2 3" and "1 3 2". This is an implementation detail that can be changed.
-     * However, it is guaranteed that "Done" will be printed only when both `withContext` calls are completed.
+     * However, it is guaranteed that "Done" will only be printed once the code in both `withContext` and `launch` completes.
      *
      * If you need your coroutine to be confined to a particular thread or a thread-pool after resumption,
      * but still want to execute it in the current call-frame until its first suspension, you can use

--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -56,7 +56,7 @@ public expect object Dispatchers {
      * ```
      * withContext(Dispatchers.Unconfined) {
      *    println(1)
-     *    withContext(Dispatchers.Unconfined) { // Nested unconfined
+     *    launch(Dispatchers.Unconfined) { // Nested unconfined
      *        println(2)
      *    }
      *    println(3)

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -51,10 +51,14 @@ public inline fun <T, R> Flow<T>.map(crossinline transform: suspend (value: T) -
 /**
  * Returns a flow that contains only non-null results of applying the given [transform] function to each value of the original flow.
  */
-public inline fun <T, R: Any> Flow<T>.mapNotNull(crossinline transform: suspend (value: T) -> R?): Flow<R> = transform { value ->
-    val transformed = transform(value) ?: return@transform
-    return@transform emit(transformed)
-}
+public inline fun <T, R : Any> Flow<T>.mapNotNull(crossinline transform: suspend (value: T) -> R?): Flow<R> =
+    transform { value ->
+        val transformed = transform(value)
+        if (transformed != null) {
+            emit(transformed)
+        }
+        return@transform
+    }
 
 /**
  * Returns a flow that wraps each element into [IndexedValue], containing value and its index (starting from zero).

--- a/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
@@ -30,7 +30,7 @@ import kotlin.jvm.*
 public fun <E> SendChannel<E>.trySendBlocking(element: E): ChannelResult<Unit> {
     /*
      * Sent successfully -- bail out.
-     * But failure may indicate either that the channel it full or that
+     * But failure may indicate either that the channel is full or that
      * it is close. Go to slow path on failure to simplify the successful path and
      * to materialize default exception.
      */


### PR DESCRIPTION
This pull request fixes a bug in the code where the `mapNotNull` function was not capturing `NonNullable` objects with a `null` value. 

This can be a consequence of reflection object creation from libraries like Retrofit and Room (Android). 

No tests have been added for this bugfix, as the reflection dependencies are not included for testing.
If the addition of reflection libraries for testing is deemed necessary, I'm willing to add proper tests.