### PR TITLE
Fix flakiness of MainDispatcherTestBase.testWithTimeoutContextDelayTi…

### DIFF
--- a/kotlinx-coroutines-core/common/test/MainDispatcherTestBase.kt
+++ b/kotlinx-coroutines-core/common/test/MainDispatcherTestBase.kt
@@ -211,12 +211,12 @@ abstract class MainDispatcherTestBase: TestBase() {
             expect(1)
             assertFailsWith<TimeoutCancellationException> {
                 withTimeout(300) {
-                    withContext(Dispatchers.Main) {
+                    launch(Dispatchers.Main, start = CoroutineStart.ATOMIC) {
                         checkIsMainThread()
                         expect(2)
                         delay(1000)
                         expectUnreached()
-                    }
+                    }.join()
                 }
                 expectUnreached()
             }

--- a/kotlinx-coroutines-core/common/test/MainDispatcherTestBase.kt
+++ b/kotlinx-coroutines-core/common/test/MainDispatcherTestBase.kt
@@ -211,6 +211,8 @@ abstract class MainDispatcherTestBase: TestBase() {
             expect(1)
             assertFailsWith<TimeoutCancellationException> {
                 withTimeout(300) {
+                    // A substitute for withContext(Dispatcher.Main) that is started even if the 300ms
+                    // timeout happens fsater then dispatch
                     launch(Dispatchers.Main, start = CoroutineStart.ATOMIC) {
                         checkIsMainThread()
                         expect(2)


### PR DESCRIPTION
…meout

* On our virtualized Windows CI everything is slow and sub-seconds delays got racy on a regular basis, leading to flaky builds
* Replace withContext(Dispatcher.Main) with launch(Dispatcher.Main, ATOMIC) {}.join() in order to avoid cancellation between dispatch and start race
* An alternative way is to guard it with isJavaAndWindows that effectively disables such test on Windows