### PR TITLE
Remove outdated ExperimentalTime annotation on TimeSource

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/flow/SharingStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/flow/SharingStressTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.*
 import kotlin.time.*
 import kotlin.time.TimeSource
 
-@OptIn(ExperimentalTime::class)
 class SharingStressTest : TestBase() {
     private val testDuration = 1000L * stressTestMultiplier
     private val nSubscribers = 5

--- a/kotlinx-coroutines-test/common/src/TestCoroutineScheduler.kt
+++ b/kotlinx-coroutines-test/common/src/TestCoroutineScheduler.kt
@@ -219,7 +219,6 @@ public class TestCoroutineScheduler : AbstractCoroutineContextElement(TestCorout
     /**
      * Returns the [TimeSource] representation of the virtual time of this scheduler.
      */
-    @ExperimentalTime
     public val timeSource: TimeSource.WithComparableMarks = object : AbstractLongTimeSource(DurationUnit.MILLISECONDS) {
         override fun read(): Long = currentTime
     }

--- a/kotlinx-coroutines-test/common/src/TestScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestScope.kt
@@ -131,7 +131,6 @@ public fun TestScope.advanceTimeBy(delayTime: Duration): Unit = testScheduler.ad
  * @see TestCoroutineScheduler.timeSource
  */
 @ExperimentalCoroutinesApi
-@ExperimentalTime
 public val TestScope.testTimeSource: TimeSource.WithComparableMarks get() = testScheduler.timeSource
 
 /**

--- a/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestCoroutineSchedulerTest.kt
@@ -310,7 +310,6 @@ class TestCoroutineSchedulerTest {
     }
 
     @Test
-    @ExperimentalTime
     fun testAdvanceTimeSource() = runTest {
         val expected = 1.seconds
         val before = testTimeSource.markNow()


### PR DESCRIPTION
It's stable since Kotlin 1.9.0.