### PR TITLE
Stateful map and transform

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
@@ -43,6 +43,16 @@ public inline fun <T, R> Flow<T>.transform(
     }
 }
 
+public inline fun <T, R> Flow<T>.statefulTransform(
+    @BuilderInference crossinline transformCreator: suspend () -> (suspend FlowCollector<R>.(value: T) -> Unit)
+): Flow<R> = flow {
+    val transform = transformCreator()
+    collect { value ->
+        // kludge, without it Unit will be returned and TCE won't kick in, KT-28938
+        return@collect transform(value)
+    }
+}
+
 // For internal operator implementation
 @PublishedApi
 internal inline fun <T, R> Flow<T>.unsafeTransform(

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -63,7 +63,7 @@ public inline fun <T, R> Flow<T>.map(crossinline transform: suspend (value: T) -
  * @return a new flow
  */
 public fun <S, T, R> Flow<T>.statefulMap(
-    create: () -> S,
+    create: suspend () -> S,
     onCompletion: suspend (S) -> R?,
     transform: suspend (state: S, value: T) -> Pair<S, R>,
 ): Flow<R> = StatefulMapImpl(this, create, onCompletion, transform)
@@ -76,7 +76,7 @@ public fun <S, T, R> Flow<T>.statefulMap(
  * @return a new flow
  */
 public fun <S, T, R> Flow<T>.statefulMap(
-    create: () -> S,
+    create: suspend () -> S,
     transform: suspend (state: S, value: T) -> Pair<S, R>,
 ): Flow<R> = statefulMap(create, defaultCompletion as ((S) -> R?), transform)
 
@@ -84,7 +84,7 @@ private val defaultCompletion:(Any) -> Any? = {null}
 
 private class StatefulMapImpl<S, T, R>(
     private val upstream: Flow<T>,
-    private val create: () -> S,
+    private val create: suspend () -> S,
     private val onCompletion: suspend (S) -> R? = { null },
     private val transform: suspend (state: S, value: T) -> Pair<S, R>
 ) : Flow<R> {

--- a/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+class StatefulMapTest : TestBase() {
+
+    private fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulMap(0L) { index, value ->
+        return@statefulMap Pair(index + 1L, Pair(value, index))
+    }
+
+    @Test
+    fun testStatefulMap() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        assertEquals(listOf(Pair(1, 0L), Pair(2, 1L), Pair(3, 2L)), flow.zipWithIndex().toList())
+    }
+
+    @Test
+    fun testStatefulMapWithOnCompletion() = runTest {
+        val flow = flow {
+            emit("a")
+            emit("b")
+            emit("c")
+        }
+        val flow2: Flow<Any> = flow.statefulMap(0, { it }) { counter, value ->
+            return@statefulMap Pair(counter + 1, value)
+        }
+        assertEquals(listOf("a", "b", "c", 3), flow2.toList())
+    }
+
+    @Test
+    fun testEmptyFlow() = runTest {
+        val sum = emptyFlow<Int>().statefulMap(1) { state, value ->
+            expectUnreached()
+            Pair(state, value)
+        }.sum()
+        assertEquals(0, sum)
+    }
+
+    private fun <T> Flow<T>.grouped(size: Int): Flow<List<T>> =
+        statefulMap(mutableListOf<T>(), { value -> value.toList() }) { acc, value ->
+            if (acc.size < size) {
+                acc.add(value)
+            }
+            if (acc.size == size) {
+                val result = acc.toList()
+                acc.clear()
+                return@statefulMap Pair(acc, result)
+            }
+            return@statefulMap Pair(acc, emptyList<T>())
+        }.filterNot(List<T>::isEmpty)
+
+    @Test
+    fun testGrouped() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            emit(4)
+            emit(5)
+        }
+        assertEquals(listOf(listOf(1, 2), listOf(3, 4), listOf(5)), flow.grouped(2).toList())
+    }
+
+    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulMap(mutableSetOf<T>()) { set, value ->
+        if (set.add(value)) {
+            return@statefulMap Pair(set, value)
+        }
+        return@statefulMap Pair(set, null)
+    }.filterNotNull()
+
+    @Test
+    fun testAsDistinct() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(1)
+            emit(2)
+            emit(2)
+            emit(3)
+            emit(3)
+        }
+        assertEquals(listOf(1, 2, 3), flow.distinct().toList())
+    }
+
+    @Test
+    fun testErrorCancelsUpstream() = runTest {
+        var cancelled = false
+        val latch = Channel<Unit>()
+        val flow: Flow<Int> = flow {
+            coroutineScope {
+                launch {
+                    latch.send(Unit)
+                    hang { cancelled = true }
+                }
+                emit(1)
+                expectUnreached()
+            }
+        }.statefulMap<Int, Int, Int>(1) { _, _ ->
+            latch.receive()
+            throw TestException()
+        }.catch { emit(42) }
+
+        assertEquals(42, flow.single())
+        assertTrue(cancelled)
+    }
+}

