### PR TITLE
Mute "expect/actual classes are experimental" warning

### DIFF
--- a/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
@@ -19,8 +19,11 @@ configure(subprojects) {
             }
             val newOptions =
                 listOf(
-                    "-progressive", "-Xno-param-assertions", "-Xno-receiver-assertions",
-                    "-Xno-call-assertions"
+                    "-progressive",
+                    "-Xno-param-assertions",
+                    "-Xno-receiver-assertions",
+                    "-Xexpect-actual-classes",
+                    "-Xno-call-assertions",
                 ) + optInAnnotations.map { "-opt-in=$it" }
             freeCompilerArgs = freeCompilerArgs + newOptions
         }


### PR DESCRIPTION
This warning is introduced in Kotlin 1.9. KT-61573 If I don't mute this warning then the build fails because of `-Werror`