### PR TITLE
Make annotations on expect declarations comply with new compiler restriction

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -276,6 +276,11 @@ public final class kotlinx/coroutines/DebugKt {
 	public static final field DEBUG_PROPERTY_VALUE_AUTO Ljava/lang/String;
 	public static final field DEBUG_PROPERTY_VALUE_OFF Ljava/lang/String;
 	public static final field DEBUG_PROPERTY_VALUE_ON Ljava/lang/String;
+	public static final fun getRECOVER_STACK_TRACES ()Z
+}
+
+public final class kotlinx/coroutines/DefaultExecutorKt {
+	public static final fun getDefaultDelay ()Lkotlinx/coroutines/Delay;
 }
 
 public abstract interface class kotlinx/coroutines/Deferred : kotlinx/coroutines/Job {

--- a/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
@@ -20,7 +20,7 @@ public expect fun CoroutineScope.newCoroutineContext(context: CoroutineContext):
 @InternalCoroutinesApi
 public expect fun CoroutineContext.newCoroutineContext(addedContext: CoroutineContext): CoroutineContext
 
-@PublishedApi
+@PublishedApi // to have unmangled name when using from other modules via suppress
 @Suppress("PropertyName")
 internal expect val DefaultDelay: Delay
 

--- a/kotlinx-coroutines-core/common/src/internal/InternalAnnotations.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/InternalAnnotations.common.kt
@@ -5,6 +5,13 @@
 package kotlinx.coroutines.internal
 
 // Ignore JRE requirements for animal-sniffer, compileOnly dependency
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE)
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FILE
+)
 @OptionalExpectation
 internal expect annotation class IgnoreJreRequirement()

--- a/kotlinx-coroutines-core/common/src/internal/StackTraceRecovery.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/StackTraceRecovery.common.kt
@@ -40,7 +40,7 @@ internal expect suspend inline fun recoverAndThrow(exception: Throwable): Nothin
  * The opposite of [recoverStackTrace].
  * It is guaranteed that `unwrap(recoverStackTrace(e)) === e`
  */
-@PublishedApi // published for the multiplatform implementation of kotlinx-coroutines-test
+@PublishedApi // Used from kotlinx-coroutines-test and reactor modules via suppress, not part of ABI
 internal expect fun <E: Throwable> unwrap(exception: E): E
 
 internal expect class StackTraceElement

--- a/kotlinx-coroutines-core/js/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/js/src/CoroutineContext.kt
@@ -33,6 +33,7 @@ private fun isJsdom() = jsTypeOf(navigator) != UNDEFINED &&
     jsTypeOf(navigator.userAgent.match) != UNDEFINED &&
     navigator.userAgent.match("\\bjsdom\\b")
 
+@PublishedApi // Used from kotlinx-coroutines-test via suppress, not part of ABI
 internal actual val DefaultDelay: Delay
     get() = Dispatchers.Default as Delay
 

--- a/kotlinx-coroutines-core/js/src/internal/StackTraceRecovery.kt
+++ b/kotlinx-coroutines-core/js/src/internal/StackTraceRecovery.kt
@@ -10,6 +10,7 @@ internal actual fun <E: Throwable> recoverStackTrace(exception: E, continuation:
 internal actual fun <E: Throwable> recoverStackTrace(exception: E): E = exception
 internal actual suspend inline fun recoverAndThrow(exception: Throwable): Nothing = throw exception
 
+@PublishedApi
 internal actual fun <E : Throwable> unwrap(exception: E): E = exception
 
 @Suppress("UNUSED")

--- a/kotlinx-coroutines-core/jvm/src/Debug.kt
+++ b/kotlinx-coroutines-core/jvm/src/Debug.kt
@@ -78,7 +78,8 @@ internal actual val DEBUG = systemProp(DEBUG_PROPERTY_NAME).let { value ->
 
 // Note: stack-trace recovery is enabled only in debug mode
 // @JvmField: Don't use JvmField here to enable R8 optimizations via "assumenosideeffects"
-internal actual val RECOVER_STACK_TRACES =
+@PublishedApi
+internal actual val RECOVER_STACK_TRACES: Boolean =
     DEBUG && systemProp(STACKTRACE_RECOVERY_PROPERTY_NAME, true)
 
 // It is used only in debug mode

--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -10,6 +10,7 @@ import kotlin.coroutines.*
 
 private val defaultMainDelayOptIn = systemProp("kotlinx.coroutines.main.delay", false)
 
+@PublishedApi
 internal actual val DefaultDelay: Delay = initializeDefaultDelay()
 
 private fun initializeDefaultDelay(): Delay {

--- a/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/StackTraceRecovery.kt
@@ -157,10 +157,12 @@ internal actual suspend inline fun recoverAndThrow(exception: Throwable): Nothin
     }
 }
 
+@PublishedApi
 @Suppress("NOTHING_TO_INLINE") // Inline for better R8 optimizations
 internal actual inline fun <E : Throwable> unwrap(exception: E): E =
     if (!RECOVER_STACK_TRACES) exception else unwrapImpl(exception)
 
+@PublishedApi
 internal fun <E : Throwable> unwrapImpl(exception: E): E {
     val cause = exception.cause
     // Fast-path to avoid array cloning

--- a/kotlinx-coroutines-core/native/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/native/src/CoroutineContext.kt
@@ -30,6 +30,7 @@ internal actual object DefaultExecutor : CoroutineDispatcher(), Delay {
 
 internal expect fun createDefaultDispatcher(): CoroutineDispatcher
 
+@PublishedApi
 internal actual val DefaultDelay: Delay = DefaultExecutor
 
 public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext {

--- a/kotlinx-coroutines-core/native/src/internal/StackTraceRecovery.kt
+++ b/kotlinx-coroutines-core/native/src/internal/StackTraceRecovery.kt
@@ -8,6 +8,8 @@ import kotlin.coroutines.*
 
 internal actual fun <E: Throwable> recoverStackTrace(exception: E, continuation: Continuation<*>): E = exception
 internal actual fun <E: Throwable> recoverStackTrace(exception: E): E = exception
+
+@PublishedApi
 internal actual fun <E : Throwable> unwrap(exception: E): E = exception
 internal actual suspend inline fun recoverAndThrow(exception: Throwable): Nothing = throw exception
 


### PR DESCRIPTION
In KT-58551 we require all annotations from expect declaration to be present on actual.

This commit fixes the following violations:

1. `DefaultDelay` has `@PublishedApi` only on expect. But it is not used from public inline functions, so we can safely remove annotation.

2. expect `IgnoreJreRequirement` has `AnnotationTarget.TYPE` which is not present in actual. This is because Java target TYPE doesn't correspond to Kotlin target TYPE. Since `IgnoreJreRequirement` is internal, we can safely change targets on expect and make them equal to actual.