### PR TITLE
Bugfix: mapNotNull missing NonNullables with null value.

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -57,9 +57,10 @@ public inline fun <T, R> Flow<T>.map(crossinline transform: suspend (value: T) -
 /**
  * Returns a flow that contains only non-null results of applying the given [transform] function to each value of the original flow.
  */
-public inline fun <T, R: Any> Flow<T>.mapNotNull(crossinline transform: suspend (value: T) -> R?): Flow<R> = transform { value ->
-    val transformed = transform(value) ?: return@transform
-    return@transform emit(transformed)
+public inline fun <T, R : Any> Flow<T>.mapNotNull(crossinline transform: suspend (value: T) -> R?): Flow<R> = transform { value ->
+    val transformed = transform(value)
+    if (transformed != null) { emit(transformed) }
+    return@transform
 }
 
 /**


### PR DESCRIPTION
This pull request fixes a bug in the code where the `mapNotNull` function was not capturing `non-null` objects with a `null` value.
This can be a consequence of reflection object creation from libraries like Retrofit and Room (Android).
No tests have been added for this bugfix, as the reflection dependencies are not included for testing. 
 If the addition of reflection libraries for testing are allowed, then I will add proper tests.