### PR TITLE
fix missing reference to already defined isClosedForSend

### DIFF
--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -120,8 +120,7 @@ private class RxObservableCoroutine<T : Any>(
 
     // assert: mutex.isLocked()
     private fun doLockedNext(elem: T): Throwable? {
-        // check if already closed for send
-        if (!isActive) {
+        if (isClosedForSend) {
             doLockedSignalCompleted(completionCause, completionCauseHandled)
             return getCancellationException()
         }


### PR DESCRIPTION
The `// check if already closed for send` comment is unnecessary, there's already a property defined as `isClosedForSend`. This will also prevent bugs related to multiple sources of truth related to which makes it closed for sending.