### PR TITLE
Kotlin 1.9.20 migration: Fix NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS

### DIFF
--- a/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
+++ b/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
@@ -25,6 +25,7 @@ private object BlackHole {
     var sink = 1
 }
 
+@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS")
 internal actual typealias SuppressSupportingThrowable = SuppressSupportingThrowableImpl
 
 actual val Throwable.suppressed: Array<Throwable>


### PR DESCRIPTION
KT-59665