### PR TITLE
Change the order of atomicfu and kotlin plugins in the classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ buildscript {
 
     dependencies {
         // Please ensure that atomicfu-gradle-plugin is added to the classpath first, do not change the order, for details see #3984.
+        // The corresponding issue in kotlinx-atomicfu: https://github.com/Kotlin/kotlinx-atomicfu/issues/384
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicfu_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ buildscript {
     }
 
     dependencies {
+        // Please ensure that atomicfu-gradle-plugin is added to the classpath first, do not change the order, for details see #3984.
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicfu_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,9 @@ buildscript {
     }
 
     dependencies {
+        classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicfu_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
-        classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicfu_version"
         classpath "org.jetbrains.kotlinx:kotlinx-knit:$knit_version"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
         classpath "ru.vyarus:gradle-animalsniffer-plugin:1.5.4" // Android API check


### PR DESCRIPTION
A rather obscure problem was revealed while compiling coroutines against the current develop atomicfu branch before 0.23.2 release.  

**Reproducer:**
kotlinx-atomicfu: 
`develop` branch: `clean build publishToMavenLocal` 
kotlinx.coroutines:
`obscure-atomicfu-application-order` branch: `:kotlinx-coroutines-core:compileKotlinJvm -Patomicfu_version=0.23.1-SNAPSHOT`
Reproduced with Kotlin `1.9.20`, `1.9.21` and `2.0.0-dev-*`

```
e: Module kotlinx.atomicfu cannot be found in the module graph
```

> Note that this error is thrown before atomicfu-gradle-plugin is applied. 

The error started to reproduce after these changes in [kotlinx-atomicfu#377](https://github.com/Kotlin/kotlinx-atomicfu/pull/377): (atomicfu compiler plugin should be manually added to the classpath by the user).

Changing the order of `kotlin-gradle-plugin` and `atomicfu-gradle-plugin` in the classpath fixes the problem and the train build is now [green](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KotlinxTrainCoroutinesBuildAndTests/416952644?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildDeploymentsSection=true).

What changes is the compile classspath: 
Before the fix atomicfu-jvm is not included in the classpath:
```
:kotlinx-coroutines-core:compileKotlinJvm Kotlin compiler args: -Xallow-no-source-files -classpath /Users/Maria.Sokolova/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.jar:.......
```

After changing the order atomicfu-jvm is in the classpath:
```
:kotlinx-coroutines-core:compileKotlinJvm Kotlin compiler args: -Xallow-no-source-files -classpath /Users/Maria.Sokolova/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.9.20/e58b4816ac517e9cc5df1db051120c63d4cde669/kotlin-stdlib-1.9.20.jar.....:/Users/Maria.Sokolova/.m2/repository/org/jetbrains/kotlinx/atomicfu-jvm/0.23.2-SNAPSHOT/atomicfu-jvm-0.23.2-SNAPSHOT.jar
```