### PR TITLE
Include runBlocking{} in the context sample code

### DIFF
--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -24,8 +24,8 @@ Try the following example:
 ```kotlin
 import kotlinx.coroutines.*
 
-fun main() = runBlocking<Unit> {
 //sampleStart
+fun main() = runBlocking<Unit> {
     launch { // context of the parent, main runBlocking coroutine
         println("main runBlocking      : I'm working in thread ${Thread.currentThread().name}")
     }
@@ -37,9 +37,9 @@ fun main() = runBlocking<Unit> {
     }
     launch(newSingleThreadContext("MyOwnThread")) { // will get its own new thread
         println("newSingleThreadContext: I'm working in thread ${Thread.currentThread().name}")
-    }
-//sampleEnd    
+    }    
 }
+//sampleEnd
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
@@ -88,8 +88,8 @@ this thread with predictable FIFO scheduling.
 ```kotlin
 import kotlinx.coroutines.*
 
-fun main() = runBlocking<Unit> {
 //sampleStart
+fun main() = runBlocking<Unit> {
     launch(Dispatchers.Unconfined) { // not confined -- will work with main thread
         println("Unconfined      : I'm working in thread ${Thread.currentThread().name}")
         delay(500)
@@ -99,9 +99,9 @@ fun main() = runBlocking<Unit> {
         println("main runBlocking: I'm working in thread ${Thread.currentThread().name}")
         delay(1000)
         println("main runBlocking: After delay in thread ${Thread.currentThread().name}")
-    }
-//sampleEnd    
+    }    
 }
+//sampleEnd
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 


### PR DESCRIPTION
The text in the "Dispatchers and threads﻿" and "Unconfined vs confined dispatcher" sections explicitly mentions the example code having  `runBlocking` call somewhere but the sample code does not show the call. I'd propose to include the call to  `runBlocking` so that the readers don't have to guess where the actual  `runBlocking` call is done.