### PR TITLE
Work around #3968, start running integration tests for Native

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -88,6 +88,10 @@ kotlin {
             api("org.jetbrains.kotlin:kotlin-test-junit:${version("kotlin")}")
             api("junit:junit:${version("junit")}")
         }
+        nativeMain.dependencies {
+            // workaround for #3968 until this is fixed on atomicfu's side
+            api("org.jetbrains.kotlinx:atomicfu:0.23.1")
+        }
         val jsAndWasmSharedMain by registering {
             dependsOn(commonMain.get())
         }

--- a/integration-testing/smokeTest/build.gradle
+++ b/integration-testing/smokeTest/build.gradle
@@ -17,6 +17,12 @@ kotlin {
     wasmJs() {
         nodejs()
     }
+    
+    macosArm64()
+    macosX64()
+    linuxArm64()
+    linuxX64()
+    mingwX64()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
I think we should keep #3968 open until it's fixed properly.