### PR TITLE
Create pr_kotlin_master_compatibility_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_kotlin_master_compatibility_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_kotlin_master_compatibility_template.md
@@ -1,0 +1,5 @@
+- [ ] The corresponding KT issue: KT-xxx
+- [ ] The reasoning behind the broken change: 
+- [ ] The label is put on PR: https://github.com/Kotlin/kotlinx.coroutines/labels/kotlin-merge-blocker
+- [ ] A library author and a release manager are added as Reviewers
+ 


### PR DESCRIPTION
Added a template for PRs for fixing compatibility with Kotlin master (breaking aggregator).