### PR TITLE
Extract example output from comment to text block

### DIFF
--- a/docs/topics/flow.md
+++ b/docs/topics/flow.md
@@ -677,14 +677,16 @@ fun main() = runBlocking<Unit> {
   
 Notice how `flow { ... }` works in the background thread, while collection happens in the main thread:   
 
-<!--- TEST FLEXIBLE_THREAD
+```text
 [DefaultDispatcher-worker-1 @coroutine#2] Emitting 1
 [main @coroutine#1] Collected 1
 [DefaultDispatcher-worker-1 @coroutine#2] Emitting 2
 [main @coroutine#1] Collected 2
 [DefaultDispatcher-worker-1 @coroutine#2] Emitting 3
 [main @coroutine#1] Collected 3
--->
+```
+
+<!--- TEST FLEXIBLE_THREAD -->
 
 Another thing to observe here is that the [flowOn] operator has changed the default sequential nature of the flow.
 Now collection happens in one coroutine ("coroutine#1") and emission happens in another coroutine


### PR DESCRIPTION
Recently I've come across the flow docs and noticed one example output isn't displayed in the online version.

In the source file the output is present but hidden inside an XML comment.

I've extracted the output to a text block to display it in the online docs.