### PR TITLE
Fix a build error

### DIFF
--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -142,7 +142,7 @@ kotlin {
 
         // For animal sniffer
         withJava()
-        compilations.create("benchmark") { associateWith(compilations.getByName("main")) }
+        compilations.create("benchmark") { associateWith(this@jvm.compilations.getByName("main")) }
     }
 }
 


### PR DESCRIPTION
With the newer Kotlin Gradle plugin, we got this error: `'var compilations: NamedDomainObjectContainer<KotlinJvmCompilation>' can't be called in this context by implicit receiver. Use the explicit one if necessary`

With this change, we use an explicit receiver, as instructed.