### PR TITLE
Update Gradle Dokka configuration to make sure `(source)` button is visible in all API docs

### DIFF
--- a/gradle/dokka.gradle.kts
+++ b/gradle/dokka.gradle.kts
@@ -37,14 +37,31 @@ tasks.withType(DokkaTaskPartial::class).configureEach {
     }
 }
 
-// Custom configuration for MPP modules
-tasks.withType(DokkaTaskPartial::class).configureEach {
-    dokkaSourceSets.configureEach {
-        sourceLink {
-            val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
-            localDirectory.set(projectDir.resolve("src"))
-            remoteUrl.set(URL("https://github.com/kotlin/kotlinx.coroutines/tree/master/$relPath/src"))
-            remoteLineSuffix.set("#L")
+fun GradleDokkaSourceSetBuilder.makeLinkMapping(projectDir: File) {
+    sourceLink {
+        val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
+        localDirectory.set(projectDir.resolve("src"))
+        remoteUrl.set(URL("https://github.com/kotlin/kotlinx.coroutines/tree/master/$relPath/src"))
+        remoteLineSuffix.set("#L")
+    }
+}
+
+if (project.isMultiplatform) {
+    // Configuration for MPP modules
+    tasks.withType(DokkaTaskPartial::class).configureEach {
+        // sources in MPP are located in moduleDir/PLATFORM/src,
+        // where PLATFORM could be jvm, js, jdk8, concurrent, etc
+        // configuration happens in buildSrc/src/main/kotlin/SourceSetsKt.configureMultiplatform
+        dokkaSourceSets.matching { it.name.endsWith("Main") }.configureEach {
+            val platform = name.dropLast(4)
+            makeLinkMapping(project.file(platform))
+        }
+    }
+} else {
+    // Configuration for JVM modules
+    tasks.withType(DokkaTaskPartial::class).configureEach {
+        dokkaSourceSets.named("main") {
+            makeLinkMapping(projectDir)
         }
     }
 }


### PR DESCRIPTION
Fully fixes #3929 

After #3930 was merged there is no more `(source)` for MPP modules (core and test) because they are using different convention for sources.

In this PR dokka configuration for MPP modules is aligned with how sources are configured + it now doesn't use hardcoded names of sourceSets (previously, f.e. `jdk8` and `concurrent` were not configured, and so no `(source)` link were there)

BTW, I found, that there is some issue, that functions which are in `jdk8` can't resolve classes from `common` (in this case there should be `Flow`:
<details><summary>Screenshot</summary>
<img width="1149" alt="image" src="https://github.com/Kotlin/kotlinx.coroutines/assets/50462752/a7f7645a-6254-42ca-8264-b6089e9e79fa">
</details>
I will try to address this in another PR later, or create an issue at Dokka side, depending on the results of investigation