### PR TITLE
Add native targets to the smokeTest project in integration tests.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,4 @@ kotlinx.atomicfu.enableJvmIrTransformation=true
 # When the flag below is set to `true`, AtomicFU cannot process
 # usages of `moveForward` in `ConcurrentLinkedList.kt` correctly.
 kotlinx.atomicfu.enableJsIrTransformation=false
-kotlinx.atomicfu.enableNativeIrTransformation=true
+#kotlinx.atomicfu.enableNativeIrTransformation=true

--- a/integration-testing/smokeTest/build.gradle
+++ b/integration-testing/smokeTest/build.gradle
@@ -17,6 +17,12 @@ kotlin {
     wasmJs() {
         nodejs()
     }
+    
+    macosArm64()
+    macosX64()
+    linuxArm64()
+    linuxX64()
+    mingwX64()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
As there were no native targets in smokeTest, the problem with lacking atomicfu dependency ([KT-64111](https://youtrack.jetbrains.com/issue/KT-64111)) was not addressed in time. 

```
Could not find "org.jetbrains.kotlinx:atomicfu-cinterop-interop" in [/playground/compileOnly-native,/.konan/klib, /.konan/kotlin-native-prebuilt-macos-x86_64-1.9.21/klib/common, /.konan/kotlin-native-prebuilt-macos-x86_64-1.9.21/klib/platform/linux_x64]
```

The bug was revealed after  release of `kotlinx.coroutines` with `atomicfu-gradle-plugin` `0.23.1`. Coroutines enabled Native IR transformation, and for this mode `atomicfu-gradle-plugin` only provided compile dependency to atomicfu, though implementation dependency was still necessary because coroutines depend on the API from `kotlinx.atomicfu.locks` package: like `SynchronizedObject`, `withLock()` etc.

I guess we can merge this PR after update to atomicfu 0.23.2 with the fix. 