### PR TITLE
Add a warning that actors are part of an obsolete API

### DIFF
--- a/docs/topics/shared-mutable-state-and-concurrency.md
+++ b/docs/topics/shared-mutable-state-and-concurrency.md
@@ -490,6 +490,11 @@ have to switch to a different context at all.
 >
 {type="note"}
 
+> The Actor API will become obsolete in future updates with introduction of complex actors. 
+> See issue [#87](https://github.com/Kotlin/kotlinx.coroutines/issues/87).
+>
+{type="warning"}
+
 <!--- MODULE kotlinx-coroutines-core -->
 <!--- INDEX kotlinx.coroutines -->
 


### PR DESCRIPTION
It's not clear from the documentation that Actors are part of an obsolete API.

re https://github.com/Kotlin/kotlinx.coroutines/issues/87