### PR TITLE
Suppress MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES warnings

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -147,12 +147,14 @@ private open class BroadcastCoroutine<E>(
     override val channel: SendChannel<E>
         get() = this
 
+    @Suppress("MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES_DEPRECATION_ERROR")
     @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     final override fun cancel(cause: Throwable?): Boolean {
         cancelInternal(cause ?: defaultCancellationException())
         return true
     }
 
+    @Suppress("MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES_DEPRECATION_ERROR")
     final override fun cancel(cause: CancellationException?) {
         cancelInternal(cause ?: defaultCancellationException())
     }

--- a/kotlinx-coroutines-core/common/src/channels/BroadcastChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BroadcastChannel.kt
@@ -136,6 +136,7 @@ public class ConflatedBroadcastChannel<E> private constructor(
  *
  * This channel is created by `BroadcastChannel(capacity)` factory function invocation.
  */
+@Suppress("MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES_WHEN_NO_EXPLICIT_OVERRIDE_DEPRECATION_ERROR")
 internal class BroadcastChannelImpl<E>(
     /**
      * Buffer capacity; [Channel.CONFLATED] when this broadcast is conflated.

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -21,12 +21,14 @@ internal open class ChannelCoroutine<E>(
         cancelInternal(defaultCancellationException())
     }
 
+    @Suppress("MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES_DEPRECATION_ERROR")
     @Deprecated(level = DeprecationLevel.HIDDEN, message = "Since 1.2.0, binary compatibility with versions <= 1.1.x")
     final override fun cancel(cause: Throwable?): Boolean {
         cancelInternal(defaultCancellationException())
         return true
     }
 
+    @Suppress("MULTIPLE_DEFAULTS_INHERITED_FROM_SUPERTYPES_DEPRECATION_ERROR")
     final override fun cancel(cause: CancellationException?) {
         if (isCancelled) return // Do not create an exception if the coroutine (-> the channel) is already cancelled
         cancelInternal(cause ?: defaultCancellationException())


### PR DESCRIPTION
K2 now detects the cases that K1 misses, and
reports warnings, just in case.

^KT-36188
