### PR TITLE
Add cooperativeCatch as coroutine-safe alternative to runCatching

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -147,6 +147,11 @@ public final class kotlinx/coroutines/CompletionHandlerException : java/lang/Run
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
+public final class kotlinx/coroutines/CooperativeCatchKt {
+	public static final fun cooperativeCatch (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun cooperativeMap (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public abstract interface class kotlinx/coroutines/CopyableThreadContextElement : kotlinx/coroutines/ThreadContextElement {
 	public abstract fun copyForChild ()Lkotlinx/coroutines/CopyableThreadContextElement;
 	public abstract fun mergeForChild (Lkotlin/coroutines/CoroutineContext$Element;)Lkotlin/coroutines/CoroutineContext;

--- a/kotlinx-coroutines-core/common/src/CooperativeCatch.kt
+++ b/kotlinx-coroutines-core/common/src/CooperativeCatch.kt
@@ -1,0 +1,35 @@
+package kotlinx.coroutines
+
+/**
+ * Calls the specified function [block] and returns its encapsulated result if invocation was successful.
+ * If a [CancellationException] occurs during execution of the specified function [block], then it will
+ * be immediately thrown. Otherwise, any other [Throwable] exception that was thrown from the [block]
+ * function execution and encapsulating it as a failure.
+ */
+public inline fun <T, R> T.cooperativeCatch(block: T.() -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}
+
+/**
+ * Returns the encapsulated result of the given [transform] function applied to the encapsulated value
+ * if this instance represents [success][Result.isSuccess]. If a [CancellationException] occurs during
+ * the execution of the given [transform] function, it will be thrown immediately. Otherwise, the
+ * original encapsulated [Throwable] exception if it is [failure][Result.isFailure].
+ *
+ * This function catches any [Throwable] exception thrown by [transform] function other than
+ * [CancellationException], and encapsulates it as a failure.
+ *
+ * See [map] for an alternative that rethrows all exceptions from `transform` function.
+ */
+public inline fun <R, T> Result<T>.cooperativeMap(transform: (value: T) -> R): Result<R> {
+    mapCatching(transform)
+    return getOrNull()?.let {
+        cooperativeCatch { transform(it) }
+    } ?: Result.failure(exceptionOrNull() ?: error("Unreachable state"))
+}

--- a/kotlinx-coroutines-core/common/src/CooperativeCatch.kt
+++ b/kotlinx-coroutines-core/common/src/CooperativeCatch.kt
@@ -28,7 +28,6 @@ public inline fun <T, R> T.cooperativeCatch(block: T.() -> R): Result<R> {
  * See [map] for an alternative that rethrows all exceptions from `transform` function.
  */
 public inline fun <R, T> Result<T>.cooperativeMap(transform: (value: T) -> R): Result<R> {
-    mapCatching(transform)
     return getOrNull()?.let {
         cooperativeCatch { transform(it) }
     } ?: Result.failure(exceptionOrNull() ?: error("Unreachable state"))

--- a/ui/kotlinx-coroutines-android/android-unit-tests/test/CooperativeCatchKtTest.kt
+++ b/ui/kotlinx-coroutines-android/android-unit-tests/test/CooperativeCatchKtTest.kt
@@ -1,0 +1,99 @@
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
+import org.junit.Test
+import kotlinx.coroutines.testing.*
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CooperativeCatchKtTest {
+
+    @Test
+    fun cooperativeCatchSuccess() = runTest {
+        val result = cooperativeCatch { 42 }
+
+        assertTrue(result.isSuccess)
+        assertEquals(42, result.getOrNull())
+    }
+
+    @Test
+    fun cooperativeCatchFailure() = runTest {
+        val result = cooperativeCatch {
+            error("exception thrown in cooperativeCatch")
+            42
+        }
+
+        assertTrue(result.isFailure)
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun cooperativeCatchPropagatesCancellationException() = runTest(UnconfinedTestDispatcher()) {
+        var cancellationExceptionWasPropagated = false
+        val job = backgroundScope.launch {
+            try {
+                cooperativeCatch {
+                    while (true) {
+                        ensureActive()
+                        delay(100)
+                    }
+                    42
+                }
+            } catch (e: CancellationException) {
+                cancellationExceptionWasPropagated = true
+                throw e
+            }
+        }
+
+        job.cancel()
+
+        assertTrue(cancellationExceptionWasPropagated)
+    }
+
+    @Test
+    fun cooperativeMapAppliesTransform() = runTest {
+        val result = cooperativeCatch {
+            42
+        }.cooperativeMap {
+            "The answer to life, the universe, and everything? $it"
+        }
+
+        assertEquals("The answer to life, the universe, and everything? 42", result.getOrNull())
+    }
+
+    @Test
+    fun cooperativeMapEncapsulatesThrowables() = runTest {
+        val result = cooperativeCatch {
+            42
+        }.cooperativeMap {
+            error("exception in cooperativeMap")
+            "The answer to life, the universe, and everything? $it"
+        }
+
+        assertTrue(result.isFailure)
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun cooperativeMapPropagatesCancellationException() = runTest(UnconfinedTestDispatcher()) {
+        var cancellationExceptionWasPropagated = false
+        val job = backgroundScope.launch {
+            try {
+                cooperativeCatch {
+                    42
+                }.cooperativeMap {
+                    while (true) {
+                        ensureActive()
+                        delay(100)
+                    }
+                }
+            } catch (e: CancellationException) {
+                cancellationExceptionWasPropagated = true
+                throw e
+            }
+        }
+
+        job.cancel()
+
+        assertTrue(cancellationExceptionWasPropagated)
+    }
+}


### PR DESCRIPTION

## What is this?
This PR adds 2 new methods:
 1. cooperativeCatch
 2. cooperativeMap

Both of these function the same way that `runCatching` and `mapCatching`.
However, these implementations obey cooperative cancellation by immediately propagating `CancellationException` instead of encapsulating it, as `runCatching` and `mapCatching` do.

## Why do we want it?
Firstly, it is not immediately obvious to developers that `runCatching` may actually swallow `CancellationException` and cause memory leaks when a suspend function is invoked inside `runCatching`. It is perfectly reasonable to assume that devs would think a language-provided feature would play nicely with another language-provided feature

Secondly, many devs strongly prefer the functional style of `runCatching` over a typical `try/catch` block. And they simply cannot use their preferred functional style of exception handling with the current state of coroutines. This PR gives devs the power to preserve their preferred programming style.

Discussion on this topic can be found in this issue: https://github.com/Kotlin/kotlinx.coroutines/issues/1814