### PR TITLE
Remove metaInfo usage

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-js-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-js-conventions.gradle.kts
@@ -36,6 +36,5 @@ tasks.withType<KotlinJsCompile> {
     kotlinOptions {
         moduleKind = "umd"
         sourceMap = true
-        metaInfo = true
     }
 }


### PR DESCRIPTION
Remove deprecated and will-be-removed property which is actual only for legacy JS compiler