### PR TITLE
Add "scanNotNull" function to Flow extension

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/ScanTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/ScanTest.kt
@@ -24,6 +24,13 @@ class ScanTest : TestBase() {
     }
 
     @Test
+    fun testScanNotNullWithInitial() = runTest {
+        val flow = flowOf(1, 2, 3)
+        val result = flow.scanNotNull(emptyList<Int>()) { acc, value -> if (value == 2) null else acc + value }.toList()
+        assertEquals(listOf(emptyList(), listOf(1), listOf(1, 3)), result)
+    }
+
+    @Test
     fun testFoldWithInitial() = runTest {
         val flow = flowOf(1, 2, 3)
         val result = flow.runningFold(emptyList<Int>()) { acc, value -> acc + value }.toList()


### PR DESCRIPTION
Adds feature #3806
This adds the "scanNotNull" function as an extension to the Flow class. The "scanNotNull" function allows folding the flow's values using a provided operation and emitting every intermediate non-null result. It skips emitting any intermediate results that are null, ensuring only non-null results are included in the resulting flow.