### PR TITLE
@OptIn for experimental identityHashCode

### DIFF
--- a/kotlinx-coroutines-core/native/src/Debug.kt
+++ b/kotlinx-coroutines-core/native/src/Debug.kt
@@ -9,6 +9,7 @@ import kotlin.native.*
 
 internal actual val DEBUG: Boolean = false
 
+@OptIn(ExperimentalStdlibApi::class)
 internal actual val Any.hexAddress: String get() = identityHashCode().toUInt().toString(16)
 
 internal actual val Any.classSimpleName: String get() = this::class.simpleName ?: "Unknown"


### PR DESCRIPTION
The function was made experimental as a part of efforts to stabilize Native stdlib.