### PR TITLE
Fix expect/actual mismatched member scope for `open expect` compilati…

### DIFF
--- a/kotlinx-coroutines-core/concurrent/src/CompletionHandler.kt
+++ b/kotlinx-coroutines-core/concurrent/src/CompletionHandler.kt
@@ -6,12 +6,20 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+// New 'CompletionHandler` supertype is added compared to the expect declaration.
+// Probably we can add it to JS and common too, to avoid the suppression/opt-in
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER")
 internal actual abstract class CompletionHandlerBase actual constructor() : LockFreeLinkedListNode(), CompletionHandler {
     actual abstract override fun invoke(cause: Throwable?)
 }
 
 internal actual inline val CompletionHandlerBase.asHandler: CompletionHandler get() = this
 
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+// New 'CompletionHandler` supertype is added compared to the expect declaration.
+// Probably we can add it to JS and common too, to avoid the suppression/opt-in
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER")
 internal actual abstract class CancelHandlerBase actual constructor() : CompletionHandler {
     actual abstract override fun invoke(cause: Throwable?)
 }

--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -42,7 +42,11 @@ internal val CONDITION_FALSE: Any = Symbol("CONDITION_FALSE")
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
-@Suppress("LeakingThis")
+@Suppress(
+    "LeakingThis",
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER"
+)
 @InternalCoroutinesApi
 public actual open class LockFreeLinkedListNode {
     private val _next = atomic<Any>(this) // Node | Removed | OpDescriptor
@@ -68,14 +72,20 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     @PublishedApi
     internal inline fun makeCondAddOp(node: Node, crossinline condition: () -> Boolean): CondAddOp =
         object : CondAddOp(node) {
             override fun prepare(affected: Node): Any? = if (condition()) null else CONDITION_FALSE
         }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("MODALITY_CHANGED_IN_NON_FINAL_EXPECT_CLASSIFIER_ACTUALIZATION")
     public actual open val isRemoved: Boolean get() = next is Removed
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     // LINEARIZABLE. Returns Node | Removed
     public val next: Any get() {
         _next.loop { next ->
@@ -166,6 +176,8 @@ public actual open class LockFreeLinkedListNode {
      *  Where `==>` denotes linearization point.
      *  Returns `false` if `next` was not following `this` node.
      */
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     @PublishedApi
     internal fun addNext(node: Node, next: Node): Boolean {
         node._prev.lazySet(this)
@@ -176,6 +188,8 @@ public actual open class LockFreeLinkedListNode {
         return true
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     // returns UNDECIDED, SUCCESS or FAILURE
     @PublishedApi
     internal fun tryCondAddNext(node: Node, next: Node, condAdd: CondAddOp): Int {
@@ -199,6 +213,8 @@ public actual open class LockFreeLinkedListNode {
     public actual open fun remove(): Boolean =
         removeOrNext() == null
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     // returns null if removed successfully or next node if this node is already removed
     @PublishedApi
     internal fun removeOrNext(): Node? {
@@ -255,6 +271,8 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     protected open fun nextIfRemoved(): Node? = (next as? Removed)?.ref
 
     /**
@@ -311,6 +329,8 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     internal fun validateNode(prev: Node, next: Node) {
         assert { prev === this._prev.value }
         assert { next === this._next.value }
@@ -331,6 +351,8 @@ internal fun Any.unwrap(): Node = (this as? Removed)?.ref ?: this as Node
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER")
 public actual open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     public actual val isEmpty: Boolean get() = next === this
 
@@ -352,6 +374,8 @@ public actual open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     override val isRemoved: Boolean get() = false
     override fun nextIfRemoved(): Node? = null
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     internal fun validate() {
         var prev: Node = this
         var cur: Node = next as Node

--- a/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
@@ -10,7 +10,14 @@ import kotlinx.coroutines.*
 
 private typealias Node = LinkedListNode
 /** @suppress **This is unstable API and it is subject to change.** */
-@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS") // :TODO: Remove when fixed: https://youtrack.jetbrains.com/issue/KT-23703
+@Suppress(
+    // :TODO: Remove when fixed: https://youtrack.jetbrains.com/issue/KT-23703
+    "NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS",
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER",
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER"
+)
 public actual typealias LockFreeLinkedListNode = LinkedListNode
 
 /** @suppress **This is unstable API and it is subject to change.** */

--- a/kotlinx-coroutines-core/jvm/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/jvm/src/EventLoop.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.scheduling.*
 import kotlinx.coroutines.scheduling.CoroutineScheduler
 
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER")
 internal actual abstract class EventLoopImplPlatform: EventLoop() {
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     protected abstract val thread: Thread
 
     protected actual fun unpark() {
@@ -17,6 +21,8 @@ internal actual abstract class EventLoopImplPlatform: EventLoop() {
             unpark(thread)
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("MODALITY_CHANGED_IN_NON_FINAL_EXPECT_CLASSIFIER_ACTUALIZATION")
     protected actual open fun reschedule(now: Long, delayedTask: EventLoopImplBase.DelayedTask) {
         DefaultExecutor.schedule(now, delayedTask)
     }

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -37,6 +37,12 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
     public abstract override fun close()
 }
 
+@Suppress(
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER",
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER"
+)
 @ExperimentalCoroutinesApi
 public actual typealias CloseableCoroutineDispatcher = ExecutorCoroutineDispatcher
 

--- a/kotlinx-coroutines-core/jvm/src/SchedulerTask.kt
+++ b/kotlinx-coroutines-core/jvm/src/SchedulerTask.kt
@@ -6,8 +6,12 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.scheduling.*
 
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER")
 internal actual typealias SchedulerTask = Task
 
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER")
 internal actual typealias SchedulerTaskContext = TaskContext
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")

--- a/kotlinx-coroutines-core/jvm/test/TestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/TestBase.kt
@@ -54,7 +54,12 @@ public actual typealias TestResult = Unit
  * }
  * ```
  */
-@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS") // Counterpart for @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+@Suppress(
+    // Counterpart for @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+    "NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS",
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER"
+)
 public actual open class TestBase(private var disableOutCheck: Boolean)  {
 
     actual constructor(): this(false)
@@ -80,11 +85,14 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
      * Throws [IllegalStateException] like `error` in stdlib, but also ensures that the test will not
      * complete successfully even if this exception is consumed somewhere in the test.
      */
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
     @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
     public actual fun error(message: Any, cause: Throwable? = null): Nothing {
         throw makeError(message, cause)
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     public fun hasError() = error.get() != null
 
     private fun makeError(message: Any, cause: Throwable? = null): IllegalStateException =
@@ -108,6 +116,8 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
      * Throws [IllegalStateException] when `value` is false like `check` in stdlib, but also ensures that the
      * test will not complete successfully even if this exception is consumed somewhere in the test.
      */
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     public inline fun check(value: Boolean, lazyMessage: () -> Any) {
         if (!value) error(lazyMessage())
     }
@@ -155,12 +165,16 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         }
     })
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     fun println(message: Any?) {
         if (disableOutCheck) kotlin.io.println(message)
         else previousOut.println(message)
     }
 
     @Before
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     fun before() {
         initPoolsBeforeTest()
         threadsBefore = currentThreads()
@@ -176,6 +190,8 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         }
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     @After
     fun onCompletion() {
         // onCompletion should not throw exceptions before it finishes all cleanup, so that other tests always
@@ -203,16 +219,21 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         error.get()?.let { throw it }
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     fun initPoolsBeforeTest() {
         DefaultScheduler.usePrivateScheduler()
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     fun shutdownPoolsAfterTest() {
         DefaultScheduler.shutdown(SHUTDOWN_TIMEOUT)
         DefaultExecutor.shutdownForTests(SHUTDOWN_TIMEOUT)
         DefaultScheduler.restore()
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
     @Suppress("ACTUAL_WITHOUT_EXPECT", "ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
     public actual fun runTest(
         expected: ((Throwable) -> Boolean)? = null,
@@ -247,12 +268,16 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
             error("Too few unhandled exceptions $exCount, expected ${unhandled.size}")
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     protected inline fun <reified T: Throwable> assertFailsWith(block: () -> Unit): T {
         val result = runCatching(block)
         assertTrue(result.exceptionOrNull() is T, "Expected ${T::class}, but had $result")
         return result.exceptionOrNull()!! as T
     }
 
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     protected suspend fun currentDispatcher() = coroutineContext[ContinuationInterceptor]!!
 }
 

--- a/kotlinx-coroutines-core/native/src/internal/Synchronized.kt
+++ b/kotlinx-coroutines-core/native/src/internal/Synchronized.kt
@@ -11,6 +11,8 @@ import kotlinx.atomicfu.locks.withLock as withLock2
  * @suppress **This an internal API and should not be used from general code.**
  */
 @InternalCoroutinesApi
+// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER")
 public actual typealias SynchronizedObject = kotlinx.atomicfu.locks.SynchronizedObject
 
 /**


### PR DESCRIPTION
…on errors

Those are compilation errors introduced in Kotlin 1.9.20 in scope of https://youtrack.jetbrains.com/issue/KT-22841