### PR TITLE
Create Dispatcher.Default threads with the same context classloader a…

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -135,6 +135,12 @@ internal actual object DefaultExecutor : EventLoopImplBase(), Runnable {
     private fun createThreadSync(): Thread {
         return _thread ?: Thread(this, THREAD_NAME).apply {
             _thread = this
+            /*
+             * `DefaultExecutor` is a global singleton that creates its thread lazily.
+             * To isolate the classloaders properly, we are inherting the context classloader from
+             * the singleton itself instead of using parent' thread one
+             * in order not to accidentally capture temporary application classloader.
+             */
             contextClassLoader = this@DefaultExecutor.javaClass.classLoader
             isDaemon = true
             start()

--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -135,6 +135,7 @@ internal actual object DefaultExecutor : EventLoopImplBase(), Runnable {
     private fun createThreadSync(): Thread {
         return _thread ?: Thread(this, THREAD_NAME).apply {
             _thread = this
+            contextClassLoader = this@DefaultExecutor.javaClass.classLoader
             isDaemon = true
             start()
         }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -593,6 +593,13 @@ internal class CoroutineScheduler(
     internal inner class Worker private constructor() : Thread() {
         init {
             isDaemon = true
+            /*
+             * `Dispatchers.Default` is used as *the* dispatcher in the containerized environments,
+             * isolated by their own classloaders. Workers are populated lazily, thus we are inheriting
+             * `Dispatchers.Default` context class loader here instead of using parent' thread one
+             * in order not to accidentally capture temporary application classloader.
+             */
+            contextClassLoader = this@CoroutineScheduler.javaClass.classLoader
         }
 
         // guarded by scheduler lock, index in workers array, 0 when not in array (terminated)


### PR DESCRIPTION
…s the dispatcher itself

In order to properly operate in modularized on a classloader level environments with the absence of other workarounds (i.e. supplying application-specific thread factory)

Fixes #3832