### PR TITLE
Replace `!==` with `!=` when comparing `Int?` with `null` in `ChannelsLincheckTest`

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/lincheck/ChannelsLincheckTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/lincheck/ChannelsLincheckTest.kt
@@ -223,7 +223,7 @@ abstract class SequentialIntChannelBase(private val capacity: Int) {
         if (buffer.isNotEmpty()) {
             val el = buffer.removeAt(0)
             resumeFirstSender().also {
-                if (it !== null) buffer.add(it)
+                if (it != null) buffer.add(it)
             }
             return el
         }


### PR DESCRIPTION
^KT-62143 Fixed
