### PR TITLE
Remove usage of `kotlin.random.Random` form `CoroutineScheduler.Worker` init

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -657,20 +657,17 @@ internal class CoroutineScheduler(
         var nextParkedWorker: Any? = NOT_IN_STACK
 
         /*
-         * The delay until at least one task in other worker queues will  become stealable.
+         * The delay until at least one task in other worker queues will become stealable.
          */
         private var minDelayUntilStealableTaskNs = 0L
 
         /**
          * The state of embedded Marsaglia xorshift random number generator, used for work-stealing purposes.
          * It is initialized with a seed.
-         *
-         * @see nextInt
          */
         private var rngState: Int = run {
-            // Initialize with a seed from the least significant integer portion of the nanoTime to ensure initial randomness.
+            // This could've been Random.nextInt(), but we are shaving an extra initialization cost, see #4051
             val seed = System.nanoTime().toInt()
-
             // rngState shouldn't be zero, as required for the xorshift algorithm
             if (seed != 0) return@run seed
             42


### PR DESCRIPTION
During the creation of `CoroutineScheduler.Worker`, we need to initialize its embedded random number generator. To avoid additional class-loading costs (#4051), `rngState` is now directly initialized from the current nanoTime (that is used as seed).

Also, a potential bug is fixed, where `nextInt` will always return zero due to incorrect initialization of rngState with zero.
This may happen during the creation of a worker with thread id = `1595972770` (JDK >=8), or unpredictable if fallback thread-local random is used (android SDK <34 or JDK <7), approximate probability is 2.4E-10

Fixes #4051