### PR TITLE
Preserve binary compatibility with `TestScope.runTest(Long)`

### DIFF
--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.api
@@ -22,6 +22,7 @@ public final class kotlinx/coroutines/test/TestBuildersKt {
 	public static final fun runTest (Lkotlinx/coroutines/test/TestScope;JLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun runTest$default (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun runTest$default (Lkotlinx/coroutines/test/TestCoroutineScope;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final synthetic fun runTest$default (Lkotlinx/coroutines/test/TestScope;Ljava/lang/Long;Lkotlin/jvm/functions/Function2;Ljava/lang/Integer;Ljava/lang/Object;)V
 	public static final fun runTest-8Mi8wO0 (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;)V
 	public static final fun runTest-8Mi8wO0 (Lkotlinx/coroutines/test/TestScope;JLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun runTest-8Mi8wO0$default (Lkotlin/coroutines/CoroutineContext;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V

--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -570,3 +570,16 @@ internal fun throwAll(head: Throwable?, other: List<Throwable>) {
 }
 
 internal expect fun dumpCoroutines()
+
+@Deprecated(
+    "This is for binary compatibility with the `runTest` overload that existed at some point",
+    level = DeprecationLevel.HIDDEN
+)
+@JvmName("runTest\$default")
+@Suppress("DEPRECATION", "UNUSED_PARAMETER")
+public fun TestScope.runTestLegacy(
+    dispatchTimeoutMs: Long?,
+    testBody: suspend TestScope.() -> Unit,
+    unused1: Int?,
+    unused2: Any?,
+): TestResult = runTest(dispatchTimeoutMs ?: 60_000, testBody)


### PR DESCRIPTION
Fixes #3673