### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/Kotlin/kotlinx.coroutines/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such, we ask
+that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #3721.

This PR adds a security policy to the project. As described in more detail in the linked issue, this eases the responsible reporting of vulnerabilities before they're publicized to the wider public.

The policy currently allows reporting either via email (currently a placeholder) or using GitHub's private reporting feature. Let me know which email (or website to use) or whether you'd rather just use GitHub's feature.

The policy also mentions a 90-day remediation timeline. This is pretty standard, but let me know if you'd rather change this or anything else!