### PR TITLE
Make `BufferedChannelIterator#hasNext` idempotent

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -1615,7 +1615,7 @@ internal open class BufferedChannel<E>(
 
         // `hasNext()` is just a special receive operation.
         override suspend fun hasNext(): Boolean {
-            return if (this.receiveResult != NO_RECEIVE_RESULT && this.receiveResult != CHANNEL_CLOSED) {
+            return if (this.receiveResult !== NO_RECEIVE_RESULT && this.receiveResult !== CHANNEL_CLOSED) {
                 true
             } else receiveImpl( // <-- this is an inline function
                 // Do not create a continuation until it is required;

--- a/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.*
 
 class BufferedChannelTest : TestBase() {
     @Test
-    fun testIterHasNextIsIdempotant() = runTest {
+    fun testIteratorHasNextIsIdempotent() = runTest {
         val q = Channel<Int>()
         check(q.isEmpty)
         val iter = q.iterator()

--- a/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
@@ -6,6 +6,40 @@ import kotlin.test.*
 
 class BufferedChannelTest : TestBase() {
     @Test
+    fun testIterHasNextIsIdempotant() = runTest {
+        val q = Channel<Int>()
+        check(q.isEmpty)
+        val iter = q.iterator()
+        expect(1)
+        val sender = launch {
+            expect(4)
+            q.send(1) // sent
+            expect(10)
+            q.close()
+            expect(11)
+        }
+        expect(2)
+        val receiver = launch {
+            expect(5)
+            check(iter.hasNext())
+            expect(6)
+            check(iter.hasNext())
+            expect(7)
+            check(iter.hasNext())
+            expect(8)
+            check(iter.next() == 1)
+            expect(9)
+            check(!iter.hasNext())
+            expect(12)
+        }
+        expect(3)
+        sender.join()
+        receiver.join()
+        check(q.isClosedForReceive)
+        finish(13)
+    }
+
+    @Test
     fun testSimple() = runTest {
         val q = Channel<Int>(1)
         check(q.isEmpty)


### PR DESCRIPTION
The rationale in favor of the change includes:
* in the `1.6.x` series `Channel().iterator().hasNext()` was idempotent
* despite the lack of requirement for the `Iterator#hasNext` method implementations to be idempotent, it is generally safer to make them such. The same applies to `ChannelIterator#hasNext`

Here is an example where it matters. Consider the following code snippet:

```
val chunk = mutableListOf<Int>()
while(iter.hasNext()) {
  val v = iter.next()
  chunk.add(v)
  if (chunk.size >= MAX_BATCH_SIZE || !iter.hasNext()) {
    yield(chunk.toList())
    chunk.clear()
  }
}
```

We address two concerns with one block of code - we run the if-block on reaching the chunk size limit or on the last chunk.

If `#hasNext` isn't idempotent, I see a couple of options. The first solution is, the code would essentially have to execute the content of the if-block in two places - in the loop and after the loop:

```
val chunk = mutableListOf<Int>()
while(iter.hasNext()) {
  val v = iter.next()
  chunk.add(v)
  if (chunk.size >= MAX_BATCH_SIZE) {
    yield(chunk.toList())
    chunk.clear()
  }
}

if (chunk.isNotEmpty) {
    yield(chunk.toList())
}
```

Alternatively, we can do memoization of `#hasNext` ourselves e.g.:

```
val chunk = mutableListOf<Int>()
var hasNextMemo = iter.hasNext()
while(hasNextMemo) {
  val v = iter.next()
  chunk.add(v)
  hasNextMemo = iter.hasNext()
  if (chunk.size >= MAX_BATCH_SIZE || !hasNextMemo) {
    yield(chunk.toList())
    chunk.clear()
  }
}
```

Either way, the lack of idempotency of `#hasNext` spills the concern of knowing the state of the iterator over into the caller's code.