### PR TITLE
Kotlin update followup

### DIFF
--- a/gradle/compile-native-multiplatform.gradle
+++ b/gradle/compile-native-multiplatform.gradle
@@ -7,11 +7,6 @@ import static KotlinVersion.isKotlinVersionAtLeast
 project.ext.nativeMainSets = []
 project.ext.nativeTestSets = []
 
-// TODO: this block should be removed when Kotlin version is updated to 1.9.20
-// Right now it is used for conditional removal of native targets that will be removed in 1.9.20 (iosArm32, watchosX86)
-// and is necessary for testing of Kotlin dev builds.
-def enableDeprecatedNativeTargets = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 20)
-
 kotlin {
     targets {
         delegate.metaClass.addTarget = { preset ->
@@ -48,12 +43,6 @@ kotlin {
         addTarget(presets.androidNativeX64)
         addTarget(presets.mingwX64)
         addTarget(presets.watchosDeviceArm64)
-
-        // Deprecated, but were provided by coroutine; can be removed only when K/N drops the target
-        if (enableDeprecatedNativeTargets) {
-            addTarget(presets.iosArm32)
-            addTarget(presets.watchosX86)
-        }
     }
 
     sourceSets {

--- a/kotlinx-coroutines-core/concurrent/src/CompletionHandler.kt
+++ b/kotlinx-coroutines-core/concurrent/src/CompletionHandler.kt
@@ -6,20 +6,12 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-// New 'CompletionHandler` supertype is added compared to the expect declaration.
-// Probably we can add it to JS and common too, to avoid the suppression/opt-in
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 internal actual abstract class CompletionHandlerBase actual constructor() : LockFreeLinkedListNode(), CompletionHandler {
     actual abstract override fun invoke(cause: Throwable?)
 }
 
 internal actual inline val CompletionHandlerBase.asHandler: CompletionHandler get() = this
 
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-// New 'CompletionHandler` supertype is added compared to the expect declaration.
-// Probably we can add it to JS and common too, to avoid the suppression/opt-in
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 internal actual abstract class CancelHandlerBase actual constructor() : CompletionHandler {
     actual abstract override fun invoke(cause: Throwable?)
 }

--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -42,11 +42,7 @@ internal val CONDITION_FALSE: Any = Symbol("CONDITION_FALSE")
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
-@Suppress(
-    "LeakingThis",
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING"
-)
+@Suppress("LeakingThis")
 @InternalCoroutinesApi
 public actual open class LockFreeLinkedListNode {
     private val _next = atomic<Any>(this) // Node | Removed | OpDescriptor
@@ -72,20 +68,14 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     @PublishedApi
     internal inline fun makeCondAddOp(node: Node, crossinline condition: () -> Boolean): CondAddOp =
         object : CondAddOp(node) {
             override fun prepare(affected: Node): Any? = if (condition()) null else CONDITION_FALSE
         }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("MODALITY_CHANGED_IN_NON_FINAL_EXPECT_CLASSIFIER_ACTUALIZATION_WARNING")
     public actual open val isRemoved: Boolean get() = next is Removed
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     // LINEARIZABLE. Returns Node | Removed
     public val next: Any get() {
         _next.loop { next ->
@@ -176,8 +166,6 @@ public actual open class LockFreeLinkedListNode {
      *  Where `==>` denotes linearization point.
      *  Returns `false` if `next` was not following `this` node.
      */
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     @PublishedApi
     internal fun addNext(node: Node, next: Node): Boolean {
         node._prev.lazySet(this)
@@ -188,8 +176,6 @@ public actual open class LockFreeLinkedListNode {
         return true
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     // returns UNDECIDED, SUCCESS or FAILURE
     @PublishedApi
     internal fun tryCondAddNext(node: Node, next: Node, condAdd: CondAddOp): Int {
@@ -213,8 +199,6 @@ public actual open class LockFreeLinkedListNode {
     public actual open fun remove(): Boolean =
         removeOrNext() == null
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     // returns null if removed successfully or next node if this node is already removed
     @PublishedApi
     internal fun removeOrNext(): Node? {
@@ -271,8 +255,6 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     protected open fun nextIfRemoved(): Node? = (next as? Removed)?.ref
 
     /**
@@ -329,8 +311,6 @@ public actual open class LockFreeLinkedListNode {
         }
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     internal fun validateNode(prev: Node, next: Node) {
         assert { prev === this._prev.value }
         assert { next === this._next.value }
@@ -351,8 +331,6 @@ internal fun Any.unwrap(): Node = (this as? Removed)?.ref ?: this as Node
  *
  * @suppress **This is unstable API and it is subject to change.**
  */
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 public actual open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     public actual val isEmpty: Boolean get() = next === this
 
@@ -373,12 +351,8 @@ public actual open class LockFreeLinkedListHead : LockFreeLinkedListNode() {
     // optimization: because head is never removed, we don't have to read _next.value to check these:
     override val isRemoved: Boolean get() = false
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION")
     override fun nextIfRemoved(): Node? = null
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     internal fun validate() {
         var prev: Node = this
         var cur: Node = next as Node

--- a/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
+++ b/kotlinx-coroutines-core/js/src/internal/LinkedList.kt
@@ -9,15 +9,8 @@ package kotlinx.coroutines.internal
 import kotlinx.coroutines.*
 
 private typealias Node = LinkedListNode
+
 /** @suppress **This is unstable API and it is subject to change.** */
-@Suppress(
-    // :TODO: Remove when fixed: https://youtrack.jetbrains.com/issue/KT-23703
-    "NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS",
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING",
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING"
-)
 public actual typealias LockFreeLinkedListNode = LinkedListNode
 
 /** @suppress **This is unstable API and it is subject to change.** */

--- a/kotlinx-coroutines-core/jvm/src/EventLoop.kt
+++ b/kotlinx-coroutines-core/jvm/src/EventLoop.kt
@@ -8,11 +8,8 @@ import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.scheduling.*
 import kotlinx.coroutines.scheduling.CoroutineScheduler
 
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 internal actual abstract class EventLoopImplPlatform: EventLoop() {
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
+
     protected abstract val thread: Thread
 
     protected actual fun unpark() {
@@ -21,8 +18,6 @@ internal actual abstract class EventLoopImplPlatform: EventLoop() {
             unpark(thread)
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("MODALITY_CHANGED_IN_NON_FINAL_EXPECT_CLASSIFIER_ACTUALIZATION_WARNING")
     protected actual open fun reschedule(now: Long, delayedTask: EventLoopImplBase.DelayedTask) {
         DefaultExecutor.schedule(now, delayedTask)
     }

--- a/kotlinx-coroutines-core/jvm/src/Executors.kt
+++ b/kotlinx-coroutines-core/jvm/src/Executors.kt
@@ -37,12 +37,6 @@ public abstract class ExecutorCoroutineDispatcher: CoroutineDispatcher(), Closea
     public abstract override fun close()
 }
 
-@Suppress(
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING",
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_SUPERTYPES_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING"
-)
 @ExperimentalCoroutinesApi
 public actual typealias CloseableCoroutineDispatcher = ExecutorCoroutineDispatcher
 

--- a/kotlinx-coroutines-core/jvm/src/SchedulerTask.kt
+++ b/kotlinx-coroutines-core/jvm/src/SchedulerTask.kt
@@ -6,12 +6,8 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.scheduling.*
 
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 internal actual typealias SchedulerTask = Task
 
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 internal actual typealias SchedulerTaskContext = TaskContext
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")

--- a/kotlinx-coroutines-core/jvm/test/TestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/TestBase.kt
@@ -54,10 +54,6 @@ public actual typealias TestResult = Unit
  * }
  * ```
  */
-@Suppress(
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING"
-)
 public actual open class TestBase(private var disableOutCheck: Boolean)  {
 
     actual constructor(): this(false)
@@ -83,13 +79,10 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
      * Throws [IllegalStateException] like `error` in stdlib, but also ensures that the test will not
      * complete successfully even if this exception is consumed somewhere in the test.
      */
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
     public actual fun error(message: Any, cause: Throwable?): Nothing {
         throw makeError(message, cause)
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     public fun hasError() = error.get() != null
 
     private fun makeError(message: Any, cause: Throwable? = null): IllegalStateException =
@@ -113,8 +106,6 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
      * Throws [IllegalStateException] when `value` is false like `check` in stdlib, but also ensures that the
      * test will not complete successfully even if this exception is consumed somewhere in the test.
      */
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     public inline fun check(value: Boolean, lazyMessage: () -> Any) {
         if (!value) error(lazyMessage())
     }
@@ -162,16 +153,12 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         }
     })
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     fun println(message: Any?) {
         if (disableOutCheck) kotlin.io.println(message)
         else previousOut.println(message)
     }
 
     @Before
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     fun before() {
         initPoolsBeforeTest()
         threadsBefore = currentThreads()
@@ -187,8 +174,6 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         }
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     @After
     fun onCompletion() {
         // onCompletion should not throw exceptions before it finishes all cleanup, so that other tests always
@@ -216,22 +201,17 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         error.get()?.let { throw it }
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     fun initPoolsBeforeTest() {
         DefaultScheduler.usePrivateScheduler()
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     fun shutdownPoolsAfterTest() {
         DefaultScheduler.shutdown(SHUTDOWN_TIMEOUT)
         DefaultExecutor.shutdownForTests(SHUTDOWN_TIMEOUT)
         DefaultScheduler.restore()
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("ACTUAL_WITHOUT_EXPECT", "ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+    @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
     public actual fun runTest(
         expected: ((Throwable) -> Boolean)? = null,
         unhandled: List<(Throwable) -> Boolean> = emptyList(),
@@ -265,16 +245,12 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
             error("Too few unhandled exceptions $exCount, expected ${unhandled.size}")
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     protected inline fun <reified T: Throwable> assertFailsWith(block: () -> Unit): T {
         val result = runCatching(block)
         assertTrue(result.exceptionOrNull() is T, "Expected ${T::class}, but had $result")
         return result.exceptionOrNull()!! as T
     }
 
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    @Suppress("NON_ACTUAL_MEMBER_DECLARED_IN_EXPECT_NON_FINAL_CLASSIFIER_ACTUALIZATION_WARNING")
     protected suspend fun currentDispatcher() = coroutineContext[ContinuationInterceptor]!!
 }
 

--- a/kotlinx-coroutines-core/native/src/internal/Synchronized.kt
+++ b/kotlinx-coroutines-core/native/src/internal/Synchronized.kt
@@ -11,8 +11,6 @@ import kotlinx.atomicfu.locks.withLock as withLock2
  * @suppress **This an internal API and should not be used from general code.**
  */
 @InternalCoroutinesApi
-// fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-@Suppress("ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING")
 public actual typealias SynchronizedObject = kotlinx.atomicfu.locks.SynchronizedObject
 
 /**

--- a/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
+++ b/kotlinx-coroutines-core/native/test/ConcurrentTestUtilities.kt
@@ -25,10 +25,6 @@ private object BlackHole {
     var sink = 1
 }
 
-@Suppress(
-    // fixme replace the suppress with AllowDifferentMembersInActual once stdlib is updated to 1.9.20 https://github.com/Kotlin/kotlinx.coroutines/issues/3846
-    "ACTUAL_CLASSIFIER_MUST_HAVE_THE_SAME_MEMBERS_AS_NON_FINAL_EXPECT_CLASSIFIER_WARNING",
-)
 internal actual typealias SuppressSupportingThrowable = SuppressSupportingThrowableImpl
 
 actual val Throwable.suppressed: Array<Throwable>


### PR DESCRIPTION
A few notes:

* WASM is not in `develop`, there is nothing to change
* `AllowDifferentMembersInActual` idea was reverted and there are no more warnings for mismatches: https://youtrack.jetbrains.com/issue/KT-62656/Drop-AllowDifferentMembersInActual-from-stdlib

Fixes #3828
Fixes #3846