### PR TITLE
Fix typo in coroutine-context-and-dispatchers.md

### DIFF
--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -504,7 +504,7 @@ class Activity {
     // to be continued ...
 ```
 
-Now, we can launch coroutines in the scope of this `Activity` using the defined `scope`.
+Now, we can launch coroutines in the scope of this `Activity` using the defined `mainScope`.
 For the demo, we launch ten coroutines that delay for a different time:
 
 ```kotlin


### PR DESCRIPTION
This PR fixes a typo in the `coroutine-context-and-dispatchers.md`.