### PR TITLE
fix: errors in runnable snippet

### DIFF
--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -242,7 +242,6 @@ fun main() {
 //sampleEnd    
 }
 ```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
 >


### PR DESCRIPTION
Runnable snippet produces errors, probably due to Playground limitations. See [KT-60424](https://youtrack.jetbrains.com/issue/KT-60424/Web-feedback-from-Coroutine-context-and-dispatchers-https-kotlinlang.org-docs-coroutine-context-and-dispatchers.html)