### PR TITLE
Fix type mismatch for integer cinterop conversions KT-56583

### DIFF
--- a/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
@@ -20,7 +20,7 @@ internal actual fun createDefaultDispatcher(): CoroutineDispatcher = DarwinGloba
 private object DarwinGlobalQueueDispatcher : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         autoreleasepool {
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.convert(), 0)) {
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.convert(), 0u)) {
                 block.run()
             }
         }


### PR DESCRIPTION
Fix is needed for kotlinx.train on master after [KT-56583](https://youtrack.jetbrains.com/issue/KT-56583). 