### PR TITLE
fix link to `Thread.uncaughtException Handler`: give the link to the interface itself; fix the number of DefaultDispatcher-worker in the output

### DIFF
--- a/docs/topics/exception-handling.md
+++ b/docs/topics/exception-handling.md
@@ -60,7 +60,7 @@ The output of this code is (with [debug](https://github.com/Kotlin/kotlinx.corou
 
 ```text
 Throwing exception from launch
-Exception in thread "DefaultDispatcher-worker-2 @coroutine#2" java.lang.IndexOutOfBoundsException
+Exception in thread "DefaultDispatcher-worker-1 @coroutine#2" java.lang.IndexOutOfBoundsException
 Joined failed job
 Throwing exception from async
 Caught ArithmeticException
@@ -73,7 +73,7 @@ Caught ArithmeticException
 It is possible to customize the default behavior of printing **uncaught** exceptions to the console.
 [CoroutineExceptionHandler] context element on a _root_ coroutine can be used as a generic `catch` block for
 this root coroutine and all its children where custom exception handling may take place.
-It is similar to [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)).
+It is similar to [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.UncaughtExceptionHandler.html).
 You cannot recover from the exception in the `CoroutineExceptionHandler`. The coroutine had already completed
 with the corresponding exception when the handler is called. Normally, the handler is used to
 log the exception, show some kind of error message, terminate, and/or restart the application.

--- a/docs/topics/exception-handling.md
+++ b/docs/topics/exception-handling.md
@@ -73,7 +73,7 @@ Caught ArithmeticException
 It is possible to customize the default behavior of printing **uncaught** exceptions to the console.
 [CoroutineExceptionHandler] context element on a _root_ coroutine can be used as a generic `catch` block for
 this root coroutine and all its children where custom exception handling may take place.
-It is similar to [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.UncaughtExceptionHandler.html).
+It is similar to [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setUncaughtExceptionHandler-java.lang.Thread.UncaughtExceptionHandler-).
 You cannot recover from the exception in the `CoroutineExceptionHandler`. The coroutine had already completed
 with the corresponding exception when the handler is called. Normally, the handler is used to
 log the exception, show some kind of error message, terminate, and/or restart the application.

--- a/kotlinx-coroutines-core/jvm/test/guide/test/ExceptionsGuideTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/test/ExceptionsGuideTest.kt
@@ -9,7 +9,7 @@ class ExceptionsGuideTest {
     fun testExampleExceptions01() {
         test("ExampleExceptions01") { kotlinx.coroutines.guide.exampleExceptions01.main() }.verifyExceptions(
             "Throwing exception from launch",
-            "Exception in thread \"DefaultDispatcher-worker-2 @coroutine#2\" java.lang.IndexOutOfBoundsException",
+            "Exception in thread \"DefaultDispatcher-worker-1 @coroutine#2\" java.lang.IndexOutOfBoundsException",
             "Joined failed job",
             "Throwing exception from async",
             "Caught ArithmeticException"


### PR DESCRIPTION
1. fix the number of DefaultDispatcher-worker in the output: the output always gives the number 1 for worker, not 2:
<img width="769" alt="Screenshot 2024-04-16 at 14 14 42" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/c88fba19-06ed-40c5-ab1d-8bb259272b22">

2. give the link to the `Thread.uncaughtException Handler` interface itself:
Now it will be:
<img width="1913" alt="Screenshot 2024-04-16 at 14 16 55" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/6260ec4c-c008-4668-bf97-07bca7f5dbad">

It was:
<img width="1916" alt="Screenshot 2024-04-16 at 14 16 47" src="https://github.com/Kotlin/kotlinx.coroutines/assets/78360457/f4861f99-3db5-4628-8fcc-1520f763117b">
