### PR TITLE
Ignore adding additional optIns also for "jvmCoreMain" source set

### DIFF
--- a/kotlinx-coroutines-core/build.gradle
+++ b/kotlinx-coroutines-core/build.gradle
@@ -233,7 +233,7 @@ kotlin.sourceSets {
 
 kotlin.sourceSets.configureEach {
     // Do not apply 'ExperimentalForeignApi' where we have allWarningsAsErrors set
-    if (it.name in ["jvmMain", "jsMain", "concurrentMain", "commonMain"]) return
+    if (it.name in ["jvmMain", "jvmCoreMain", "jsMain", "concurrentMain", "commonMain"]) return
     languageSettings {
         optIn('kotlinx.cinterop.ExperimentalForeignApi')
         optIn('kotlin.experimental.ExperimentalNativeApi')


### PR DESCRIPTION
After changes required for https://youtrack.jetbrains.com/issue/KT-57292/Rework-configuration-of-compiler-settings-in-MPP-Projects consistency checks were move later in configuration phase. Now they started also catch inconsistency between "jvmMain" and "jvmCoreMain" source sets.