### PR TITLE
Remove `@PublishedApi` from `unwrap` to comply with new compiler resriction

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/StackTraceRecovery.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/StackTraceRecovery.common.kt
@@ -40,7 +40,6 @@ internal expect suspend inline fun recoverAndThrow(exception: Throwable): Nothin
  * The opposite of [recoverStackTrace].
  * It is guaranteed that `unwrap(recoverStackTrace(e)) === e`
  */
-@PublishedApi // published for the multiplatform implementation of kotlinx-coroutines-test
 internal expect fun <E: Throwable> unwrap(exception: E): E
 
 internal expect class StackTraceElement


### PR DESCRIPTION
In https://youtrack.jetbrains.com/issue/KT-58551 we require all annotations from expect declaration to be present on actual.
`unwrap` violates this by having `@PublishedApi` only on expect.
This blocks merge of PR in KT-58551.

Currently, `unwrap` is not called from public inline functions. 
Looks like just removing annotation is a safe fix.