### PR TITLE
Kotlin 1.9.20 migration: Fix ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEM…BERS_AS_NON_FINAL_EXPECT_CLASSIFIER compilation error (#3870)

### DIFF
--- a/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
+++ b/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
@@ -25,7 +25,10 @@ private object BlackHole {
     var sink = 1
 }
 
-@Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS")
+@Suppress(
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER",
+)
 internal actual typealias SuppressSupportingThrowable = SuppressSupportingThrowableImpl
 
 actual val Throwable.suppressed: Array<Throwable>


### PR DESCRIPTION
Update suppress after KT-22841