### PR TITLE
Rename `inner` to `innerJob` in exception-handling.md to fix highlighting

### DIFF
--- a/docs/topics/exception-handling.md
+++ b/docs/topics/exception-handling.md
@@ -306,7 +306,7 @@ fun main() = runBlocking {
         println("CoroutineExceptionHandler got $exception")
     }
     val job = GlobalScope.launch(handler) {
-        val inner = launch { // all this stack of coroutines will get cancelled
+        val innerJob = launch { // all this stack of coroutines will get cancelled
             launch {
                 launch {
                     throw IOException() // the original exception
@@ -314,7 +314,7 @@ fun main() = runBlocking {
             }
         }
         try {
-            inner.join()
+            innerJob.join()
         } catch (e: CancellationException) {
             println("Rethrowing CancellationException with original cause")
             throw e // cancellation exception is rethrown, yet the original IOException gets to the handler  


### PR DESCRIPTION
Because `inner` is a soft keyword in Kotlin, it's wrongly highlighted in the playground. Renaming the variable to `innerJob` makes it consistent with the other `job` variable that is in the same snippet, and removes this odd highlighting.

<img width="800" alt="Screenshot 2023-11-06 at 15 44 40" src="https://github.com/Kotlin/kotlinx.coroutines/assets/2178959/005d7661-e8ec-4359-952f-6776ef310fd8">
