### PR TITLE
Ensure that `println` is properly resolved in the JVM tests

### DIFF
--- a/kotlinx-coroutines-core/common/test/TestBase.common.kt
+++ b/kotlinx-coroutines-core/common/test/TestBase.common.kt
@@ -39,6 +39,7 @@ public expect open class TestBase constructor() {
     public fun finish(index: Int)
     public fun ensureFinished() // Ensures that 'finish' was invoked
     public fun reset() // Resets counter and finish flag. Workaround for parametrized tests absence in common
+    public fun println(message: Any?)
 
     public fun runTest(
         expected: ((Throwable) -> Boolean)? = null,

--- a/kotlinx-coroutines-core/js/test/TestBase.kt
+++ b/kotlinx-coroutines-core/js/test/TestBase.kt
@@ -77,6 +77,10 @@ public actual open class TestBase actual constructor() {
         finished = false
     }
 
+    actual fun println(message: Any?) {
+        kotlin.io.println(message)
+    }
+
     @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
     public actual fun runTest(
         expected: ((Throwable) -> Boolean)? = null,

--- a/kotlinx-coroutines-core/jvm/test/TestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/TestBase.kt
@@ -153,7 +153,7 @@ public actual open class TestBase(private var disableOutCheck: Boolean)  {
         }
     })
 
-    fun println(message: Any?) {
+    actual fun println(message: Any?) {
         if (disableOutCheck) kotlin.io.println(message)
         else previousOut.println(message)
     }

--- a/kotlinx-coroutines-core/native/test/TestBase.kt
+++ b/kotlinx-coroutines-core/native/test/TestBase.kt
@@ -73,6 +73,10 @@ public actual open class TestBase actual constructor() {
         finished.value = false
     }
 
+    actual fun println(message: Any?) {
+        kotlin.io.println(message)
+    }
+
     @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
     public actual fun runTest(
         expected: ((Throwable) -> Boolean)? = null,


### PR DESCRIPTION
In K2, the resolution rules changed, and we relied on the specific behavior of the K1 compiler.