### PR TITLE
Suppress forgotten error about actual classifier scope mismatch

### DIFF
--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -372,6 +372,9 @@ public actual open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
 
     // optimization: because head is never removed, we don't have to read _next.value to check these:
     override val isRemoved: Boolean get() = false
+
+    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
+    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     override fun nextIfRemoved(): Node? = null
 
     // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846


### PR DESCRIPTION
Code red in IDE on IU-232.9921.47, Kotlin IDE Plugin 232-1.9.20-Beta-release-242

Would be nice to merge it, because IDE Integration tests in IJ check exactly this file and they're failing at the moment. 