### PR TITLE
Remove w3c usages from wasmJs implementation

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
@@ -944,6 +944,11 @@ final suspend fun (org.w3c.dom/Window).kotlinx.coroutines/awaitAnimationFrame():
 // Targets: [js]
 final suspend fun <#A: kotlin/Any?> (kotlin.js/Promise<#A>).kotlinx.coroutines/await(): #A // kotlinx.coroutines/await|await@kotlin.js.Promise<0:0>(){0§<kotlin.Any?>}[0]
 // Targets: [wasmJs]
+abstract class kotlinx.coroutines/W3CWindow { // kotlinx.coroutines/W3CWindow|null[0]
+    constructor <init>() // kotlinx.coroutines/W3CWindow.<init>|<init>(){}[0]
+    final fun clearTimeout(kotlin/Int) // kotlinx.coroutines/W3CWindow.clearTimeout|clearTimeout(kotlin.Int){}[0]
+}
+// Targets: [wasmJs]
 final fun <#A: kotlin/Any?> (kotlin.js/Promise<kotlin.js/JsAny?>).kotlinx.coroutines/asDeferred(): kotlinx.coroutines/Deferred<#A> // kotlinx.coroutines/asDeferred|asDeferred@kotlin.js.Promise<kotlin.js.JsAny?>(){0§<kotlin.Any?>}[0]
 // Targets: [wasmJs]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/CoroutineScope).kotlinx.coroutines/promise(kotlin.coroutines/CoroutineContext = ..., kotlinx.coroutines/CoroutineStart = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): kotlin.js/Promise<kotlin.js/JsAny?> // kotlinx.coroutines/promise|promise@kotlinx.coroutines.CoroutineScope(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.CoroutineStart;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]

--- a/kotlinx-coroutines-core/wasmJs/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/wasmJs/src/CoroutineContext.kt
@@ -1,7 +1,5 @@
 package kotlinx.coroutines
 
-import org.w3c.dom.*
-
 internal external interface JsProcess : JsAny {
     fun nextTick(handler: () -> Unit)
 }
@@ -9,7 +7,7 @@ internal external interface JsProcess : JsAny {
 internal fun tryGetProcess(): JsProcess? =
     js("(typeof(process) !== 'undefined' && typeof(process.nextTick) === 'function') ? process : null")
 
-internal fun tryGetWindow(): Window? =
+internal fun tryGetWindow(): W3CWindow? =
     js("(typeof(window) !== 'undefined' && window != null && typeof(window.addEventListener) === 'function') ? window : null")
 
 internal actual fun createDefaultDispatcher(): CoroutineDispatcher =

--- a/kotlinx-coroutines-core/wasmJs/src/JSDispatcher.kt
+++ b/kotlinx-coroutines-core/wasmJs/src/JSDispatcher.kt
@@ -1,9 +1,10 @@
 package kotlinx.coroutines
 
-import org.w3c.dom.Window
 import kotlin.js.*
 
-public actual typealias W3CWindow = Window
+public actual abstract external class W3CWindow {
+    fun clearTimeout(handle: Int)
+}
 
 internal actual fun w3cSetTimeout(window: W3CWindow, handler: () -> Unit, timeout: Int): Int =
     setTimeout(window, handler, timeout)
@@ -40,7 +41,7 @@ internal class NodeDispatcher(private val process: JsProcess) : SetTimeoutBasedD
 }
 
 @Suppress("UNUSED_PARAMETER")
-private fun subscribeToWindowMessages(window: Window, process: () -> Unit): Unit = js("""{
+private fun subscribeToWindowMessages(window: W3CWindow, process: () -> Unit): Unit = js("""{
     const handler = (event) => {
         if (event.source == window && event.data == 'dispatchCoroutine') {
             event.stopPropagation();
@@ -51,7 +52,7 @@ private fun subscribeToWindowMessages(window: Window, process: () -> Unit): Unit
 }""")
 
 @Suppress("UNUSED_PARAMETER")
-private fun createRescheduleMessagePoster(window: Window): () -> Unit =
+private fun createRescheduleMessagePoster(window: W3CWindow): () -> Unit =
     js("() => window.postMessage('dispatchCoroutine', '*')")
 
 @Suppress("UNUSED_PARAMETER")
@@ -84,5 +85,6 @@ private fun clearTimeout(handle: Int): Unit =
     js("{ if (typeof clearTimeout !== 'undefined') clearTimeout(handle); }")
 
 @Suppress("UNUSED_PARAMETER")
-private fun setTimeout(window: Window, handler: () -> Unit, timeout: Int): Int =
+private fun setTimeout(window: W3CWindow, handler: () -> Unit, timeout: Int): Int =
     js("window.setTimeout(handler, timeout)")
+


### PR DESCRIPTION
In a matter of removing w3c declarations from WasmJs stdlib we need to remove its usages from the coroutines.