### PR TITLE
+flow Add Flow.statefulMap operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change log for kotlinx.coroutines
 
+## Version 1.7.3
+
+* Disabled the publication of the multiplatform library metadata for the old (1.6 and earlier) KMP Gradle plugin (#3809).
+* Fixed a bug introduced in 1.7.2 that disabled the coroutine debugger in IDEA (#3822).
+
 ## Version 1.7.2
 
 ### Bug fixes and improvements

--- a/docs/topics/composing-suspending-functions.md
+++ b/docs/topics/composing-suspending-functions.md
@@ -189,6 +189,12 @@ standard `lazy` function in cases when computation of the value involves suspend
 
 ## Async-style functions
 
+> This programming style with async functions is provided here only for illustration, because it is a popular style
+> in other programming languages. Using this style with Kotlin coroutines is **strongly discouraged** for the
+> reasons explained below.
+>
+{type="note"}
+
 We can define async-style functions that invoke `doSomethingUsefulOne` and `doSomethingUsefulTwo`
 _asynchronously_ using the [async] coroutine builder using a [GlobalScope] reference to 
 opt-out of the structured concurrency.
@@ -274,12 +280,6 @@ suspend fun doSomethingUsefulTwo(): Int {
 The answer is 42
 Completed in 1085 ms
 -->
-
-> This programming style with async functions is provided here only for illustration, because it is a popular style
-> in other programming languages. Using this style with Kotlin coroutines is **strongly discouraged** for the
-> reasons explained below.
->
-{type="note"}
 
 Consider what happens if between the `val one = somethingUsefulOneAsync()` line and `one.await()` expression there is some logic
 error in the code, and the program throws an exception, and the operation that was being performed by the program aborts. 

--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -242,7 +242,6 @@ fun main() {
 //sampleEnd    
 }
 ```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
 >

--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -6,7 +6,7 @@ This section covers basic coroutine concepts.
 
 ## Your first coroutine
 
-A _coroutine_ is an instance of suspendable computation. It is conceptually similar to a thread, in the sense that it 
+A _coroutine_ is an instance of a suspendable computation. It is conceptually similar to a thread, in the sense that it 
 takes a block of code to run that works concurrently with the rest of the code.
 However, a coroutine is not bound to any particular thread. It may suspend its execution in one thread and resume in another one. 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 # Kotlin
-version=1.7.2-SNAPSHOT
+version=1.7.3-SNAPSHOT
 group=org.jetbrains.kotlinx
 kotlin_version=1.9.0
 

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -226,7 +226,7 @@ public object GlobalScope : CoroutineScope {
  * The provided scope inherits its [coroutineContext][CoroutineScope.coroutineContext] from the outer scope, but overrides
  * the context's [Job].
  *
- * This function is designed for _parallel decomposition_ of work. When any child coroutine in this scope fails,
+ * This function is designed for _concurrent decomposition_ of work. When any child coroutine in this scope fails,
  * this scope fails and all the rest of the children are cancelled (for a different behavior see [supervisorScope]).
  * This function returns as soon as the given block and all its children coroutines are completed.
  * A usage example of a scope looks like this:

--- a/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
@@ -43,6 +43,16 @@ public inline fun <T, R> Flow<T>.transform(
     }
 }
 
+public inline fun <T, R> Flow<T>.statefulTransform(
+    @BuilderInference crossinline transformCreator: suspend () -> (suspend FlowCollector<R>.(value: T) -> Unit)
+): Flow<R> = flow {
+    val transform = transformCreator()
+    collect { value ->
+        // kludge, without it Unit will be returned and TCE won't kick in, KT-28938
+        return@collect transform(value)
+    }
+}
+
 // For internal operator implementation
 @PublishedApi
 internal inline fun <T, R> Flow<T>.unsafeTransform(

--- a/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+class StatefulMapTest : TestBase() {
+
+    private fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulMap(0L) { index, value ->
+        return@statefulMap Pair(index + 1L, Pair(value, index))
+    }
+
+    @Test
+    fun testStatefulMap() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        assertEquals(listOf(Pair(1, 0L), Pair(2, 1L), Pair(3, 2L)), flow.zipWithIndex().toList())
+    }
+
+    @Test
+    fun testStatefulMapWithOnCompletion() = runTest {
+        val flow = flow {
+            emit("a")
+            emit("b")
+            emit("c")
+        }
+        val flow2: Flow<Any> = flow.statefulMap(0, { it }) { counter, value ->
+            return@statefulMap Pair(counter + 1, value)
+        }
+        assertEquals(listOf("a", "b", "c", 3), flow2.toList())
+    }
+
+    @Test
+    fun testEmptyFlow() = runTest {
+        val sum = emptyFlow<Int>().statefulMap(1) { state, value ->
+            expectUnreached()
+            Pair(state, value)
+        }.sum()
+        assertEquals(0, sum)
+    }
+
+    private fun <T> Flow<T>.grouped(size: Int): Flow<List<T>> =
+        statefulMap(mutableListOf<T>(), { value -> value.toList() }) { acc, value ->
+            if (acc.size < size) {
+                acc.add(value)
+            }
+            if (acc.size == size) {
+                val result = acc.toList()
+                acc.clear()
+                return@statefulMap Pair(acc, result)
+            }
+            return@statefulMap Pair(acc, emptyList<T>())
+        }.filterNot(List<T>::isEmpty)
+
+    @Test
+    fun testGrouped() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            emit(4)
+            emit(5)
+        }
+        assertEquals(listOf(listOf(1, 2), listOf(3, 4), listOf(5)), flow.grouped(2).toList())
+    }
+
+    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulMap(mutableSetOf<T>()) { set, value ->
+        if (set.add(value)) {
+            return@statefulMap Pair(set, value)
+        }
+        return@statefulMap Pair(set, null)
+    }.filterNotNull()
+
+    @Test
+    fun testAsDistinct() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(1)
+            emit(2)
+            emit(2)
+            emit(3)
+            emit(3)
+        }
+        assertEquals(listOf(1, 2, 3), flow.distinct().toList())
+    }
+
+    @Test
+    fun testErrorCancelsUpstream() = runTest {
+        var cancelled = false
+        val latch = Channel<Unit>()
+        val flow: Flow<Int> = flow {
+            coroutineScope {
+                launch {
+                    latch.send(Unit)
+                    hang { cancelled = true }
+                }
+                emit(1)
+                expectUnreached()
+            }
+        }.statefulMap<Int, Int, Int>(1) { _, _ ->
+            latch.receive()
+            throw TestException()
+        }.catch { emit(42) }
+
+        assertEquals(42, flow.single())
+        assertTrue(cancelled)
+    }
+}

--- a/kotlinx-coroutines-core/common/test/flow/operators/StatefulTransformTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/StatefulTransformTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+class StatefulTransformTest : TestBase() {
+
+    private suspend fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulTransform {
+        var index = 0L;
+        { value ->
+            emit(Pair(value, index++))
+        }
+    }
+
+    @Test
+    fun testStatefulTransform() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        assertEquals(
+            listOf(Pair(1, 0L), Pair(2, 1L), Pair(3, 2L)), flow.zipWithIndex().toList()
+        )
+    }
+
+    @Test
+    fun testEmptyFlow() = runTest {
+        val sum = emptyFlow<Int>().statefulTransform<Int, Int> {
+            var state = 0
+            {
+                expectUnreached()
+                state++
+                it
+            }
+        }.sum()
+        assertEquals(0, sum)
+    }
+
+    private fun <T> Flow<T>.grouped(size: Int): Flow<List<T>> = statefulTransform {
+        val acc = mutableListOf<T>();
+        { value ->
+            acc.add(value)
+            if (acc.size == size) {
+                val list = acc.toList()
+                acc.clear()
+                emit(list)
+            }
+        }
+    }
+
+    @Test
+    fun testGrouped() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            emit(4)
+            emit(5)
+        }
+        assertEquals(listOf(listOf(1, 2), listOf(3, 4)), flow.grouped(2).toList())
+    }
+
+    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulTransform {
+        val set = mutableSetOf<T>();
+        { value ->
+            if (set.add(value)) {
+                emit(value);
+            }
+        }
+    }
+
+    @Test
+    fun testAsDistinct() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(1)
+            emit(2)
+            emit(2)
+            emit(3)
+            emit(3)
+        }
+        assertEquals(listOf(1, 2, 3), flow.distinct().toList())
+    }
+
+    @Test
+    fun testErrorCancelsUpstream() = runTest {
+        var cancelled = false
+        val latch = Channel<Unit>()
+        val flow: Flow<Int> = flow {
+            coroutineScope {
+                launch {
+                    latch.send(Unit)
+                    hang { cancelled = true }
+                }
+                emit(1)
+                expectUnreached()
+            }
+        }.statefulTransform<Int, Int> {
+
+            {
+                latch.receive()
+                throw TestException()
+            }
+        }.catch { emit(42) }
+
+        assertEquals(42, flow.single())
+        assertTrue(cancelled)
+    }
+}

--- a/kotlinx-coroutines-debug/README.md
+++ b/kotlinx-coroutines-debug/README.md
@@ -61,7 +61,7 @@ stacktraces will be dumped to the console.
 ### Using as JVM agent
 
 Debug module can also be used as a standalone JVM agent to enable debug probes on the application startup.
-You can run your application with an additional argument: `-javaagent:kotlinx-coroutines-debug-1.7.2.jar`.
+You can run your application with an additional argument: `-javaagent:kotlinx-coroutines-debug-1.7.3.jar`.
 Additionally, on Linux and Mac OS X you can use `kill -5 $pid` command in order to force your application to print all alive coroutines.
 When used as Java agent, `"kotlinx.coroutines.debug.enable.creation.stack.trace"` system property can be used to control 
 [DebugProbes.enableCreationStackTraces] along with agent startup.

--- a/kotlinx-coroutines-test/README.md
+++ b/kotlinx-coroutines-test/README.md
@@ -26,7 +26,7 @@ Provided [TestDispatcher] implementations:
 Add `kotlinx-coroutines-test` to your project test dependencies:
 ```
 dependencies {
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
 }
 ```
 

--- a/ui/coroutines-guide-ui.md
+++ b/ui/coroutines-guide-ui.md
@@ -110,7 +110,7 @@ Add dependencies on `kotlinx-coroutines-android` module to the `dependencies { .
 `app/build.gradle` file:
 
 ```groovy
-implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2"
+implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 ```
 
 You can clone [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) project from GitHub onto your 


### PR DESCRIPTION
refs: https://github.com/Kotlin/kotlinx.coroutines/issues/2580

As the original Akka's `statefulMapConcat` can lost the state when the stream/flow is completed, so later, a `statefulMap` is introduced for optional emiting value when the stream/flow is completed.

This PR introduces:

1. Flow#statefulMap
2. Flow#statefulTransform

Difference in statefulMap

I made the `onCompletion` as the second parameter, which is different as it is in Akka, because I think most of the time, the optional last emition may not be needed, and can make use of the trailing lambda.

With the `onCompletion` then this operator can be to implement the `grouped` function without losing data, the default behavior aline with `mapAccumlate`.

Early draft, feedback is welcome, thanks.


