### PR TITLE
Remove the java.lang.management dependency from the debug probes

### DIFF
--- a/kotlinx-coroutines-debug/src/DebugProbes.kt
+++ b/kotlinx-coroutines-debug/src/DebugProbes.kt
@@ -5,7 +5,6 @@ package kotlinx.coroutines.debug
 import kotlinx.coroutines.*
 import kotlinx.coroutines.debug.internal.*
 import java.io.*
-import java.lang.management.*
 import kotlin.coroutines.*
 
 /**


### PR DESCRIPTION
This appears to be unused, and prevents debug probes from being imported on android