### PR TITLE
Remove JDK7 reference from exception handling guide

### DIFF
--- a/docs/topics/exception-handling.md
+++ b/docs/topics/exception-handling.md
@@ -276,10 +276,6 @@ fun main() = runBlocking {
 >
 {type="note"}
 
-> Note: This above code will work properly only on JDK7+ that supports `suppressed` exceptions
->
-{type="note"}
-
 The output of this code is:
 
 ```text


### PR DESCRIPTION
Since [Kotlin 1.5](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), the compiler does not support producing bytecode compatible with Java versions below 8. Therefore, this reference to needing JDK 8 or higher seems superfluous.