### PR TITLE
Workaround for KT-58685

### DIFF
--- a/kotlinx-coroutines-core/common/test/sync/SemaphoreTest.kt
+++ b/kotlinx-coroutines-core/common/test/sync/SemaphoreTest.kt
@@ -168,4 +168,20 @@ class SemaphoreTest : TestBase() {
         assertFailsWith<IllegalArgumentException> { Semaphore(1, -1) }
         assertFailsWith<IllegalArgumentException> { Semaphore(1, 2) }
     }
+
+    @Test
+    fun testWithPermitJsMiscompilation() = runTest {
+        // This is a reproducer for KT-58685
+        // On Kotlin/JS IR, the compiler miscompiles calls to 'release' in an inlined finally
+        // This is visible on the withPermit function
+        // Until the compiler bug is fixed, this test case checks that we do not suffer from it
+        val semaphore = Semaphore(1)
+        assertFailsWith<IndexOutOfBoundsException> {
+            try {
+                semaphore.withPermit { null } ?: throw IndexOutOfBoundsException() // should throw…
+            } catch (e: Exception) {
+                throw e // …but instead fails here
+            }
+        }
+    }
 }


### PR DESCRIPTION
Since at least Kotlin 1.8.0, the Kotlin/JS IR compiler miscompiles a specific combination of a caller of an `inline` function containing a `finally` block: the `finally` block is called twice. This is rare, but can happen when a user calls `Mutex.withLock` or `Semaphore.withPermit`.

I originally reported this issue to the library (https://github.com/Kotlin/kotlinx.coroutines/issues/3754) without any idea how to reproduce it. @dkhalanskyjb managed to create a minimal reproducer and created a ticket against the Kotlin compiler ([KT-58685](https://youtrack.jetbrains.com/issue/KT-58685)). After discussing on the Kotlin Slack ([thread](https://kotlinlang.slack.com/archives/C0B8L3U69/p1693863899538249)), @rjaros found the workaround contained in this PR. Thanks to @JSMonk as well for attempting to fix this on the compiler side.

I added a unit test that reproduces the bug on the JS platform for both `Mutex.withLock` and `Semaphore.withPermit`. I then applied the workaround to both sources, ensuring it fixes both tests. Until a proper fix is found for the compiler, this should ensure users of the library do not have to deal with this. I believe the workaround has no impact on the library, though of course I'm open to your feedback.

For a more real-life example, this has been blocking the release of the [Pedestal](https://gitlab.com/opensavvy/pedestal) library for a long time now ([#101](https://gitlab.com/opensavvy/pedestal/-/issues/101)) because it appears in our cache implementation.