### PR TITLE
3789: Update flow.timeout example to re-throw

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -203,7 +203,7 @@ public fun <T> Flow<T>.debounce(timeout: (T) -> Duration): Flow<T> =
         timeout(emittedItem).toDelayMillis()
     }
 
-private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long) : Flow<T> =
+private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long): Flow<T> =
     scopedFlow { downstream ->
         // Produce the values using the default (rendezvous) channel
         val values = produce {
@@ -306,7 +306,10 @@ public fun <T> Flow<T>.sample(periodMillis: Long): Flow<T> {
 /*
  * TODO this design (and design of the corresponding operator) depends on #540
  */
-internal fun CoroutineScope.fixedPeriodTicker(delayMillis: Long, initialDelayMillis: Long = delayMillis): ReceiveChannel<Unit> {
+internal fun CoroutineScope.fixedPeriodTicker(
+    delayMillis: Long,
+    initialDelayMillis: Long = delayMillis
+): ReceiveChannel<Unit> {
     require(delayMillis >= 0) { "Expected non-negative delay, but has $delayMillis ms" }
     require(initialDelayMillis >= 0) { "Expected non-negative initial delay, but has $initialDelayMillis ms" }
     return produce(capacity = 0) {
@@ -361,12 +364,12 @@ public fun <T> Flow<T>.sample(period: Duration): Flow<T> = sample(period.toDelay
  *     emit(4)
  * }.timeout(100.milliseconds).catch { exception ->
  *     if (exception is TimeoutCancellationException) {
- *       // Catch the TimeoutCancellationException emitted above.
- *       // Emit desired item on timeout.
- *       emit(-1)
+ *         // Catch the TimeoutCancellationException emitted above.
+ *         // Emit desired item on timeout.
+ *         emit(-1)
  *     } else {
- *       // Throw other exceptions.
- *       throw exception
+ *         // Throw other exceptions.
+ *         throw exception
  *     }
  * }.onEach {
  *     delay(300) // This will not cause a timeout

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -359,8 +359,15 @@ public fun <T> Flow<T>.sample(period: Duration): Flow<T> = sample(period.toDelay
  *     emit(3)
  *     delay(1000)
  *     emit(4)
- * }.timeout(100.milliseconds).catch {
- *     emit(-1) // Item to emit on timeout
+ * }.timeout(100.milliseconds).catch { exception ->
+ *     if (exception is TimeoutCancellationException) {
+ *       // Catch the TimeoutCancellationException emitted above.
+ *       // Emit desired item on timeout.
+ *       emit(-1)
+ *     } else {
+ *       // Throw other exceptions.
+ *       throw exception
+ *     }
  * }.onEach {
  *     delay(300) // This will not cause a timeout
  * }

--- a/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
+++ b/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
@@ -21,12 +21,12 @@ flow {
     emit(4)
 }.timeout(100.milliseconds).catch { exception ->
     if (exception is TimeoutCancellationException) {
-      // Catch the TimeoutCancellationException emitted above.
-      // Emit desired item on timeout.
-      emit(-1)
+        // Catch the TimeoutCancellationException emitted above.
+        // Emit desired item on timeout.
+        emit(-1)
     } else {
-      // Throw other exceptions.
-      throw exception
+        // Throw other exceptions.
+        throw exception
     }
 }.onEach {
     delay(300) // This will not cause a timeout

--- a/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
+++ b/kotlinx-coroutines-core/jvm/test/examples/example-timeout-duration-01.kt
@@ -19,8 +19,15 @@ flow {
     emit(3)
     delay(1000)
     emit(4)
-}.timeout(100.milliseconds).catch {
-    emit(-1) // Item to emit on timeout
+}.timeout(100.milliseconds).catch { exception ->
+    if (exception is TimeoutCancellationException) {
+      // Catch the TimeoutCancellationException emitted above.
+      // Emit desired item on timeout.
+      emit(-1)
+    } else {
+      // Throw other exceptions.
+      throw exception
+    }
 }.onEach {
     delay(300) // This will not cause a timeout
 }


### PR DESCRIPTION
Fixes #3789