### PR TITLE
Conditionally remove native targets that are removed in 1.9.20

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinVersion.kt
+++ b/buildSrc/src/main/kotlin/KotlinVersion.kt
@@ -1,0 +1,14 @@
+@file:JvmName("KotlinVersion")
+
+fun isKotlinVersionAtLeast(kotlinVersion: String, atLeastMajor: Int, atLeastMinor: Int, atLeastPatch: Int): Boolean {
+    val (major, minor) = kotlinVersion
+        .split('.')
+        .take(2)
+        .map { it.toInt() }
+    val patch = kotlinVersion.substringAfterLast('.').substringBefore('-').toInt()
+    return when {
+        major > atLeastMajor -> true
+        major < atLeastMajor -> false
+        else -> (minor == atLeastMinor && patch >= atLeastPatch) || minor > atLeastMinor
+    }
+}

--- a/gradle/compile-native-multiplatform.gradle
+++ b/gradle/compile-native-multiplatform.gradle
@@ -1,9 +1,16 @@
+import static KotlinVersion.isKotlinVersionAtLeast
+
 /*
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 project.ext.nativeMainSets = []
 project.ext.nativeTestSets = []
+
+// TODO: this block should be removed when Kotlin version is updated to 1.9.20
+// Right now it is used for conditional removal of native targets that will be removed in 1.9.20 (iosArm32, watchosX86)
+// and is necessary for testing of Kotlin dev builds.
+def enableDeprecatedNativeTargets = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 20)
 
 kotlin {
     targets {
@@ -43,8 +50,10 @@ kotlin {
         addTarget(presets.watchosDeviceArm64)
 
         // Deprecated, but were provided by coroutine; can be removed only when K/N drops the target
-        addTarget(presets.iosArm32)
-        addTarget(presets.watchosX86)
+        if (enableDeprecatedNativeTargets) {
+            addTarget(presets.iosArm32)
+            addTarget(presets.watchosX86)
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
This commit conditionally removes `iosArm32`, `watchosX86`  that are removed in 1.9.20.

This commit is necessary for the aggreagate builds.

A similar commit was added earlier to atomicfu: https://github.com/Kotlin/kotlinx-atomicfu/commit/7697fff37a68007a4c112c3321ef07f763990d37
