### PR TITLE
Fix broken API reference links to the Project Reactor Javadoc

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ lincheck_version=2.18.1
 dokka_version=1.9.20
 byte_buddy_version=1.10.9
 reactor_version=3.4.1
+reactor_docs_version=3.4.5
 reactive_streams_version=1.0.3
 rxjava2_version=2.2.8
 rxjava3_version=3.0.2

--- a/reactive/kotlinx-coroutines-reactor/build.gradle.kts
+++ b/reactive/kotlinx-coroutines-reactor/build.gradle.kts
@@ -5,10 +5,8 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-val reactorVersion = version("reactor")
-
 dependencies {
-    api("io.projectreactor:reactor-core:$reactorVersion")
+    api("io.projectreactor:reactor-core:${version("reactor")}")
     api(project(":kotlinx-coroutines-reactive"))
 }
 
@@ -27,8 +25,10 @@ tasks {
     }
 }
 
+// the version of the docs can be different from the version of the Reactor
+// library itself: https://github.com/reactor/reactor-core/issues/3794
 externalDocumentationLink(
-    url = "https://projectreactor.io/docs/core/$reactorVersion/api/"
+    url = "https://projectreactor.io/docs/core/${version("reactor_docs")}/api/"
 )
 
 


### PR DESCRIPTION
See <https://github.com/reactor/reactor-core/issues/3794>