### PR TITLE
Update atomicfu to 0.23.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ kotlin_version=1.9.20
 # Dependencies
 junit_version=4.12
 junit5_version=5.7.0
-atomicfu_version=0.22.0
+atomicfu_version=0.23.0
 knit_version=0.4.0
 html_version=0.7.2
 lincheck_version=2.18.1
@@ -43,6 +43,7 @@ org.gradle.jvmargs=-Xmx3g
 
 kotlin.mpp.stability.nowarn=true
 kotlinx.atomicfu.enableJvmIrTransformation=true
+kotlinx.atomicfu.enableNativeIrTransformation=true
 # When the flag below is set to `true`, AtomicFU cannot process
 # usages of `moveForward` in `ConcurrentLinkedList.kt` correctly.
 kotlinx.atomicfu.enableJsIrTransformation=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,6 +4,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,6 +4,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlinx-coroutines-core/native/test/TestBase.kt
+++ b/kotlinx-coroutines-core/native/test/TestBase.kt
@@ -17,8 +17,8 @@ public actual typealias TestResult = Unit
 
 public actual open class TestBase actual constructor() {
     public actual val isBoundByJsTestTimeout = false
-    private var actionIndex = atomic(0)
-    private var finished = atomic(false)
+    private val actionIndex = atomic(0)
+    private val finished = atomic(false)
     private var error: Throwable? = null
 
     /**


### PR DESCRIPTION
This PR updates atomicfu version to `0.23.0`.
The major updates in the new atomicfu:
- support of both Wasm targets (`wasmJs` and `wasmWasi`)
- support of K/N Ir transformations, that will are enabled in this PR with a flag `kotlinx.atomicfu.enableNativeIrTransformation=true`


UPD: as the regression with klib incompatibilty was discovered in 1.9.20 (https://github.com/Kotlin/kotlinx-atomicfu/issues/365), I'm waiting for 1.9.21 release where this issue will be fixed, then I'll publish the new atomicfu release `0.23.1` and update the atomicfu version here as well.