### PR TITLE
Do not require atomicfu module

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/module-info.java
+++ b/kotlinx-coroutines-core/jvm/src/module-info.java
@@ -3,7 +3,6 @@ import kotlinx.coroutines.internal.MainDispatcherFactory;
 
 module kotlinx.coroutines.core {
     requires transitive kotlin.stdlib;
-    requires kotlinx.atomicfu;
 
     // these are used by kotlinx.coroutines.debug.AgentPremain
     requires static java.instrument; // contains java.lang.instrument.*

--- a/reactive/kotlinx-coroutines-reactive/src/module-info.java
+++ b/reactive/kotlinx-coroutines-reactive/src/module-info.java
@@ -1,7 +1,6 @@
 module kotlinx.coroutines.reactive {
     requires kotlin.stdlib;
     requires kotlinx.coroutines.core;
-    requires kotlinx.atomicfu;
     requires org.reactivestreams;
 
     exports kotlinx.coroutines.reactive;

--- a/reactive/kotlinx-coroutines-rx2/src/module-info.java
+++ b/reactive/kotlinx-coroutines-rx2/src/module-info.java
@@ -3,7 +3,6 @@ module kotlinx.coroutines.rx2 {
     requires kotlin.stdlib;
     requires kotlinx.coroutines.core;
     requires kotlinx.coroutines.reactive;
-    requires kotlinx.atomicfu;
     requires io.reactivex.rxjava2;
 
     exports kotlinx.coroutines.rx2;

--- a/reactive/kotlinx-coroutines-rx3/src/module-info.java
+++ b/reactive/kotlinx-coroutines-rx3/src/module-info.java
@@ -3,7 +3,6 @@ module kotlinx.coroutines.rx3 {
     requires kotlin.stdlib;
     requires kotlinx.coroutines.core;
     requires kotlinx.coroutines.reactive;
-    requires kotlinx.atomicfu;
     requires io.reactivex.rxjava3;
 
     exports kotlinx.coroutines.rx3;


### PR DESCRIPTION
This dependency is compile-time only and should not leak into user's classpath