### PR TITLE
Stop building and publishing compatibility MPP metadata variant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,10 +75,6 @@ buildscript {
 
     CacheRedirector.configureBuildScript(buildscript, rootProject)
 }
-// todo:KLUDGE: Hierarchical project structures are not fully supported in IDEA, enable only for a regular built
-if (!Idea.active) {
-    ext.set("kotlin.mpp.enableGranularSourceSetsMetadata", "true")
-}
 
 // todo:KLUDGE: This is needed to workaround dependency resolution between Java and MPP modules
 def configureKotlinJvmPlatform(configuration) {
@@ -278,7 +274,7 @@ configure(subprojects.findAll { !unpublished.contains(it.name) }) {
 
     List<String> jarTasks
     if (isMultiplatform(it)) {
-        jarTasks = ["jvmJar", "metadataJar"]
+        jarTasks = ["jvmJar"]
     } else if (it.name == "kotlinx-coroutines-debug") {
         // We shadow debug module instead of just packaging it
         jarTasks = ["shadowJar"]

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,6 @@ kotlin.native.ignoreDisabledTargets=true
 # TODO: Remove once KT-37187 is fixed
 org.gradle.jvmargs=-Xmx3g
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.mpp.stability.nowarn=true
 kotlinx.atomicfu.enableJvmIrTransformation=true
 # When the flag below is set to `true`, AtomicFU cannot process

--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -260,7 +260,7 @@ jvmJar { setupManifest(it) }
  * kotlinx-coroutines-core-jvm, but our resolving machinery guarantees that
  * any JVM project that depends on -core artifact also depends on -core-jvm one.
  */
-metadataJar { setupManifest(it) }
+allMetadataJar { setupManifest(it) }
 
 static def setupManifest(Jar jar) {
     jar.manifest {


### PR DESCRIPTION
Please review the changes in the published artifacts in kotlinx-coroutines-core and kotlinx-coroutines-test:
- the main artifact is now a common klib (with .jar extension) instead of legacy metadata jar, 
- no artifact is published under `-all` classifier, which was previously a common klib.