### PR TITLE
Enable -Xjvm-default=all for benchmarks

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 tasks.named<KotlinCompile>("compileJmhKotlin") {
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += "-Xjvm-default=enable"
+        freeCompilerArgs += "-Xjvm-default=all"
     }
 }
 

--- a/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/ShakespearePlaysScrabble.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/ShakespearePlaysScrabble.kt
@@ -34,14 +34,12 @@ abstract class ShakespearePlaysScrabble {
     public interface LongWrapper {
         fun get(): Long
 
-        @JvmDefault
         fun incAndSet(): LongWrapper {
             return object : LongWrapper {
                 override fun get(): Long = this@LongWrapper.get() + 1L
             }
         }
 
-        @JvmDefault
         fun add(other: LongWrapper): LongWrapper {
             return object : LongWrapper {
                 override fun get(): Long = this@LongWrapper.get() + other.get()


### PR DESCRIPTION
And remove usages of JvmDefault, which is going to be deprecated with error in KT-54746.