### PR TITLE
Adopt Renovate, here's a suggested config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "benchmarks/**",
+    "buildSrc/**",
+    "gradle/**",
+    "integration-testing/**",
+    "js/**",
+    "kotlinx-coroutines-bom/**",
+    "kotlinx-coroutines-core/**",
+    "kotlinx-coroutines-debug/**",
+    "kotlinx-coroutines-test/**",
+    "reactive/**",
+    "ui/**",
+    "integration/**"
+  ],
+  "schedule": "before 4am on the first day of the month",
+  "minimumReleaseAge": "15",
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "*"
+      ],
+      "groupName": "Kotlin dependencies"
+    }
+  ],
+  "baseBranches": [
+    "develop"
   ]
 }


### PR DESCRIPTION
Related to #4001.

This PR contains a suggested config for the Renovate App, which may help keep kotlinx.coroutines' dependencies up-to-date.

Note that merging the PR is insufficient to enable Renovate. An admin will need to [install the App](https://github.com/apps/renovate) and configure it to run on this repository ([docs](https://docs.renovatebot.com/getting-started/installing-onboarding)). Once the App is given access to the repo, it sends a handy "tutorial PR" (see https://github.com/pnacht/kotlinx.coroutines/pull/1 to see what I got on my fork) that can help with further configuration.

The config I'm sending here tells Renovate to send a single monthly PR updating all outdated dependencies. But if it detects any major version bumps, it sends those in a second PR. This makes it easy to merge the likely-safe minor-version-bumps but still warning the project about new major versions of your dependencies, in case you want to migrate.