### PR TITLE
Restore TCO in BufferedChannel

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -130,7 +130,8 @@ internal open class BufferedChannel<E>(
             onNoWaiterSuspend = { segm, i, elem, s -> sendOnNoWaiterSuspend(segm, i, elem, s) }
         )
 
-    private suspend fun onClosedSend(element: E): Nothing = suspendCancellableCoroutine { continuation ->
+    // NB: return type could've been Nothing, but it breaks TCO
+    private suspend fun onClosedSend(element: E): Unit = suspendCancellableCoroutine { continuation ->
         onUndeliveredElement?.callUndeliveredElementCatchingException(element)?.let {
             // If it crashes, add send exception as suppressed for better diagnostics
             it.addSuppressed(sendException)


### PR DESCRIPTION
This alone improves our default `ChannelSinkBenchmark` by 30%:  `3.121` -> `2.045`