### PR TITLE
fix MDCContext lost updates made in coroutine after suspension and restoration

### DIFF
--- a/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
+++ b/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
@@ -44,7 +44,7 @@ public class MDCContext(
      * The value of [MDC] context map.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    public val contextMap: MDCContextMap = MDC.getCopyOfContextMap()
+    public var contextMap: MDCContextMap = MDC.getCopyOfContextMap()
 ) : ThreadContextElement<MDCContextMap>, AbstractCoroutineContextElement(Key) {
     /**
      * Key of [MDCContext] in [CoroutineContext].
@@ -60,6 +60,7 @@ public class MDCContext(
 
     /** @suppress */
     override fun restoreThreadContext(context: CoroutineContext, oldState: MDCContextMap) {
+        contextMap = MDC.getCopyOfContextMap()
         setCurrent(oldState)
     }
 

--- a/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
+++ b/integration/kotlinx-coroutines-slf4j/test/MDCContextTest.kt
@@ -108,4 +108,16 @@ class MDCContextTest : TestBase() {
             }
         }
     }
+
+    @Test
+    fun testContextFollowsInnerUpdatesAfterRestoration() = runTest {
+        withContext(MDCContext()) {
+            MDC.put("myKey", "myValue")
+            // force coroutine suspending
+            delay(1)
+            assertEquals("myValue", MDC.get("myKey"))
+        }
+
+        assertEquals(null, MDC.get("myKey"))
+    }
 }


### PR DESCRIPTION
**Issue:**
When using `withContext(MDCContext()) { ... }`, I observed that the MDC context set inside the block is lost after coroutine suspension. Upon investigation, I discovered that this behavior occurs because MDCContext() always restores the original outer MDC context, ignoring any changes made within the block.

**Proposed Solution:**
To address this issue, I propose updating the MDC contextMap with the actual MDC Context on each coroutine suspension. This modification ensures that the MDC context changes made within the block persist beyond coroutine suspension.