### PR TITLE
Mark the coroutine started with `UNDISPATCHED` as running

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/ProbesSupport.common.kt
+++ b/kotlinx-coroutines-core/common/src/internal/ProbesSupport.common.kt
@@ -3,3 +3,5 @@ package kotlinx.coroutines.internal
 import kotlin.coroutines.*
 
 internal expect inline fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T>
+
+internal expect inline fun <T> probeCoroutineResumed(completion: Continuation<T>): Unit

--- a/kotlinx-coroutines-core/common/src/intrinsics/Undispatched.kt
+++ b/kotlinx-coroutines-core/common/src/intrinsics/Undispatched.kt
@@ -9,9 +9,12 @@ import kotlin.coroutines.intrinsics.*
  * Use this function to restart a coroutine directly from inside of [suspendCoroutine],
  * when the code is already in the context of this coroutine.
  * It does not use [ContinuationInterceptor] and does not update the context of the current thread.
+ *
+ * Used only for tests.
  */
 internal fun <T> (suspend () -> T).startCoroutineUnintercepted(completion: Continuation<T>) {
     startDirect(completion) { actualCompletion ->
+        probeCoroutineResumed(actualCompletion)
         startCoroutineUninterceptedOrReturn(actualCompletion)
     }
 }
@@ -24,6 +27,7 @@ internal fun <T> (suspend () -> T).startCoroutineUnintercepted(completion: Conti
 internal fun <R, T> (suspend (R) -> T).startCoroutineUndispatched(receiver: R, completion: Continuation<T>) {
     startDirect(completion) { actualCompletion ->
         withCoroutineContext(completion.context, null) {
+            probeCoroutineResumed(actualCompletion)
             startCoroutineUninterceptedOrReturn(receiver, actualCompletion)
         }
     }

--- a/kotlinx-coroutines-core/jsAndWasmShared/src/internal/ProbesSupport.kt
+++ b/kotlinx-coroutines-core/jsAndWasmShared/src/internal/ProbesSupport.kt
@@ -4,3 +4,6 @@ import kotlin.coroutines.*
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> = completion
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T> probeCoroutineResumed(completion: Continuation<T>) { }

--- a/kotlinx-coroutines-core/jvm/src/internal/ProbesSupport.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ProbesSupport.kt
@@ -3,6 +3,10 @@
 package kotlinx.coroutines.internal
 
 import kotlin.coroutines.*
-import kotlin.coroutines.jvm.internal.probeCoroutineCreated as probe
 
-internal actual inline fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> = probe(completion)
+internal actual inline fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> =
+    kotlin.coroutines.jvm.internal.probeCoroutineCreated(completion)
+
+internal actual inline fun <T> probeCoroutineResumed(completion: Continuation<T>) {
+    kotlinx.coroutines.debug.internal.probeCoroutineResumed(completion)
+}

--- a/kotlinx-coroutines-core/native/src/internal/ProbesSupport.kt
+++ b/kotlinx-coroutines-core/native/src/internal/ProbesSupport.kt
@@ -4,3 +4,6 @@ import kotlin.coroutines.*
 
 @Suppress("NOTHING_TO_INLINE")
 internal actual inline fun <T> probeCoroutineCreated(completion: Continuation<T>): Continuation<T> = completion
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T> probeCoroutineResumed(completion: Continuation<T>) { }

--- a/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
+++ b/kotlinx-coroutines-debug/test/CoroutinesDumpTest.kt
@@ -106,6 +106,26 @@ class CoroutinesDumpTest : DebugTestBase() {
         }
     }
 
+    /**
+     * Tests that a coroutine started with [CoroutineStart.UNDISPATCHED] is considered running.
+     */
+    @Test
+    fun testUndispatchedCoroutineIsRunning() = runBlocking {
+        val job = launch(Dispatchers.IO, start = CoroutineStart.UNDISPATCHED) { // or launch(Dispatchers.Unconfined)
+            verifyDump(
+                "Coroutine \"coroutine#1\":StandaloneCoroutine{Active}@1e4a7dd4, state: RUNNING\n",
+                ignoredCoroutine = "BlockingCoroutine"
+            )
+            delay(Long.MAX_VALUE)
+        }
+        verifyDump(
+            "Coroutine \"coroutine#1\":StandaloneCoroutine{Active}@1e4a7dd4, state: SUSPENDED\n",
+            ignoredCoroutine = "BlockingCoroutine"
+        ) {
+            job.cancel()
+        }
+    }
+
     @Test
     fun testCreationStackTrace() = runBlocking {
         val deferred = async(Dispatchers.IO) {


### PR DESCRIPTION
This solves the issue of a coroutine started with `CoroutineStart.UNDISPATCHED` not being in the list of running coroutines when its code is, in fact, being executed.

It is still the case that several coroutines can be running on the same thread. For example, trying to run-to-cursor from "A" to "B" will actually enter the "B" in the outer coroutine in the following example:
```kotlin
suspend fun outer() {
  // run from here
  launch(start = CoroutineStart.UNDISPATCHED) {
    println("A")
    delay(1.seconds)
    target()
  }
  target()
}

suspend fun target() {
  println("B")
}
```
It's questionable whether this is incorrect; in any case, this is still less incorrect than what we have now, where the "B" in the inner coroutine would never get entered.

Fixes #4058