### PR TITLE
Get rid of Thread.name augmentation with CoroutineId when debug mode …

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
@@ -284,27 +284,7 @@ private const val DEBUG_THREAD_NAME_SEPARATOR = " @"
 @IgnoreJreRequirement // desugared hashcode implementation
 internal data class CoroutineId(
     val id: Long
-) : ThreadContextElement<String>, AbstractCoroutineContextElement(CoroutineId) {
+) : AbstractCoroutineContextElement(CoroutineId) {
     companion object Key : CoroutineContext.Key<CoroutineId>
     override fun toString(): String = "CoroutineId($id)"
-
-    override fun updateThreadContext(context: CoroutineContext): String {
-        val coroutineName = context[CoroutineName]?.name ?: "coroutine"
-        val currentThread = Thread.currentThread()
-        val oldName = currentThread.name
-        var lastIndex = oldName.lastIndexOf(DEBUG_THREAD_NAME_SEPARATOR)
-        if (lastIndex < 0) lastIndex = oldName.length
-        currentThread.name = buildString(lastIndex + coroutineName.length + 10) {
-            append(oldName.substring(0, lastIndex))
-            append(DEBUG_THREAD_NAME_SEPARATOR)
-            append(coroutineName)
-            append('#')
-            append(id)
-        }
-        return oldName
-    }
-
-    override fun restoreThreadContext(context: CoroutineContext, oldState: String) {
-        Thread.currentThread().name = oldState
-    }
 }

--- a/kotlinx-coroutines-core/jvm/src/Debug.kt
+++ b/kotlinx-coroutines-core/jvm/src/Debug.kt
@@ -17,8 +17,6 @@ import kotlin.internal.InlineOnly
  * ### Debugging facilities
  *
  * In debug mode every coroutine is assigned a unique consecutive identifier.
- * Every thread that executes a coroutine has its name modified to include the name and identifier of
- * the currently running coroutine.
  *
  * Enable debugging facilities with "`kotlinx.coroutines.debug`" ([DEBUG_PROPERTY_NAME]) system property,
  * use the following values:
@@ -32,6 +30,11 @@ import kotlin.internal.InlineOnly
  *
  * Debugging facilities are implemented by [newCoroutineContext][CoroutineScope.newCoroutineContext] function that
  * is used in all coroutine builders to create context of a new coroutine.
+ *
+ * ### Legacy note
+ *
+ * Previously, every thread that executed a coroutine had its name modified to include the name and identifier of the currently running coroutine.
+ * This behaviour was removed as part of #3677 and #2234.
  */
 public const val DEBUG_PROPERTY_NAME: String = "kotlinx.coroutines.debug"
 


### PR DESCRIPTION
…is enabled

See #3677 and #2234 for the rationale

Fixes #2234