### PR TITLE
Fix NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS compilation error

### DIFF
--- a/kotlinx-coroutines-core/native/test/TestBase.kt
+++ b/kotlinx-coroutines-core/native/test/TestBase.kt
@@ -15,6 +15,7 @@ public actual val isNative = true
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 public actual typealias TestResult = Unit
 
+@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS") // Counterpart for @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual open class TestBase actual constructor() {
     public actual val isBoundByJsTestTimeout = false
     private var actionIndex = atomic(0)


### PR DESCRIPTION
The compilation error appeared after KT-59665

This MR fixes one more case which was missed in https://github.com/Kotlin/kotlinx.coroutines/pull/3851  