### PR TITLE
Clarify documentation of Mutex.lock() behavior

### DIFF
--- a/kotlinx-coroutines-core/common/src/sync/Mutex.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Mutex.kt
@@ -42,7 +42,7 @@ public interface Mutex {
     public fun tryLock(owner: Any? = null): Boolean
 
     /**
-     * Locks this mutex, suspending caller while the mutex is locked.
+     * Locks this mutex, suspending caller until the lock is acquired (in other words, while the lock is held elsewhere).
      *
      * This suspending function is cancellable. If the [Job] of the current coroutine is cancelled or completed while this
      * function is suspended, this function immediately resumes with [CancellationException].


### PR DESCRIPTION
The previous documentation of the `Mutex.lock()` method was confusing to me. It seemed to imply that the call would suspend the entire time that the lock was held, when in fact it just suspends until the lock is acquired.