### PR TITLE
Add a documentation for JobSupport.addLastAtomic

### DIFF
--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -951,8 +951,8 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      *
      * If it returns `false` then there is no children to wait for and it's safe to finalize the final job's state.
      * Note that at this point, new children can appear:
-     * * For `cancelling` state they are immediately cancelled.
-     * * For `completing` state they are not cancelled and left hanging out to dry.
+     * * If the state is `cancelling`, they are immediately cancelled.
+     * * If the state is `completing`, they are not cancelled; instead, we observe an inconsistent state where their parent is completed and doesn't store references to the children, but they are still active.
      */
     private tailrec fun tryWaitForChildren(state: Finishing, child: ChildHandleNode, proposedUpdate: Any?): Boolean {
         val handle = child.childJob.invokeOnCompletion(

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -949,7 +949,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
      * It's done via an addition of a special completion handler to the child that, when invoked, invokes
      * [continueCompleting] that almost immediately fallbacks to [tryWaitForChildren].
      *
-     * If it returns `false` then there is no children to wait for and it's safe to finalize the final job's state.
+     * If it returns `false`, then there are no children to wait for and it's safe to finalize the final job's state.
      * Note that at this point, new children can appear:
      * * If the state is `cancelling`, they are immediately cancelled.
      * * If the state is `completing`, they are not cancelled; instead, we observe an inconsistent state where their parent is completed and doesn't store references to the children, but they are still active.

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -943,7 +943,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
         state as? ChildHandleNode ?: state.list?.nextChild()
 
     /**
-     * This method is invoked by the JobSupport lifecycle when it transitions into "completing" state (also includes "cancelling"),
+     * This method is invoked by the JobSupport lifecycle when it transitions into "finishing" state,
      * and in order to be transitioned into its final state it has to wait for all the children.
      * If this method returns `true` then the current job is waiting for its children.
      * It's done via an addition of a special completion handler to the child that, when invoked, invokes

--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -72,6 +72,8 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
+    // This is Harris's RDCSS (Restricted Double-Compare Single Swap) operation
+    // It inserts "op" descriptor of when "op" status is still undecided (rolls back otherwise)
     // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
     @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     @PublishedApi
@@ -230,9 +232,6 @@ public actual open class LockFreeLinkedListNode {
             }
         }
     }
-
-    // This is Harris's RDCSS (Restricted Double-Compare Single Swap) operation
-    // It inserts "op" descriptor of when "op" status is still undecided (rolls back otherwise)
 
 
     // ------ other helpers ------

--- a/kotlinx-coroutines-core/jvm/test/MemoryFootprintTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/MemoryFootprintTest.kt
@@ -5,14 +5,32 @@
 package kotlinx.coroutines
 
 import org.junit.Test
-import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.*
 import kotlin.test.*
 
 
 class MemoryFootprintTest : TestBase(true) {
 
     @Test
-    fun testJobLayout() = assertLayout(Job().javaClass, 24)
+    fun testJobLayout() {
+        assertLayout(jobWithChildren(0).javaClass, 24)
+    }
+
+    @Test
+    fun testJobSize() {
+        assertTotalSize(jobWithChildren(1), 112)
+        assertTotalSize(jobWithChildren(2), 192) // + 80
+        assertTotalSize(jobWithChildren(3), 248) // + 56
+        assertTotalSize(jobWithChildren(4), 304) // + 56
+    }
+
+    private fun jobWithChildren(numberOfChildren: Int): Job {
+        val result = Job()
+        repeat(numberOfChildren) {
+            Job(result)
+        }
+        return result
+    }
 
     @Test
     fun testCancellableContinuationFootprint() = assertLayout(CancellableContinuationImpl::class.java, 48)
@@ -20,6 +38,11 @@ class MemoryFootprintTest : TestBase(true) {
     private fun assertLayout(clz: Class<*>, expectedSize: Int) {
         val size = ClassLayout.parseClass(clz).instanceSize()
 //        println(ClassLayout.parseClass(clz).toPrintable())
+        assertEquals(expectedSize.toLong(), size)
+    }
+
+    private fun assertTotalSize(instance: Job, expectedSize: Int) {
+        val size = GraphLayout.parseInstance(instance).totalSize()
         assertEquals(expectedSize.toLong(), size)
     }
 }


### PR DESCRIPTION
* Document internal invariants
* Add memory footprint test
* This explanation can be used to reasonably review follow-up PR that gets rid of addLastIf