### PR TITLE
Update Kotlin to 1.9.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![JetBrains official project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Download](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.7.2)](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.7.2)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.9.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.9.20-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/coroutines/)
 
 Library support for Kotlin coroutines with [multiplatform](#multiplatform) support.
-This is a companion version for the Kotlin `1.9.0` release.
+This is a companion version for the Kotlin `1.9.20` release.
 
 ```kotlin
 suspend fun main() = coroutineScope {
@@ -93,7 +93,7 @@ And make sure that you use the latest Kotlin version:
 
 ```xml
 <properties>
-    <kotlin.version>1.9.0</kotlin.version>
+    <kotlin.version>1.9.20</kotlin.version>
 </properties>
 ```
 
@@ -112,10 +112,10 @@ And make sure that you use the latest Kotlin version:
 ```kotlin
 plugins {
     // For build.gradle.kts (Kotlin DSL)
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.20"
     
     // For build.gradle (Groovy DSL)
-    id "org.jetbrains.kotlin.jvm" version "1.9.0"
+    id "org.jetbrains.kotlin.jvm" version "1.9.20"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 # Kotlin
 version=1.7.2-SNAPSHOT
 group=org.jetbrains.kotlinx
-kotlin_version=1.9.0
+kotlin_version=1.9.20
 
 # Dependencies
 junit_version=4.12

--- a/integration-testing/gradle.properties
+++ b/integration-testing/gradle.properties
@@ -1,4 +1,4 @@
-kotlin_version=1.9.0
+kotlin_version=1.9.20
 coroutines_version=1.7.2-SNAPSHOT
 asm_version=9.3
 

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -321,7 +321,7 @@ public abstract interface annotation class kotlinx/coroutines/DelicateCoroutines
 }
 
 public final class kotlinx/coroutines/DispatchedCoroutine {
-	public static final fun get_decision$FU ()Ljava/util/concurrent/atomic/AtomicIntegerFieldUpdater;
+	public static final synthetic fun get_decision$volatile$FU$kotlinx_coroutines_core ()Ljava/util/concurrent/atomic/AtomicIntegerFieldUpdater;
 }
 
 public abstract class kotlinx/coroutines/DispatchedTask : kotlinx/coroutines/scheduling/Task {


### PR DESCRIPTION
Addresses [KT-60230](https://youtrack.jetbrains.com/issue/KT-60230)-related failures on our CI