### PR TITLE
Update playground link to use latest Kotlin version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ suspend fun main() = coroutineScope {
 }
 ```
 
-> Play with coroutines online [here](https://pl.kotl.in/hG_tKbid_)
+> Play with coroutines online [here](https://pl.kotl.in/9zva88r7S)
 
 ## Modules
 


### PR DESCRIPTION
This PR updates the playground link to use the latest Kotlin version in in the `README.md`.