### PR TITLE
Reduce the overall time spent on stress tests in stress mode

### DIFF
--- a/kotlinx-coroutines-core/concurrent/test/channels/BroadcastChannelSubStressTest.kt
+++ b/kotlinx-coroutines-core/concurrent/test/channels/BroadcastChannelSubStressTest.kt
@@ -12,13 +12,13 @@ import kotlin.test.*
  */
 class BroadcastChannelSubStressTest: TestBase() {
 
-    private val nSeconds = 5 * stressTestMultiplier
+    private val nSeconds = maxOf(5, stressTestMultiplier)
     private val sentTotal = atomic(0L)
     private val receivedTotal = atomic(0L)
 
     @Test
     fun testStress() = runTest {
-        TestBroadcastChannelKind.values().forEach { kind ->
+        TestBroadcastChannelKind.entries.forEach { kind ->
             println("--- BroadcastChannelSubStressTest $kind")
             val broadcast = kind.create<Long>()
             val sender =

--- a/kotlinx-coroutines-core/concurrent/test/sync/MutexStressTest.kt
+++ b/kotlinx-coroutines-core/concurrent/test/sync/MutexStressTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.*
 
 class MutexStressTest : TestBase() {
 
-    private val n = (if (isNative) 1_000 else 10_000) * stressTestMultiplier
+    private val n = 1000 * stressTestMultiplier // It mostly stresses K/N as JVM Mutex is tested by lincheck
 
     @Test
     fun testDefaultDispatcher() = runTest { testBody(Dispatchers.Default) }

--- a/kotlinx-coroutines-core/jvm/test/AbstractLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/AbstractLincheckTest.kt
@@ -13,16 +13,16 @@ abstract class AbstractLincheckTest {
 
     @Test
     fun modelCheckingTest() = ModelCheckingOptions()
-        .iterations(if (isStressTest) 200 else 20)
-        .invocationsPerIteration(if (isStressTest) 10_000 else 1_000)
+        .iterations(20 * stressTestMultiplierSqrt)
+        .invocationsPerIteration(1_000 * stressTestMultiplierSqrt)
         .commonConfiguration()
         .customize(isStressTest)
         .check(this::class)
 
     @Test
     fun stressTest() = StressOptions()
-        .iterations(if (isStressTest) 200 else 20)
-        .invocationsPerIteration(if (isStressTest) 10_000 else 1_000)
+        .iterations(20 * stressTestMultiplierSqrt)
+        .invocationsPerIteration(1_000 * stressTestMultiplierSqrt)
         .commonConfiguration()
         .customize(isStressTest)
         .check(this::class)

--- a/kotlinx-coroutines-core/jvm/test/channels/BroadcastChannelMultiReceiveStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/BroadcastChannelMultiReceiveStressTest.kt
@@ -161,6 +161,6 @@ class BroadcastChannelMultiReceiveStressTest(
     @Suppress("UNUSED_PARAMETER")
     private fun println(debugMessage: String) {
         // Uncomment for local debugging
-        // kotlin.io.println(debugMessage)
+        //println(debugMessage as Any?)
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/selects/SelectPhilosophersStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/selects/SelectPhilosophersStressTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import kotlin.test.*
 
 class SelectPhilosophersStressTest : TestBase() {
-    private val TEST_DURATION = 3000L * stressTestMultiplier
+    private val TEST_DURATION = 3000L * stressTestMultiplierSqrt
 
     val n = 10 // number of philosophers
     private val forks = Array(n) { Mutex() }


### PR DESCRIPTION
For now, it takes up to 8 hours, gobbling our TC agent pool and failing by timeout