### PR TITLE
Copy CopyableThreadContextElement when switching context with flowOn.

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/internal/ChannelFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/ChannelFlow.kt
@@ -161,7 +161,7 @@ internal abstract class ChannelFlowOperator<S, T>(
         // Fast-path: When channel creation is optional (flowOn/flowWith operators without buffer)
         if (capacity == Channel.OPTIONAL_CHANNEL) {
             val collectContext = coroutineContext
-            val newContext = collectContext + context // compute resulting collect context
+            val newContext = collectContext.newCoroutineContext(context) // compute resulting collect context
             // #1: If the resulting context happens to be the same as it was -- fallback to plain collect
             if (newContext == collectContext)
                 return flowCollect(collector)

--- a/kotlinx-coroutines-core/jvm/test/ThreadContextElementTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ThreadContextElementTest.kt
@@ -296,7 +296,6 @@ class ThreadLocalContextElement(): CopyableThreadContextElement<MyData?> {
 
     val myData: MyData? = myThreadLocal.get()
 
-
     override fun copyForChild(): CopyableThreadContextElement<MyData?> {
         return ThreadLocalContextElement()
     }
@@ -304,7 +303,6 @@ class ThreadLocalContextElement(): CopyableThreadContextElement<MyData?> {
     override fun mergeForChild(overwritingElement: CoroutineContext.Element): CoroutineContext {
         return ThreadLocalContextElement()
     }
-
 
     override fun updateThreadContext(context: CoroutineContext): MyData? {
         val oldState = myThreadLocal.get()

--- a/kotlinx-coroutines-core/jvm/test/ThreadContextMutableCopiesTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ThreadContextMutableCopiesTest.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.coroutines
 
+import kotlinx.coroutines.flow.*
 import kotlin.coroutines.*
 import kotlin.test.*
 
@@ -130,5 +131,33 @@ class ThreadContextMutableCopiesTest : TestBase() {
             assertNotSame(originalData, threadLocalData.get())
             finish(2)
         }
+    }
+
+    @Test
+    fun testDataIsCopiedThroughFlowOnUndispatched() = runTest {
+        expect(1)
+        val root = MyMutableElement(ArrayList())
+        val originalData = root.mutableData
+        flow {
+            assertNotSame(originalData, threadLocalData.get())
+            emit(1)
+        }
+            .flowOn(root)
+            .single()
+        finish(2)
+    }
+
+    @Test
+    fun testDataIsCopiedThroughFlowOnDispatched() = runTest {
+        expect(1)
+        val root = MyMutableElement(ArrayList())
+        val originalData = root.mutableData
+        flow {
+            assertNotSame(originalData, threadLocalData.get())
+            emit(1)
+        }
+            .flowOn(root + Dispatchers.Default)
+            .single()
+        finish(2)
     }
 }


### PR DESCRIPTION
Hi, coroutine owners, this patch is needed as I'm using the thread context element to propagate thread local changes across context switching with flow. I have added a test case that demonstrate my use case. Please take a look when you have time, thanks!