### PR TITLE
Fixed visibility of atomic properties as required by the new JVM compiler plugin

### DIFF
--- a/kotlinx-coroutines-core/concurrent/test/LimitedParallelismConcurrentTest.kt
+++ b/kotlinx-coroutines-core/concurrent/test/LimitedParallelismConcurrentTest.kt
@@ -68,7 +68,7 @@ class LimitedParallelismConcurrentTest : TestBase() {
     @Test
     fun testNotDoingDispatchesWhenNoTasksArePresent() = runTest {
         class NaggingDispatcher: CoroutineDispatcher() {
-            val closed = atomic(false)
+            private val closed = atomic(false)
             override fun dispatch(context: CoroutineContext, block: Runnable) {
                 if (closed.value)
                     fail("Dispatcher was closed, but still dispatched a task")

--- a/kotlinx-coroutines-core/concurrent/test/MultithreadedDispatcherStressTest.kt
+++ b/kotlinx-coroutines-core/concurrent/test/MultithreadedDispatcherStressTest.kt
@@ -9,7 +9,7 @@ import kotlin.coroutines.*
 import kotlin.test.*
 
 class MultithreadedDispatcherStressTest {
-    val shared = atomic(0)
+    private val shared = atomic(0)
 
     /**
      * Tests that [newFixedThreadPoolContext] will not drop tasks when closed.

--- a/kotlinx-coroutines-core/jvm/test/JobHandlersUpgradeStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/JobHandlersUpgradeStressTest.kt
@@ -29,7 +29,7 @@ class JobHandlersUpgradeStressTest : TestBase() {
     @Volatile
     private var job: Job? = null
 
-    class State {
+    internal class State {
         val state = atomic(0)
     }
 


### PR DESCRIPTION
The new atomicfu JVM compiler plugin (since 1.9.20) will explicitly require atomic properties to be private or internal (or be members of private or internal classes). These fixes are required now in the aggregate build to merge changes in the new jvm plugin, so this commit is added to develop first.