### PR TITLE
Update Robolectric to 4.9 for JDK 17 support during builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jna_version=5.9.0
 # Android versions
 android_version=4.1.1.4
 androidx_annotation_version=1.1.0
-robolectric_version=4.4
+robolectric_version=4.9
 baksmali_version=2.2.7
 
 # JS


### PR DESCRIPTION
Currently, tests for `android-unit-tests` and `kotlinx-coroutines-android` modules fail if they are being run on JDK 17. This is due to using version 4.4 of Robolectric; [starting from version 4.7 and onwards, Robolectric supports JDK 17](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.7).

Bumping Robolectric version to 4.9 in the project seems to have fixed the issue (and have not introduced any new issues) (checked via running `gradle clean build -x kotlinStoreYarnLock --continue --no-build-cache --no-configuration-cache`).