### PR TITLE
Fix increased memory consumption in JobSupport

### DIFF
--- a/kotlinx-coroutines-core/common/src/Await.kt
+++ b/kotlinx-coroutines-core/common/src/Await.kt
@@ -115,6 +115,6 @@ private class AwaitAll<T>(private val deferreds: Array<out Deferred<T>>) {
             }
         }
 
-        override val onCancelling = false
+        override val onCancelling get() = false
     }
 }

--- a/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuationImpl.kt
@@ -675,5 +675,5 @@ private class ChildContinuation(
         child.parentCancelled(child.getContinuationCancellationCause(job))
     }
 
-    override val onCancelling = true
+    override val onCancelling get() = true
 }

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -673,5 +673,5 @@ private class DisposeOnCompletion(
 ) : JobNode() {
     override fun invoke(cause: Throwable?) = handle.dispose()
 
-    override val onCancelling = false
+    override val onCancelling get() = false
 }

--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -577,7 +577,7 @@ public open class JobSupport constructor(active: Boolean) : Job, ChildJob, Paren
         override fun invoke(cause: Throwable?) {
             select.trySelect(this@JobSupport, Unit)
         }
-        override val onCancelling: Boolean = false
+        override val onCancelling: Boolean get() = false
     }
 
     /**
@@ -1410,14 +1410,14 @@ private class InvokeOnCompletion(
     private val handler: CompletionHandler
 ) : JobNode()  {
     override fun invoke(cause: Throwable?) = handler.invoke(cause)
-    override val onCancelling = false
+    override val onCancelling get() = false
 }
 
 private class ResumeOnCompletion(
     private val continuation: Continuation<Unit>
 ) : JobNode() {
     override fun invoke(cause: Throwable?) = continuation.resume(Unit)
-    override val onCancelling = false
+    override val onCancelling get() = false
 }
 
 private class ResumeAwaitOnCompletion<T>(
@@ -1435,7 +1435,7 @@ private class ResumeAwaitOnCompletion<T>(
             continuation.resume(state.unboxState() as T)
         }
     }
-    override val onCancelling = false
+    override val onCancelling get() = false
 }
 
 // -------- invokeOnCancellation nodes
@@ -1448,7 +1448,7 @@ private class InvokeOnCancelling(
     override fun invoke(cause: Throwable?) {
         if (_invoked.compareAndSet(expect = false, update = true)) handler.invoke(cause)
     }
-    override val onCancelling = true
+    override val onCancelling get() = true
 }
 
 private class ChildHandleNode(
@@ -1457,5 +1457,5 @@ private class ChildHandleNode(
     override val parent: Job get() = job
     override fun invoke(cause: Throwable?) = childJob.parentCancelled(job)
     override fun childCancelled(cause: Throwable): Boolean = job.childCancelled(cause)
-    override val onCancelling: Boolean = true
+    override val onCancelling: Boolean get() = true
 }

--- a/kotlinx-coroutines-core/jvm/src/Future.kt
+++ b/kotlinx-coroutines-core/jvm/src/Future.kt
@@ -37,7 +37,7 @@ private class CancelFutureOnCompletion(
         if (cause != null) future.cancel(false)
     }
 
-    override val onCancelling = false
+    override val onCancelling get() = false
 }
 
 private class CancelFutureOnCancel(private val future: Future<*>) : CancelHandler {

--- a/kotlinx-coroutines-core/jvm/src/Interruptible.kt
+++ b/kotlinx-coroutines-core/jvm/src/Interruptible.kt
@@ -154,7 +154,7 @@ private class ThreadState : JobNode() {
         }
     }
 
-    override val onCancelling = true
+    override val onCancelling get() = true
 
     private fun invalidState(state: Int): Nothing = error("Illegal state $state")
 }

--- a/kotlinx-coroutines-core/jvm/test/MemoryFootprintTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/MemoryFootprintTest.kt
@@ -2,7 +2,7 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.testing.*
 import org.junit.Test
-import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.*
 import kotlin.test.*
 
 
@@ -12,11 +12,32 @@ class MemoryFootprintTest : TestBase(true) {
     fun testJobLayout() = assertLayout(Job().javaClass, 24)
 
     @Test
+    fun testJobSize() {
+        assertTotalSize(jobWithChildren(1), 112)
+        assertTotalSize(jobWithChildren(2), 192) // + 80
+        assertTotalSize(jobWithChildren(3), 248) // + 56
+        assertTotalSize(jobWithChildren(4), 304) // + 56
+    }
+
+    private fun jobWithChildren(numberOfChildren: Int): Job {
+        val result = Job()
+        repeat(numberOfChildren) {
+            Job(result)
+        }
+        return result
+    }
+
+    @Test
     fun testCancellableContinuationFootprint() = assertLayout(CancellableContinuationImpl::class.java, 48)
 
     private fun assertLayout(clz: Class<*>, expectedSize: Int) {
         val size = ClassLayout.parseClass(clz).instanceSize()
 //        println(ClassLayout.parseClass(clz).toPrintable())
+        assertEquals(expectedSize.toLong(), size)
+    }
+
+    private fun assertTotalSize(instance: Job, expectedSize: Int) {
+        val size = GraphLayout.parseInstance(instance).totalSize()
         assertEquals(expectedSize.toLong(), size)
     }
 }


### PR DESCRIPTION
Fixup to 65ef6ea4b4cf200856db1614e0b4ab98e08fe6b0: that commit made `JobSupport` consume more memory by making the information about whether a callback should be invoked when the job enters the cancelling state be represented as a boolean flag and not part of the object class hierarchy.

Now that flag is a virtual function instead.