### PR TITLE
KT-51515 cleanup

### DIFF
--- a/docs/topics/cancellation-and-timeouts.md
+++ b/docs/topics/cancellation-and-timeouts.md
@@ -424,7 +424,7 @@ fun main() {
 If you run the above code, you'll see that it does not always print zero, though it may depend on the timings 
 of your machine. You may need to tweak the timeout in this example to actually see non-zero values. 
 
-> Note that incrementing and decrementing `acquired` counter here from 100K coroutines is completely thread-safe,
+> Note that incrementing and decrementing `acquired` counter here from 10K coroutines is completely thread-safe,
 > since it always happens from the same thread, the one used by `runBlocking`.
 > More on that will be explained in the chapter on coroutine context.
 > 

--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -250,7 +250,7 @@ Done
 Coroutines are less resource-intensive than JVM threads. Code that exhausts the
 JVM's available memory when using threads can be expressed using coroutines
 without hitting resource limits. For example, the following code launches
-50000 distinct coroutines that each wait 5 seconds and then print a period
+50,000 distinct coroutines that each waits 5 seconds and then prints a period
 ('.') while consuming very little memory:
 
 ```kotlin
@@ -273,11 +273,11 @@ fun main() = runBlocking {
 
 <!--- TEST lines.size == 1 && lines[0] == ".".repeat(50_000) -->
 
-> If you write the same program using threads (remove `runBlocking`, replace
+If you write the same program using threads (remove `runBlocking`, replace
 `launch` with `thread`, and replace `delay` with `Thread.sleep`), it will
 consume a lot of memory. Depending on your operating system, JDK version, 
-and its settings it will either throw an out-of-memory error or will start threads slowly, 
-so that there are never many concurrently running threads. 
+and its settings, it will either throw an out-of-memory error or start threads slowly 
+so that there are never too many concurrently running threads. 
 
 <!--- MODULE kotlinx-coroutines-core -->
 <!--- INDEX kotlinx.coroutines -->

--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -250,14 +250,14 @@ Done
 Coroutines are less resource-intensive than JVM threads. Code that exhausts the
 JVM's available memory when using threads can be expressed using coroutines
 without hitting resource limits. For example, the following code launches
-100000 distinct coroutines that each wait 5 seconds and then print a period
+50000 distinct coroutines that each wait 5 seconds and then print a period
 ('.') while consuming very little memory:
 
 ```kotlin
 import kotlinx.coroutines.*
 
 fun main() = runBlocking {
-    repeat(100_000) { // launch a lot of coroutines
+    repeat(50_000) { // launch a lot of coroutines
         launch {
             delay(5000L)
             print(".")
@@ -265,18 +265,19 @@ fun main() = runBlocking {
     }
 }
 ```
-<!-- While coroutines do have a smaller memory footprint than threads, this
-example will exhaust the playground's heap memory; don't make it runnable. -->
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt).
 >
 {type="note"}
 
-<!--- TEST lines.size == 1 && lines[0] == ".".repeat(100_000) -->
+<!--- TEST lines.size == 1 && lines[0] == ".".repeat(50_000) -->
 
-If you write the same program using threads (remove `runBlocking`, replace
+> If you write the same program using threads (remove `runBlocking`, replace
 `launch` with `thread`, and replace `delay` with `Thread.sleep`), it will
-likely consume too much memory and throw an out-of-memory error.
+consume a lot of memory. Depending on your operating system, JDK version, 
+and its settings it will either throw an out-of-memory error or will start threads slowly, 
+so that there are never many concurrently running threads. 
 
 <!--- MODULE kotlinx-coroutines-core -->
 <!--- INDEX kotlinx.coroutines -->

--- a/kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/example-basic-06.kt
@@ -8,7 +8,7 @@ package kotlinx.coroutines.guide.exampleBasic06
 import kotlinx.coroutines.*
 
 fun main() = runBlocking {
-    repeat(100_000) { // launch a lot of coroutines
+    repeat(50_000) { // launch a lot of coroutines
         launch {
             delay(5000L)
             print(".")

--- a/kotlinx-coroutines-core/jvm/test/guide/test/BasicsGuideTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/test/BasicsGuideTest.kt
@@ -55,7 +55,7 @@ class BasicsGuideTest {
     @Test
     fun testExampleBasic06() {
         test("ExampleBasic06") { kotlinx.coroutines.guide.exampleBasic06.main() }.also { lines ->
-            check(lines.size == 1 && lines[0] == ".".repeat(100_000))
+            check(lines.size == 1 && lines[0] == ".".repeat(50_000))
         }
     }
 }


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-51515
Small fixes to clean up #3631

* Fix comment about 100k corouties in cancellation and timeouts section (it is now 10k!)
* Make "Coroutines are light-weight" example runnable by reducing the number of coroutines to 50k, also change the wording about what happens with threads
