### PR TITLE
Rollback runTest timeout to 60 seconds, configure it with getenv

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -14,7 +14,6 @@ import kotlin.jvm.*
 import kotlin.time.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.internal.*
 
 /**
  * A test result.
@@ -124,11 +123,12 @@ public expect class TestResult
  *
  * There's a built-in timeout of 60 seconds for the test body. If the test body doesn't complete within this time,
  * then the test fails with an [AssertionError]. The timeout can be changed for each test separately by setting the
- * [timeout] parameter. Additionally, setting the `kotlinx.coroutines.test.default_timeout` environment variable to
- * any string that can be parsed using [Duration.parse] (like `1m`, `30s` or `1500ms`) will change the default timeout
- * to that value for all tests whose [timeout] is not set explicitly; setting it to anything else will throw an
+ * [timeout] parameter.
+ *
+ * Additionally, setting the `kotlinx.coroutines.test.default_timeout` system property on the
+ * JVM to any string that can be parsed using [Duration.parse] (like `1m`, `30s` or `1500ms`) will change the default
+ * timeout to that value for all tests whose [timeout] is not set explicitly; setting it to anything else will throw an
  * exception every time [runTest] is invoked.
- * Note that environment variables and JVM system properties are separate concepts and are configured differently.
  *
  * On timeout, the test body is cancelled so that the test finishes. If the code inside the test body does not
  * respond to cancellation, the timeout will not be able to make the test execution stop.
@@ -433,7 +433,7 @@ internal const val DEFAULT_DISPATCH_TIMEOUT_MS = 60_000L
  * other ones would get an incomprehensible `NoClassDefFoundError`.
  */
 private val DEFAULT_TIMEOUT: Result<Duration> = runCatching {
-    environmentVariable("kotlinx.coroutines.test.default_timeout", Duration::parse, 60.seconds)
+    systemProperty("kotlinx.coroutines.test.default_timeout", Duration::parse, 60.seconds)
 }
 
 /**
@@ -583,16 +583,16 @@ internal fun throwAll(head: Throwable?, other: List<Throwable>) {
 
 internal expect fun dumpCoroutines()
 
-private fun <T: Any> environmentVariable(
+private fun <T: Any> systemProperty(
     name: String,
     parse: (String) -> T,
     default: T,
 ): T {
-    val value = environmentVariableImpl(name) ?: return default
+    val value = systemPropertyImpl(name) ?: return default
     return parse(value)
 }
 
-internal expect fun environmentVariableImpl(name: String): String?
+internal expect fun systemPropertyImpl(name: String): String?
 
 @Deprecated(
     "This is for binary compatibility with the `runTest` overload that existed at some point",

--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -122,8 +122,13 @@ public expect class TestResult
  *
  * #### Timing out
  *
- * There's a built-in timeout of 10 seconds for the test body. If the test body doesn't complete within this time,
- * then the test fails with an [AssertionError]. The timeout can be changed by setting the [timeout] parameter.
+ * There's a built-in timeout of 60 seconds for the test body. If the test body doesn't complete within this time,
+ * then the test fails with an [AssertionError]. The timeout can be changed for each test separately by setting the
+ * [timeout] parameter. Additionally, setting the `kotlinx.coroutines.test.default_timeout` environment variable to
+ * any string that can be parsed using [Duration.parse] (like `1m`, `30s` or `1500ms`) will change the default timeout
+ * to that value for all tests whose [timeout] is not set explicitly; setting it to anything else will throw an
+ * exception every time [runTest] is invoked.
+ * Note that environment variables and JVM system properties are separate concepts and are configured differently.
  *
  * On timeout, the test body is cancelled so that the test finishes. If the code inside the test body does not
  * respond to cancellation, the timeout will not be able to make the test execution stop.
@@ -157,7 +162,7 @@ public expect class TestResult
  */
 public fun runTest(
     context: CoroutineContext = EmptyCoroutineContext,
-    timeout: Duration = DEFAULT_TIMEOUT,
+    timeout: Duration = DEFAULT_TIMEOUT.getOrThrow(),
     testBody: suspend TestScope.() -> Unit
 ): TestResult {
     check(context[RunningInRunTest] == null) {
@@ -301,7 +306,7 @@ public fun runTest(
  * Performs [runTest] on an existing [TestScope]. See the documentation for [runTest] for details.
  */
 public fun TestScope.runTest(
-    timeout: Duration = DEFAULT_TIMEOUT,
+    timeout: Duration = DEFAULT_TIMEOUT.getOrThrow(),
     testBody: suspend TestScope.() -> Unit
 ): TestResult = asSpecificImplementation().let { scope ->
     scope.enter()
@@ -421,8 +426,15 @@ internal const val DEFAULT_DISPATCH_TIMEOUT_MS = 60_000L
 
 /**
  * The default timeout to use when running a test.
+ *
+ * It's not just a [Duration] but a [Result] so that every access to [runTest]
+ * throws the same clear exception if parsing the environment variable failed.
+ * Otherwise, the parsing error would only be thrown in one tests, while the
+ * other ones would get an incomprehensible `NoClassDefFoundError`.
  */
-internal val DEFAULT_TIMEOUT = 10.seconds
+private val DEFAULT_TIMEOUT: Result<Duration> = runCatching {
+    environmentVariable("kotlinx.coroutines.test.default_timeout", Duration::parse, 60.seconds)
+}
 
 /**
  * Run the [body][testBody] of the [test coroutine][coroutine], waiting for asynchronous completions for at most
@@ -570,6 +582,17 @@ internal fun throwAll(head: Throwable?, other: List<Throwable>) {
 }
 
 internal expect fun dumpCoroutines()
+
+private fun <T: Any> environmentVariable(
+    name: String,
+    parse: (String) -> T,
+    default: T,
+): T {
+    val value = environmentVariableImpl(name) ?: return default
+    return parse(value)
+}
+
+internal expect fun environmentVariableImpl(name: String): String?
 
 @Deprecated(
     "This is for binary compatibility with the `runTest` overload that existed at some point",

--- a/kotlinx-coroutines-test/js/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/js/src/TestBuilders.kt
@@ -9,14 +9,7 @@ import kotlin.js.*
 @Suppress("ACTUAL_WITHOUT_EXPECT", "ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE")
 public actual typealias TestResult = Promise<Unit>
 
-private external val process: dynamic
-
-internal actual fun environmentVariableImpl(name: String): String? {
-    if (jsTypeOf(process) == "undefined") return null
-    if (jsTypeOf(process.env) == "undefined") return null
-    return process.env[name] as? String
-}
-
+internal actual fun systemPropertyImpl(name: String): String? = null
 
 internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() -> Unit): TestResult =
     GlobalScope.promise {

--- a/kotlinx-coroutines-test/js/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/js/src/TestBuilders.kt
@@ -9,6 +9,15 @@ import kotlin.js.*
 @Suppress("ACTUAL_WITHOUT_EXPECT", "ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE")
 public actual typealias TestResult = Promise<Unit>
 
+private external val process: dynamic
+
+internal actual fun environmentVariableImpl(name: String): String? {
+    if (jsTypeOf(process) == "undefined") return null
+    if (jsTypeOf(process.env) == "undefined") return null
+    return process.env[name] as? String
+}
+
+
 internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() -> Unit): TestResult =
     GlobalScope.promise {
         testProcedure()

--- a/kotlinx-coroutines-test/jvm/src/TestBuildersJvm.kt
+++ b/kotlinx-coroutines-test/jvm/src/TestBuildersJvm.kt
@@ -15,8 +15,12 @@ internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() ->
     }
 }
 
-internal actual fun environmentVariableImpl(name: String): String? =
-    System.getenv(name)
+internal actual fun systemPropertyImpl(name: String): String? =
+    try {
+        System.getProperty(name)
+    } catch (e: SecurityException) {
+        null
+    }
 
 internal actual fun dumpCoroutines() {
     @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")

--- a/kotlinx-coroutines-test/jvm/src/TestBuildersJvm.kt
+++ b/kotlinx-coroutines-test/jvm/src/TestBuildersJvm.kt
@@ -15,6 +15,9 @@ internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() ->
     }
 }
 
+internal actual fun environmentVariableImpl(name: String): String? =
+    System.getenv(name)
+
 internal actual fun dumpCoroutines() {
     @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
     if (DebugProbesImpl.isInstalled) {

--- a/kotlinx-coroutines-test/native/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/native/src/TestBuilders.kt
@@ -4,9 +4,6 @@
 
 package kotlinx.coroutines.test
 import kotlinx.coroutines.*
-import kotlin.native.concurrent.*
-import kotlinx.cinterop.*
-import platform.posix.*
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 public actual typealias TestResult = Unit
@@ -17,8 +14,6 @@ internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() ->
     }
 }
 
-@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
-internal actual fun environmentVariableImpl(name: String): String? =
-    getenv(name)?.toKString()
+internal actual fun systemPropertyImpl(name: String): String? = null
 
 internal actual fun dumpCoroutines() { }

--- a/kotlinx-coroutines-test/native/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/native/src/TestBuilders.kt
@@ -5,6 +5,8 @@
 package kotlinx.coroutines.test
 import kotlinx.coroutines.*
 import kotlin.native.concurrent.*
+import kotlinx.cinterop.*
+import platform.posix.*
 
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 public actual typealias TestResult = Unit
@@ -14,5 +16,9 @@ internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() ->
         testProcedure()
     }
 }
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+internal actual fun environmentVariableImpl(name: String): String? =
+    getenv(name)?.toKString()
 
 internal actual fun dumpCoroutines() { }


### PR DESCRIPTION
This PR attempts to fix #3800.
The first part of the fix, reverting the timeout to 60 seconds, is successful.
The second part, allowing global configuration, not so much.

On JVM, Native, and Node JS, it's possible to use environment variables to communicate data to the process, and it could in theory be the solution, but it doesn't seem to interoperate well with Gradle.

The best attempt so far was to use this:
```kotlin
tasks.withType(AbstractTestTask::class).all {
    if (this is ProcessForkOptions) {
        environment("kotlinx.coroutines.test.default_timeout", "1ms")
    }
}
```

Unfortunately, only `jvmTest` implements `ProcessForkOptions`.

Without a clear way to configure the `runTest` timeout in Gradle builds, we can't claim that this is a proper solution.