### PR TITLE
Add Optin for kotlinx.cinterop.UnsafeNumber due to KT-59859

### DIFF
--- a/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
@@ -18,6 +18,7 @@ internal actual fun createMainDispatcher(default: CoroutineDispatcher): MainCoro
 internal actual fun createDefaultDispatcher(): CoroutineDispatcher = DarwinGlobalQueueDispatcher
 
 private object DarwinGlobalQueueDispatcher : CoroutineDispatcher() {
+    @OptIn(UnsafeNumber::class)
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         autoreleasepool {
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.convert(), 0u)) {
@@ -76,6 +77,7 @@ private val TIMER_DISPOSED = NativePtr.NULL.plus(1)
 private class Timer : DisposableHandle {
     private val ref = AtomicNativePtr(TIMER_NEW)
 
+    @OptIn(UnsafeNumber::class)
     fun start(timeMillis: Long, timerBlock: TimerBlock) {
         val fireDate = CFAbsoluteTimeGetCurrent() + timeMillis / 1000.0
         val timer = CFRunLoopTimerCreateWithHandler(null, fireDate, 0.0, 0u, 0, timerBlock)


### PR DESCRIPTION
Caused by: https://youtrack.jetbrains.com/issue/KT-59859/Change-the-OptIn-Level-to-Error-for-kotlinx.cinterop.UnsafeNumber
was found in kotlinx.train, reproduced only on macOS 