### PR TITLE
Fix a broken test

### DIFF
--- a/kotlinx-coroutines-test/common/test/RunTestTest.kt
+++ b/kotlinx-coroutines-test/common/test/RunTestTest.kt
@@ -215,7 +215,7 @@ class RunTestTest {
             }
         }
     }) {
-        runTest(timeout = 1.milliseconds) {
+        runTest(timeout = 100.milliseconds) {
             coroutineContext[CoroutineExceptionHandler]!!.handleException(coroutineContext, TestException("A"))
             withContext(Dispatchers.Default) {
                 delay(10000)


### PR DESCRIPTION
The timeout was too low, the test body did not get a chance to run.

Fixes #3657