### PR TITLE
Remove -opt flag from a debug build

### DIFF
--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -92,10 +92,6 @@ kotlin {
      * All new MM targets are build with optimize = true to have stress tests properly run.
      */
     targets.withType(KotlinNativeTargetWithTests::class).configureEach {
-        binaries.getTest(DEBUG).apply {
-            optimized = true
-        }
-
         binaries.test("workerTest", listOf(DEBUG)) {
             val thisTest = this
             optimized = true


### PR DESCRIPTION
Simultaneous use of -g and -opt flags is not a good idea and is being [prohibited](https://youtrack.jetbrains.com/issue/KT-64106/Native-the-compiler-allows-using-opt-and-g-at-the-same-time).

