### PR TITLE
Install `Dispatchers.Default` on native when creating new context for coroutine builders when there is no `ContinuationInterceptor` there

### DIFF
--- a/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
+++ b/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
@@ -248,6 +248,20 @@ class CoroutineScopeTest : TestBase() {
     }
 
     @Test
+    fun testNewCoroutineContextDispatcher() {
+        fun newContextDispatcher(c1: CoroutineContext, c2: CoroutineContext) =
+            ContextScope(c1).newCoroutineContext(c2)[ContinuationInterceptor]
+
+        assertSame(Dispatchers.Default, newContextDispatcher(EmptyCoroutineContext, EmptyCoroutineContext))
+        assertSame(Dispatchers.Default, newContextDispatcher(EmptyCoroutineContext, Dispatchers.Default))
+        assertSame(Dispatchers.Default, newContextDispatcher(Dispatchers.Default, EmptyCoroutineContext))
+        assertSame(Dispatchers.Default, newContextDispatcher(Dispatchers.Default, Dispatchers.Default))
+        assertSame(Dispatchers.Default, newContextDispatcher(Dispatchers.Unconfined, Dispatchers.Default))
+        assertSame(Dispatchers.Unconfined, newContextDispatcher(Dispatchers.Default, Dispatchers.Unconfined))
+        assertSame(Dispatchers.Unconfined, newContextDispatcher(Dispatchers.Unconfined, Dispatchers.Unconfined))
+    }
+
+    @Test
     fun testScopePlusContext() {
         assertSame(EmptyCoroutineContext, scopePlusContext(EmptyCoroutineContext, EmptyCoroutineContext))
         assertSame(Dispatchers.Default, scopePlusContext(EmptyCoroutineContext, Dispatchers.Default))

--- a/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
+++ b/kotlinx-coroutines-core/common/test/CoroutineScopeTest.kt
@@ -248,6 +248,17 @@ class CoroutineScopeTest : TestBase() {
     }
 
     @Test
+    fun testLaunchContainsDefaultDispatcher() = runTest {
+        val scopeWithoutDispatcher = CoroutineScope(coroutineContext.minusKey(ContinuationInterceptor))
+        scopeWithoutDispatcher.launch(Dispatchers.Default) {
+            assertSame(Dispatchers.Default, coroutineContext[ContinuationInterceptor])
+        }.join()
+        scopeWithoutDispatcher.launch {
+            assertSame(Dispatchers.Default, coroutineContext[ContinuationInterceptor])
+        }.join()
+    }
+
+    @Test
     fun testNewCoroutineContextDispatcher() {
         fun newContextDispatcher(c1: CoroutineContext, c2: CoroutineContext) =
             ContextScope(c1).newCoroutineContext(c2)[ContinuationInterceptor]

--- a/kotlinx-coroutines-core/native/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/native/src/CoroutineContext.kt
@@ -31,8 +31,8 @@ internal actual val DefaultDelay: Delay = DefaultExecutor
 
 public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext {
     val combined = coroutineContext + context
-    return if (combined !== DefaultDelay && combined[ContinuationInterceptor] == null)
-        combined + (DefaultDelay as CoroutineContext.Element) else combined
+    return if (combined !== Dispatchers.Default && combined[ContinuationInterceptor] == null)
+        combined + Dispatchers.Default else combined
 }
 
 public actual fun CoroutineContext.newCoroutineContext(addedContext: CoroutineContext): CoroutineContext {


### PR DESCRIPTION
Fixes #4074