--- a/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/StatefulMapTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 
 class StatefulMapTest : TestBase() {
 
-    private fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulMap(0L) { index, value ->
+    private fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulMap({0L}) { index, value ->
         return@statefulMap Pair(index + 1L, Pair(value, index))
     }
 
@@ -31,7 +31,7 @@ class StatefulMapTest : TestBase() {
             emit("b")
             emit("c")
         }
-        val flow2: Flow<Any> = flow.statefulMap(0, { it }) { counter, value ->
+        val flow2: Flow<Any> = flow.statefulMap({0}, { it }) { counter, value ->
             return@statefulMap Pair(counter + 1, value)
         }
         assertEquals(listOf("a", "b", "c", 3), flow2.toList())
@@ -39,7 +39,7 @@ class StatefulMapTest : TestBase() {
 
     @Test
     fun testEmptyFlow() = runTest {
-        val sum = emptyFlow<Int>().statefulMap(1) { state, value ->
+        val sum = emptyFlow<Int>().statefulMap({1}) { state, value ->
             expectUnreached()
             Pair(state, value)
         }.sum()
@@ -47,7 +47,7 @@ class StatefulMapTest : TestBase() {
     }
 
     private fun <T> Flow<T>.grouped(size: Int): Flow<List<T>> =
-        statefulMap(mutableListOf<T>(), { value -> value.toList() }) { acc, value ->
+        statefulMap({mutableListOf<T>()}, { value -> value.toList() }) { acc, value ->
             if (acc.size < size) {
                 acc.add(value)
             }
@@ -71,7 +71,7 @@ class StatefulMapTest : TestBase() {
         assertEquals(listOf(listOf(1, 2), listOf(3, 4), listOf(5)), flow.grouped(2).toList())
     }
 
-    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulMap(mutableSetOf<T>()) { set, value ->
+    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulMap({mutableSetOf<T>()}) { set, value ->
         if (set.add(value)) {
             return@statefulMap Pair(set, value)
         }
@@ -104,7 +104,7 @@ class StatefulMapTest : TestBase() {
                 emit(1)
                 expectUnreached()
             }
-        }.statefulMap<Int, Int, Int>(1) { _, _ ->
+        }.statefulMap<Int, Int, Int>({1}) { _, _ ->
             latch.receive()
             throw TestException()
         }.catch { emit(42) }

--- a/kotlinx-coroutines-core/common/test/flow/operators/StatefulTransformTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/StatefulTransformTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.flow
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+class StatefulTransformTest : TestBase() {
+
+    private suspend fun <T> Flow<T>.zipWithIndex(): Flow<Pair<T, Long>> = statefulTransform {
+        var index = 0L;
+        { value ->
+            emit(Pair(value, index++))
+        }
+    }
+
+    @Test
+    fun testStatefulTransform() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        assertEquals(
+            listOf(Pair(1, 0L), Pair(2, 1L), Pair(3, 2L)), flow.zipWithIndex().toList()
+        )
+    }
+
+    @Test
+    fun testEmptyFlow() = runTest {
+        val sum = emptyFlow<Int>().statefulTransform<Int, Int> {
+            var state = 0
+            {
+                expectUnreached()
+                state++
+                it
+            }
+        }.sum()
+        assertEquals(0, sum)
+    }
+
+    private fun <T> Flow<T>.grouped(size: Int): Flow<List<T>> = statefulTransform {
+        val acc = mutableListOf<T>();
+        { value ->
+            acc.add(value)
+            if (acc.size == size) {
+                val list = acc.toList()
+                acc.clear()
+                emit(list)
+            }
+        }
+    }
+
+    @Test
+    fun testGrouped() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(2)
+            emit(3)
+            emit(4)
+            emit(5)
+        }
+        assertEquals(listOf(listOf(1, 2), listOf(3, 4)), flow.grouped(2).toList())
+    }
+
+    private fun <T> Flow<T>.distinct(): Flow<T?> = statefulTransform {
+        val set = mutableSetOf<T>();
+        { value ->
+            if (set.add(value)) {
+                emit(value);
+            }
+        }
+    }
+
+    @Test
+    fun testAsDistinct() = runTest {
+        val flow = flow {
+            emit(1)
+            emit(1)
+            emit(2)
+            emit(2)
+            emit(3)
+            emit(3)
+        }
+        assertEquals(listOf(1, 2, 3), flow.distinct().toList())
+    }
+
+    @Test
+    fun testErrorCancelsUpstream() = runTest {
+        var cancelled = false
+        val latch = Channel<Unit>()
+        val flow: Flow<Int> = flow {
+            coroutineScope {
+                launch {
+                    latch.send(Unit)
+                    hang { cancelled = true }
+                }
+                emit(1)
+                expectUnreached()
+            }
+        }.statefulTransform<Int, Int> {
+
+            {
+                latch.receive()
+                throw TestException()
+            }
+        }.catch { emit(42) }
+
+        assertEquals(42, flow.single())
+        assertTrue(cancelled)
+    }
+}


### PR DESCRIPTION
refs: https://github.com/Kotlin/kotlinx.coroutines/issues/2580

As the original Akka's statefulMapConcat can lost the state when the stream/flow is completed, so later, a statefulMap is introduced for optional emiting value when the stream/flow is completed.

This PR introduces:

- Flow#statefulMap
- Flow#statefulTransform

Difference in statefulMap

I made the onCompletion as the second parameter, which is different as it is in Akka, because I think most of the time, the optional last emition may not be needed, and can make use of the trailing lambda.

With the onCompletion then this operator can be to implement the grouped function without losing data, the default behavior aline with mapAccumlate.

Early draft, feedback is welcome, thanks.

And As the `statefulTransform` can lost state, which may not be a good idea to introduce ? or we can leave it with document mentioned about that?