### PR TITLE
Enable jvmLincheckTest Gradle task back

### DIFF
--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -312,12 +312,6 @@ static void configureJvmForLincheck(task, additional = false) {
 task moreTest(dependsOn: [jvmStressTest, jvmLincheckTest, jvmLincheckTestAdditional])
 check.dependsOn moreTest
 
-tasks.jvmLincheckTest {
-    kover {
-        enabled = false // Always disabled, lincheck doesn't really support coverage
-    }
-}
-
 def commonKoverExcludes =
         ["kotlinx.coroutines.debug.*", // Tested by debug module
          "kotlinx.coroutines.channels.ChannelsKt__DeprecatedKt.*", // Deprecated
@@ -326,6 +320,9 @@ def commonKoverExcludes =
         ]
 
 kover {
+    instrumentation {
+        excludeTasks.add("jvmLincheckTest") // Always disabled, lincheck doesn't really support coverage
+    }
     filters {
         classes {
             excludes.addAll(commonKoverExcludes)


### PR DESCRIPTION
This commit fixes the buildscript part that disabled Kover for jvmLincheckTest Gradle task. Previous implementation of this part disabled jvmLincheckTest altogether because `enabled` property that was being set to false actually belonged to DefaultTask class (inherited by jvmLincheckTest) instead of Kover API.