### PR TITLE
fix: remove `sampleStart` and `sampleEnd` comments from example in coroutine-context-and-dispatchers.md

### DIFF
--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -227,7 +227,6 @@ import kotlinx.coroutines.*
 fun log(msg: String) = println("[${Thread.currentThread().name}] $msg")
 
 fun main() {
-//sampleStart
     newSingleThreadContext("Ctx1").use { ctx1 ->
         newSingleThreadContext("Ctx2").use { ctx2 ->
             runBlocking(ctx1) {
@@ -239,10 +238,8 @@ fun main() {
             }
         }
     }
-//sampleEnd
 }
 ```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
 >

--- a/docs/topics/coroutine-context-and-dispatchers.md
+++ b/docs/topics/coroutine-context-and-dispatchers.md
@@ -242,6 +242,7 @@ fun main() {
 //sampleEnd
 }
 ```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 > You can get the full code [here](../../kotlinx-coroutines-core/jvm/test/guide/example-context-04.kt).
 >


### PR DESCRIPTION
https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html#jumping-between-threads

UPD: removed sampleStart and sampleEnd comments.

Fix this sample not being runnable:
<img width="875" alt="Screenshot 2024-04-02 at 13 00 09" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/9364ec68-bc49-449c-9740-6d7202fb50d8">
