### PR TITLE
Fix documented exception type for `Flow.single()`

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
+++ b/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
@@ -49,7 +49,7 @@ public suspend inline fun <T, R> Flow<T>.fold(
 
 /**
  * The terminal operator that awaits for one and only one value to be emitted.
- * Throws [NoSuchElementException] for empty flow and [IllegalStateException] for flow
+ * Throws [NoSuchElementException] for empty flow and [IllegalArgumentException] for flow
  * that contains more than one element.
  */
 public suspend fun <T> Flow<T>.single(): T {


### PR DESCRIPTION
[`require()`](https://github.com/lukellmann/kotlinx.coroutines/blob/d17e875275ff4ffbf5cf1a09e3fdbbf7d34acb83/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt#L58) throws `IllegalArgumentException`, not `IllegalStateException`.