### PR TITLE
Update BlockHound version to be compatible with JDK 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ javafx_version=17.0.2
 javafx_plugin_version=0.0.8
 binary_compatibility_validator_version=0.12.0
 kover_version=0.7.0-Beta
-blockhound_version=1.0.2.RELEASE
+blockhound_version=1.0.8.RELEASE
 jna_version=5.9.0
 
 # Android versions
@@ -48,9 +48,6 @@ jsdom_global_version=3.0.2
 # Settings
 kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true
-
-# Site generation
-jekyll_version=4.0
 
 # JS IR backend sometimes crashes with out-of-memory
 # TODO: Remove once KT-37187 is fixed

--- a/kotlinx-coroutines-debug/README.md
+++ b/kotlinx-coroutines-debug/README.md
@@ -16,7 +16,7 @@ of coroutines hierarchy referenced by a [Job] or [CoroutineScope] instances usin
 This module also provides an automatic [BlockHound](https://github.com/reactor/BlockHound) integration
 that detects when a blocking operation was called in a coroutine context that prohibits it. In order to use it,
 please follow the BlockHound [quick start guide](
-https://github.com/reactor/BlockHound/blob/1.0.2.RELEASE/docs/quick_start.md).
+https://github.com/reactor/BlockHound/blob/1.0.8.RELEASE/docs/quick_start.md).
 
 ### Using in your project
 

--- a/kotlinx-coroutines-debug/build.gradle
+++ b/kotlinx-coroutines-debug/build.gradle
@@ -33,6 +33,13 @@ java {
     disableAutoTargetJvm()
 }
 
+// This is required for BlockHound tests to work, see https://github.com/Kotlin/kotlinx.coroutines/issues/3701
+tasks.withType(Test).configureEach {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
+        jvmArgs += ["-XX:+AllowRedefinitionToAddDeleteMethods"]
+    }
+}
+
 jar {
     setEnabled(false)
 }

--- a/kotlinx-coroutines-debug/src/CoroutinesBlockHoundIntegration.kt
+++ b/kotlinx-coroutines-debug/src/CoroutinesBlockHoundIntegration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
@@ -10,6 +10,9 @@ import kotlinx.coroutines.scheduling.*
 import reactor.blockhound.*
 import reactor.blockhound.integration.*
 
+/**
+ * @suppress
+ */
 public class CoroutinesBlockHoundIntegration : BlockHoundIntegration {
 
     override fun applyTo(builder: BlockHound.Builder): Unit = with(builder) {


### PR DESCRIPTION
* Also, exclude integration from docs, it shouldn't be there

Fixes #3701