### PR TITLE
Promote the test module deprecation levels for 1.7.0

### DIFF
--- a/kotlinx-coroutines-test/jvm/src/migration/DelayController.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/DelayController.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION_ERROR")
 
 package kotlinx.coroutines.test
 
@@ -21,7 +21,7 @@ import kotlinx.coroutines.*
 @ExperimentalCoroutinesApi
 @Deprecated(
     "Use `TestCoroutineScheduler` to control virtual time.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public interface DelayController {
@@ -111,7 +111,7 @@ public interface DelayController {
      */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     public suspend fun pauseDispatcher(block: suspend () -> Unit)
@@ -124,7 +124,7 @@ public interface DelayController {
      */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     public fun pauseDispatcher()
@@ -138,7 +138,7 @@ public interface DelayController {
      */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     public fun resumeDispatcher()
@@ -151,7 +151,7 @@ internal interface SchedulerAsDelayController : DelayController {
     @Deprecated(
         "This property delegates to the test scheduler, which may cause confusing behavior unless made explicit.",
         ReplaceWith("this.scheduler.currentTime"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     override val currentTime: Long
@@ -162,7 +162,7 @@ internal interface SchedulerAsDelayController : DelayController {
     @Deprecated(
         "This function delegates to the test scheduler, which may cause confusing behavior unless made explicit.",
         ReplaceWith("this.scheduler.apply { advanceTimeBy(delayTimeMillis); runCurrent() }"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     override fun advanceTimeBy(delayTimeMillis: Long): Long {
@@ -176,7 +176,7 @@ internal interface SchedulerAsDelayController : DelayController {
     @Deprecated(
         "This function delegates to the test scheduler, which may cause confusing behavior unless made explicit.",
         ReplaceWith("this.scheduler.advanceUntilIdle()"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     override fun advanceUntilIdle(): Long {
@@ -189,7 +189,7 @@ internal interface SchedulerAsDelayController : DelayController {
     @Deprecated(
         "This function delegates to the test scheduler, which may cause confusing behavior unless made explicit.",
         ReplaceWith("this.scheduler.runCurrent()"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
     override fun runCurrent(): Unit = scheduler.runCurrent()

--- a/kotlinx-coroutines-test/jvm/src/migration/TestBuildersDeprecated.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestBuildersDeprecated.kt
@@ -56,7 +56,7 @@ import kotlin.time.Duration.Companion.milliseconds
         "https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md",
     level = DeprecationLevel.WARNING
 )
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun runBlockingTest(
     context: CoroutineContext = EmptyCoroutineContext,
     testBody: suspend TestCoroutineScope.() -> Unit
@@ -77,7 +77,7 @@ public fun runBlockingTest(
  * A version of [runBlockingTest] that works with [TestScope].
  */
 @Deprecated("Use `runTest` instead to support completing from other dispatchers.", level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun runBlockingTestOnTestScope(
     context: CoroutineContext = EmptyCoroutineContext,
     testBody: suspend TestScope.() -> Unit
@@ -126,7 +126,7 @@ public fun runBlockingTestOnTestScope(
         "https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md",
     level = DeprecationLevel.WARNING
 )
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun TestCoroutineScope.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit): Unit =
     runBlockingTest(coroutineContext, block)
 
@@ -134,7 +134,7 @@ public fun TestCoroutineScope.runBlockingTest(block: suspend TestCoroutineScope.
  * Convenience method for calling [runBlockingTestOnTestScope] on an existing [TestScope].
  */
 @Deprecated("Use `runTest` instead to support completing from other dispatchers.", level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun TestScope.runBlockingTest(block: suspend TestScope.() -> Unit): Unit =
     runBlockingTestOnTestScope(coroutineContext, block)
 
@@ -152,7 +152,7 @@ public fun TestScope.runBlockingTest(block: suspend TestScope.() -> Unit): Unit 
         "https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md",
     level = DeprecationLevel.WARNING
 )
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun TestCoroutineDispatcher.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit): Unit =
     runBlockingTest(this, block)
 
@@ -161,7 +161,7 @@ public fun TestCoroutineDispatcher.runBlockingTest(block: suspend TestCoroutineS
  */
 @ExperimentalCoroutinesApi
 @Deprecated("Use `runTest` instead.", level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun runTestWithLegacyScope(
     context: CoroutineContext = EmptyCoroutineContext,
     dispatchTimeoutMs: Long = DEFAULT_DISPATCH_TIMEOUT_MS,
@@ -200,7 +200,7 @@ public fun runTestWithLegacyScope(
  */
 @ExperimentalCoroutinesApi
 @Deprecated("Use `TestScope.runTest` instead.", level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun TestCoroutineScope.runTest(
     dispatchTimeoutMs: Long = DEFAULT_DISPATCH_TIMEOUT_MS,
     block: suspend TestCoroutineScope.() -> Unit

--- a/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineDispatcher.kt
@@ -63,7 +63,7 @@ public class TestCoroutineDispatcher(public override val scheduler: TestCoroutin
     /** @suppress */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     override suspend fun pauseDispatcher(block: suspend () -> Unit) {
         val previous = dispatchImmediately
@@ -78,7 +78,7 @@ public class TestCoroutineDispatcher(public override val scheduler: TestCoroutin
     /** @suppress */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     override fun pauseDispatcher() {
         dispatchImmediately = false
@@ -87,7 +87,7 @@ public class TestCoroutineDispatcher(public override val scheduler: TestCoroutin
     /** @suppress */
     @Deprecated(
         "Please use a dispatcher that is paused by default, like `StandardTestDispatcher`.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     override fun resumeDispatcher() {
         dispatchImmediately = true

--- a/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineDispatcher.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.*
 @Deprecated("The execution order of `TestCoroutineDispatcher` can be confusing, and the mechanism of " +
     "pausing is typically misunderstood. Please use `StandardTestDispatcher` or `UnconfinedTestDispatcher` instead.",
     level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public class TestCoroutineDispatcher(public override val scheduler: TestCoroutineScheduler = TestCoroutineScheduler()):
     TestDispatcher(), Delay, SchedulerAsDelayController
 {

--- a/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineExceptionHandler.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineExceptionHandler.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.*
         "Consider whether the default mechanism of handling uncaught exceptions is sufficient. " +
         "If not, try writing your own `CoroutineExceptionHandler` and " +
         "please report your use case at https://github.com/Kotlin/kotlinx.coroutines/issues.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public interface UncaughtExceptionCaptor {
@@ -42,11 +42,11 @@ public interface UncaughtExceptionCaptor {
 /**
  * An exception handler that captures uncaught exceptions in tests.
  */
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION_ERROR")
 @Deprecated(
     "Deprecated for removal without a replacement. " +
         "It may be to define one's own `CoroutineExceptionHandler` if you just need to handle '" +
-        "uncaught exceptions without a special `TestCoroutineScope` integration.", level = DeprecationLevel.WARNING
+        "uncaught exceptions without a special `TestCoroutineScope` integration.", level = DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public class TestCoroutineExceptionHandler :

--- a/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineScope.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION_ERROR", "DEPRECATION")
 
 package kotlinx.coroutines.test
 
@@ -239,7 +239,7 @@ public val TestCoroutineScope.currentTime: Long
     "The name of this function is misleading: it not only advances the time, but also runs the tasks " +
         "scheduled *at* the ending moment.",
     ReplaceWith("this.testScheduler.apply { advanceTimeBy(delayTimeMillis); runCurrent() }"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public fun TestCoroutineScope.advanceTimeBy(delayTimeMillis: Long): Unit =
@@ -283,7 +283,7 @@ public fun TestCoroutineScope.runCurrent() {
         "(this.coroutineContext[ContinuationInterceptor]!! as DelayController).pauseDispatcher(block)",
         "kotlin.coroutines.ContinuationInterceptor"
     ),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public suspend fun TestCoroutineScope.pauseDispatcher(block: suspend () -> Unit) {
@@ -299,7 +299,7 @@ public suspend fun TestCoroutineScope.pauseDispatcher(block: suspend () -> Unit)
         "(this.coroutineContext[ContinuationInterceptor]!! as DelayController).pauseDispatcher()",
         "kotlin.coroutines.ContinuationInterceptor"
     ),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public fun TestCoroutineScope.pauseDispatcher() {
@@ -315,7 +315,7 @@ public fun TestCoroutineScope.pauseDispatcher() {
         "(this.coroutineContext[ContinuationInterceptor]!! as DelayController).resumeDispatcher()",
         "kotlin.coroutines.ContinuationInterceptor"
     ),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public fun TestCoroutineScope.resumeDispatcher() {
@@ -335,7 +335,7 @@ public fun TestCoroutineScope.resumeDispatcher() {
         "easily misused. It is only present for backward compatibility and will be removed in the subsequent " +
         "releases. If you need to check the list of exceptions, please consider creating your own " +
         "`CoroutineExceptionHandler`.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 public val TestCoroutineScope.uncaughtExceptions: List<Throwable>
     get() = (coroutineContext[CoroutineExceptionHandler] as? UncaughtExceptionCaptor)?.uncaughtExceptions

--- a/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineScope.kt
+++ b/kotlinx-coroutines-test/jvm/src/migration/TestCoroutineScope.kt
@@ -22,7 +22,7 @@ import kotlin.coroutines.*
     "Please see the migration guide for details: " +
     "https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md",
     level = DeprecationLevel.WARNING)
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public interface TestCoroutineScope : CoroutineScope {
     /**
      * Called after the test completes.
@@ -45,7 +45,7 @@ public interface TestCoroutineScope : CoroutineScope {
      */
     @ExperimentalCoroutinesApi
     @Deprecated("Please call `runTest`, which automatically performs the cleanup, instead of using this function.")
-    // Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+    // Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
     public fun cleanupTestCoroutines()
 
     /**
@@ -139,7 +139,7 @@ internal fun CoroutineContext.activeJobs(): Set<Job> {
     ),
     level = DeprecationLevel.WARNING
 )
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext): TestCoroutineScope {
     val scheduler = context[TestCoroutineScheduler] ?: TestCoroutineScheduler()
     return createTestCoroutineScope(TestCoroutineDispatcher(scheduler) + TestCoroutineExceptionHandler() + context)
@@ -181,7 +181,7 @@ public fun TestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext)
         "Please use TestScope() construction instead, or just runTest(), without creating a scope.",
     level = DeprecationLevel.WARNING
 )
-// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
+// Since 1.6.0, kept as warning in 1.7.0, ERROR in 1.8.0 and removed as experimental in 1.9.0
 public fun createTestCoroutineScope(context: CoroutineContext = EmptyCoroutineContext): TestCoroutineScope {
     val ctxWithDispatcher = context.withDelaySkipping()
     var scope: TestCoroutineScopeImpl? = null
@@ -337,6 +337,7 @@ public fun TestCoroutineScope.resumeDispatcher() {
         "`CoroutineExceptionHandler`.",
     level = DeprecationLevel.ERROR
 )
+// Since 1.6.0, ERROR in 1.7.0 and removed as experimental in 1.8.0
 public val TestCoroutineScope.uncaughtExceptions: List<Throwable>
     get() = (coroutineContext[CoroutineExceptionHandler] as? UncaughtExceptionCaptor)?.uncaughtExceptions
         ?: emptyList()

--- a/kotlinx-coroutines-test/jvm/test/migration/TestBuildersTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/TestBuildersTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.*
 import kotlin.test.*
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class TestBuildersTest {
 
     @Test

--- a/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineDispatcherOrderTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineDispatcherOrderTest.kt
@@ -8,7 +8,7 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class TestCoroutineDispatcherOrderTest: OrderedExecutionTestBase() {
 
     @Test

--- a/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineDispatcherTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineDispatcherTest.kt
@@ -7,7 +7,7 @@ package kotlinx.coroutines.test
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class TestCoroutineDispatcherTest {
     @Test
     fun whenDispatcherPaused_doesNotAutoProgressCurrent() {

--- a/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineExceptionHandlerTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/TestCoroutineExceptionHandlerTest.kt
@@ -6,7 +6,7 @@ package kotlinx.coroutines.test
 
 import kotlin.test.*
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION_ERROR")
 class TestCoroutineExceptionHandlerTest {
     @Test
     fun whenExceptionsCaught_availableViaProperty() {

--- a/kotlinx-coroutines-test/jvm/test/migration/TestRunBlockingTest.kt
+++ b/kotlinx-coroutines-test/jvm/test/migration/TestRunBlockingTest.kt
@@ -7,7 +7,7 @@ package kotlinx.coroutines.test
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class TestRunBlockingTest {
 
     @Test


### PR DESCRIPTION
There are two kinds of APIs in the old version of the test framework:
* Foundational (`runBlockingTest`, `TestCoroutineScope`, etc.).
* Auxiliary (`DelayController`, some `TestCoroutineScope` methods like `pauseDispatcher`, etc.).

Some code bases are slow to migrate from the old foundational pieces, and I think we have quite many useful things in this release, so it would be unfortunate if someone stuck to the old release just because they didn't manage to update the tests yet. So, I just deprecated the things that the overwhelming majority of code bases don't use. The trio of `TestCoroutineScheduler`, `runBlockingTest`, and `TestCoroutineScope` is still here for one more release.