### PR TITLE
Fix NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS compilation error #2

### DIFF
--- a/kotlinx-coroutines-core/js/test/TestBase.kt
+++ b/kotlinx-coroutines-core/js/test/TestBase.kt
@@ -15,6 +15,7 @@ public actual typealias TestResult = Promise<Unit>
 
 public actual val isNative = false
 
+@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS") // Counterpart for @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual open class TestBase actual constructor() {
     public actual val isBoundByJsTestTimeout = true
     private var actionIndex = 0


### PR DESCRIPTION
The compilation error appeared after KT-59665

It's a follow-up on #3826

I didn't discover this problem when I was merging my changes in `kotlin/master` because of user-project misconfiguration in aggregator: https://jetbrains.slack.com/archives/C3AHQFSKH/p1692181741230819?thread_ts=1691744229.982909&cid=C3AHQFSKH