### PR TITLE
Fix documentation of Migration.kt

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -443,8 +443,8 @@ public fun <T> Flow<T>.scanReduce(operation: suspend (accumulator: T, value: T) 
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'publish()' is 'shareIn'. \n" +
         "publish().connect() is the default strategy (no extra call is needed), \n" +
-        "publish().autoConnect() translates to 'started = SharingStared.Lazily' argument, \n" +
-        "publish().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.",
+        "publish().autoConnect() translates to 'started = SharingStarted.Lazily' argument, \n" +
+        "publish().refCount() translates to 'started = SharingStarted.WhileSubscribed()' argument.",
     replaceWith = ReplaceWith("this.shareIn(scope, 0)")
 )
 public fun <T> Flow<T>.publish(): Flow<T> = noImpl()
@@ -454,8 +454,8 @@ public fun <T> Flow<T>.publish(): Flow<T> = noImpl()
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'publish(bufferSize)' is 'buffer' followed by 'shareIn'. \n" +
         "publish().connect() is the default strategy (no extra call is needed), \n" +
-        "publish().autoConnect() translates to 'started = SharingStared.Lazily' argument, \n" +
-        "publish().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.",
+        "publish().autoConnect() translates to 'started = SharingStarted.Lazily' argument, \n" +
+        "publish().refCount() translates to 'started = SharingStarted.WhileSubscribed()' argument.",
     replaceWith = ReplaceWith("this.buffer(bufferSize).shareIn(scope, 0)")
 )
 public fun <T> Flow<T>.publish(bufferSize: Int): Flow<T> = noImpl()
@@ -465,8 +465,8 @@ public fun <T> Flow<T>.publish(bufferSize: Int): Flow<T> = noImpl()
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'replay()' is 'shareIn' with unlimited replay. \n" +
         "replay().connect() is the default strategy (no extra call is needed), \n" +
-        "replay().autoConnect() translates to 'started = SharingStared.Lazily' argument, \n" +
-        "replay().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.",
+        "replay().autoConnect() translates to 'started = SharingStarted.Lazily' argument, \n" +
+        "replay().refCount() translates to 'started = SharingStarted.WhileSubscribed()' argument.",
     replaceWith = ReplaceWith("this.shareIn(scope, Int.MAX_VALUE)")
 )
 public fun <T> Flow<T>.replay(): Flow<T> = noImpl()
@@ -476,8 +476,8 @@ public fun <T> Flow<T>.replay(): Flow<T> = noImpl()
     level = DeprecationLevel.ERROR,
     message = "Flow analogue of 'replay(bufferSize)' is 'shareIn' with the specified replay parameter. \n" +
         "replay().connect() is the default strategy (no extra call is needed), \n" +
-        "replay().autoConnect() translates to 'started = SharingStared.Lazily' argument, \n" +
-        "replay().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.",
+        "replay().autoConnect() translates to 'started = SharingStarted.Lazily' argument, \n" +
+        "replay().refCount() translates to 'started = SharingStarted.WhileSubscribed()' argument.",
     replaceWith = ReplaceWith("this.shareIn(scope, bufferSize)")
 )
 public fun <T> Flow<T>.replay(bufferSize: Int): Flow<T> = noImpl()
@@ -485,7 +485,7 @@ public fun <T> Flow<T>.replay(bufferSize: Int): Flow<T> = noImpl()
 /** @suppress */
 @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Flow analogue of 'cache()' is 'shareIn' with unlimited replay and 'started = SharingStared.Lazily' argument'",
-    replaceWith = ReplaceWith("this.shareIn(scope, Int.MAX_VALUE, started = SharingStared.Lazily)")
+    message = "Flow analogue of 'cache()' is 'shareIn' with unlimited replay and 'started = SharingStarted.Lazily' argument'",
+    replaceWith = ReplaceWith("this.shareIn(scope, started = SharingStarted.Lazily, replay = Int.MAX_VALUE)")
 )
 public fun <T> Flow<T>.cache(): Flow<T> = noImpl()


### PR DESCRIPTION
Replacing "SharingStared" with correct "SharingStarted".  
Fixing wrong order of parameters in replaceWith of cache() method.