### PR TITLE
Change "parallel decomposition" to "concurrent decomposition"

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -226,7 +226,7 @@ public object GlobalScope : CoroutineScope {
  * The provided scope inherits its [coroutineContext][CoroutineScope.coroutineContext] from the outer scope, but overrides
  * the context's [Job].
  *
- * This function is designed for _parallel decomposition_ of work. When any child coroutine in this scope fails,
+ * This function is designed for _concurrent decomposition_ of work. When any child coroutine in this scope fails,
  * this scope fails and all the rest of the children are cancelled (for a different behavior see [supervisorScope]).
  * This function returns as soon as the given block and all its children coroutines are completed.
  * A usage example of a scope looks like this:


### PR DESCRIPTION
It probably makes sense to clearly differentiate that this is, in fact, _concurrent_ rather than _parallel_ (that is, single-threaded interleaved computations are okay)

(Previous internal discussion: https://jetbrains.slack.com/archives/C3TNY2MM5/p1680694409771889)