### PR TITLE
fix: get rid of horizontal scrolling by splitting the comment and show more code mentioned

### DIFF
--- a/docs/topics/channels.md
+++ b/docs/topics/channels.md
@@ -19,7 +19,8 @@ fun main() = runBlocking {
 //sampleStart
     val channel = Channel<Int>()
     launch {
-        // this might be heavy CPU-consuming computation or async logic, we'll just send five squares
+        // this might be heavy CPU-consuming computation or async logic, 
+        // we'll just send five squares
         for (x in 1..5) channel.send(x * x)
     }
     // here we print five received integers:
@@ -103,12 +104,12 @@ and an extension function [consumeEach], that replaces a `for` loop on the consu
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
+//sampleStart
 fun CoroutineScope.produceSquares(): ReceiveChannel<Int> = produce {
     for (x in 1..5) send(x * x)
 }
 
 fun main() = runBlocking {
-//sampleStart
     val squares = produceSquares()
     squares.consumeEach { println(it) }
     println("Done!")

--- a/kotlinx-coroutines-core/jvm/test/guide/example-channel-01.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/example-channel-01.kt
@@ -7,7 +7,8 @@ import kotlinx.coroutines.channels.*
 fun main() = runBlocking {
     val channel = Channel<Int>()
     launch {
-        // this might be heavy CPU-consuming computation or async logic, we'll just send five squares
+        // this might be heavy CPU-consuming computation or async logic, 
+        // we'll just send five squares
         for (x in 1..5) channel.send(x * x)
     }
     // here we print five received integers:


### PR DESCRIPTION
1. Got rid of this scrolling:
<img width="861" alt="Screenshot 2024-04-15 at 15 51 13" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/08580182-0b2b-4dfb-b628-3eae0d430eb0">

2. Moved //sampleStart higher to show more code. We mention the "produce" function but don't show it. A reader immediately starts searching for it in the example below:
<img width="866" alt="Screenshot 2024-04-15 at 15 54 17" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/02e2915f-f5ec-40f4-be7f-b8edea954bcf">

When not finding it, they have to expand this code anyway:
<img width="842" alt="Screenshot 2024-04-15 at 15 53 35" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/40fe9b38-e77e-434a-8e96-4913c9ecb014">
