### PR TITLE
Parallelism Compensation for CoroutineDispatcher and runBlocking

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -1,0 +1,156 @@
+package kotlinx.coroutines.internal
+
+import kotlinx.atomicfu.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.scheduling.ParallelismCompensation
+import kotlin.coroutines.*
+
+/**
+ * Introduced as part of IntelliJ patches.
+ *
+ * CoroutineDispatchers may optionally implement this interface to declare an ability to construct [SoftLimitedDispatcher]
+ * on top of themselves. This is not possible in general case, because the worker of the underlying dispatcher must
+ * implement [ParallelismCompensation] and properly propagate such requests to the task it is running.
+ */
+internal interface SoftLimitedParallelism {
+    fun softLimitedParallelism(parallelism: Int): CoroutineDispatcher
+}
+
+/**
+ * Introduced as part of IntelliJ patches.
+ */
+internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int): CoroutineDispatcher {
+    if (this is SoftLimitedParallelism) {
+        return this.softLimitedParallelism(parallelism)
+    }
+    // SoftLimitedDispatcher cannot be used on top of LimitedDispatcher, because the latter doesn't propagate compensation requests
+    throw UnsupportedOperationException("CoroutineDispatcher.softLimitedParallelism cannot be applied to $this")
+}
+
+/**
+ * Introduced as part of IntelliJ patches.
+ *
+ * Shamelessly copy-pasted from [LimitedDispatcher], but [ParallelismCompensation] is
+ * implemented for [Worker] to allow compensation.
+ *
+ * [ParallelismCompensation] breaks the contract of [LimitedDispatcher] so a separate class is made to implement a
+ * dispatcher that mostly behaves as limited, but can temporarily increase parallelism if necessary.
+ */
+internal class SoftLimitedDispatcher(
+    private val dispatcher: CoroutineDispatcher,
+    parallelism: Int
+) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
+    private val initialParallelism = parallelism
+    // `parallelism limit - runningWorkers`; may be < 0 if decompensation is expected
+    private val availablePermits = atomic(parallelism)
+
+    private val queue = LockFreeTaskQueue<Runnable>(singleConsumer = false)
+
+    private val workerAllocationLock = SynchronizedObject()
+
+    override fun limitedParallelism(parallelism: Int): CoroutineDispatcher {
+        return super.limitedParallelism(parallelism)
+    }
+
+    override fun softLimitedParallelism(parallelism: Int): CoroutineDispatcher {
+        parallelism.checkParallelism()
+        if (parallelism >= initialParallelism) return this
+        return SoftLimitedDispatcher(this, parallelism)
+    }
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatchInternal(block) { worker ->
+            dispatcher.dispatch(this, worker)
+        }
+    }
+
+    @InternalCoroutinesApi
+    override fun dispatchYield(context: CoroutineContext, block: Runnable) {
+        dispatchInternal(block) { worker ->
+            dispatcher.dispatchYield(this, worker)
+        }
+    }
+
+    /**
+     * Tries to dispatch the given [block].
+     * If there are not enough workers, it starts a new one via [startWorker].
+     */
+    private inline fun dispatchInternal(block: Runnable, startWorker: (Worker) -> Unit) {
+        queue.addLast(block)
+        if (availablePermits.value <= 0) return
+        if (!tryAllocateWorker()) return
+        val task = obtainTaskOrDeallocateWorker() ?: return
+        startWorker(Worker(task))
+    }
+
+    /**
+     * Tries to obtain the permit to start a new worker.
+     */
+    private fun tryAllocateWorker(): Boolean {
+        synchronized(workerAllocationLock) {
+            val permits = availablePermits.value
+            if (permits <= 0) return false
+            return availablePermits.compareAndSet(permits, permits - 1)
+        }
+    }
+
+    /**
+     * Obtains the next task from the queue, or logically deallocates the worker if the queue is empty.
+     */
+    private fun obtainTaskOrDeallocateWorker(): Runnable? {
+        val permits = availablePermits.value
+        if (permits < 0) { // decompensation
+            if (availablePermits.compareAndSet(permits, permits + 1)) return null
+        }
+        while (true) {
+            when (val nextTask = queue.removeFirstOrNull()) {
+                null -> synchronized(workerAllocationLock) {
+                    availablePermits.incrementAndGet()
+                    if (queue.size == 0) return null
+                    availablePermits.decrementAndGet()
+                }
+                else -> return nextTask
+            }
+        }
+    }
+
+    /**
+     * Every running Worker holds a permit
+     */
+    private inner class Worker(private var currentTask: Runnable) : Runnable, ParallelismCompensation {
+        override fun run() {
+            var fairnessCounter = 0
+            while (true) {
+                try {
+                    currentTask.run()
+                } catch (e: Throwable) {
+                    handleCoroutineException(EmptyCoroutineContext, e)
+                }
+                currentTask = obtainTaskOrDeallocateWorker() ?: return
+                // 16 is our out-of-thin-air constant to emulate fairness. Used in JS dispatchers as well
+                if (++fairnessCounter >= 16 && dispatcher.isDispatchNeeded(this@SoftLimitedDispatcher)) {
+                    // Do "yield" to let other views execute their runnable as well
+                    // Note that we do not decrement 'runningWorkers' as we are still committed to our part of work
+                    dispatcher.dispatch(this@SoftLimitedDispatcher, this)
+                    return
+                }
+            }
+        }
+
+        override fun increaseParallelismAndLimit() {
+            val newTask = obtainTaskOrDeallocateWorker() // either increases the number of permits or we launch a new worker (which holds a permit)
+            if (newTask != null) {
+                dispatcher.dispatch(this@SoftLimitedDispatcher, Worker(newTask))
+            }
+            (currentTask as? ParallelismCompensation)?.increaseParallelismAndLimit()
+        }
+
+        override fun decreaseParallelismLimit() {
+            try {
+                (currentTask as? ParallelismCompensation)?.decreaseParallelismLimit()
+            } finally {
+                availablePermits.decrementAndGet()
+            }
+        }
+    }
+}

--- a/kotlinx-coroutines-core/common/src/scheduling/ParallelismCompensation.kt
+++ b/kotlinx-coroutines-core/common/src/scheduling/ParallelismCompensation.kt
@@ -1,0 +1,20 @@
+package kotlinx.coroutines.scheduling
+
+/**
+ * Introduced as part of IntelliJ patches.
+ *
+ * Runnables that are dispatched on [kotlinx.coroutines.CoroutineDispatcher] may optionally implement this interface
+ * to declare an ability to compensate the associated parallelism resource.
+ */
+internal interface ParallelismCompensation {
+    /**
+     * Should increase both the limit and the effective parallelism.
+     */
+    fun increaseParallelismAndLimit()
+
+    /**
+     * Should only decrease the parallelism limit. The effective parallelism may temporarily stay higher than this limit.
+     * Runnable should take care of checking whether effective parallelism needs to decrease to meet the desired limit.
+     */
+    fun decreaseParallelismLimit()
+}

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -806,11 +806,15 @@ internal class CoroutineScheduler(
 
         private fun inStack(): Boolean = nextParkedWorker !== NOT_IN_STACK
 
+        private var currentTask: Task? = null
+
         private fun executeTask(task: Task) {
             val taskMode = task.mode
             idleReset(taskMode)
             beforeTask(taskMode)
+            currentTask = task
             runSafely(task)
+            currentTask = null
             afterTask(taskMode)
         }
 

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -762,8 +762,6 @@ internal class CoroutineScheduler(
                     minDelayUntilStealableTaskNs = 0L
                     executeTask(task)
                     continue
-                } else {
-                    mayHaveLocalTasks = false
                 }
                 /*
                  * No tasks were found:
@@ -1030,6 +1028,7 @@ internal class CoroutineScheduler(
                 val globalFirst = nextInt(2 * corePoolSize) == 0
                 if (globalFirst) pollGlobalQueues()?.let { return it }
                 localQueue.poll()?.let { return it }
+                mayHaveLocalTasks = false
                 if (!globalFirst) pollGlobalQueues()?.let { return it }
             } else {
                 pollGlobalQueues()?.let { return it }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/parallelismCompensation.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/parallelismCompensation.kt
@@ -1,0 +1,26 @@
+package kotlinx.coroutines.scheduling
+
+private val parallelismCompensationEnabled: Boolean =
+    System.getProperty("kotlinx.coroutines.parallelism.compensation", "true").toBoolean()
+
+/**
+ * Introduced as part of IntelliJ patches.
+ *
+ * Increases the parallelism limit of the coroutine dispatcher associated with the current thread for the duration of [body] execution.
+ * After the [body] completes, the effective parallelism may stay higher than the associated limit, but it is said
+ * that eventually it will adjust to meet it.
+ */
+internal fun <T> withCompensatedParallelism(body: () -> T): T {
+    if (!parallelismCompensationEnabled) {
+        return body()
+    }
+    // CoroutineScheduler.Worker implements ParallelismCompensation
+    val worker = Thread.currentThread() as? ParallelismCompensation
+        ?: return body()
+    worker.increaseParallelismAndLimit()
+    try {
+        return body()
+    } finally {
+        worker.decreaseParallelismLimit()
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/scheduling/RunBlockingCoroutineDispatcherTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/RunBlockingCoroutineDispatcherTest.kt
@@ -1,0 +1,59 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.*
+import org.junit.*
+import java.util.concurrent.atomic.*
+
+class RunBlockingCoroutineDispatcherTest : SchedulerTestBase() {
+    @Test
+    fun testRecursiveRunBlockingCanExceedDefaultDispatcherLimit() {
+        val maxDepth = CORES_COUNT * 3 + 3
+        fun body(depth: Int) {
+            if (depth == maxDepth) return
+            runBlocking(Dispatchers.Default) {
+                launch(Dispatchers.Default) {
+                    body(depth + 1)
+                }
+            }
+        }
+
+        body(1)
+        checkPoolThreadsCreated(maxDepth..maxDepth + 1)
+    }
+
+    @Test
+    fun testNoDefaultDispatcherStarvationWithRunBlocking() = testRunBlockingCanExceedDispatchersLimit(dispatcher, CORE_POOL_SIZE * 3 + 3)
+
+    @Test
+    fun testNoIoDispatcherStarvationWithRunBlocking() = testRunBlockingCanExceedDispatchersLimit(softBlockingDispatcher(2), 5)
+
+    private fun testRunBlockingCanExceedDispatchersLimit(targetDispatcher: CoroutineDispatcher, threadsToReach: Int) {
+        val barrier = CompletableDeferred<Unit>()
+        val count = AtomicInteger(0)
+        fun blockingCode() {
+            runBlocking {
+                count.incrementAndGet()
+                barrier.await()
+                count.decrementAndGet()
+            }
+        }
+        runBlocking {
+            repeat(threadsToReach) {
+                launch(targetDispatcher) {
+                    blockingCode()
+                }
+            }
+            while (count.get() != threadsToReach) {
+                Thread.sleep(1)
+            }
+            async(targetDispatcher) {
+                yield()
+                42
+            }.join()
+            barrier.complete(Unit)
+            while (count.get() != 0) {
+                Thread.sleep(1)
+            }
+        }
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/scheduling/RunBlockingCoroutineSchedulerLivenessStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/RunBlockingCoroutineSchedulerLivenessStressTest.kt
@@ -1,0 +1,83 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.internal.softLimitedParallelism
+import kotlinx.coroutines.testing.*
+import org.junit.*
+import org.junit.runner.*
+import org.junit.runners.*
+import java.util.*
+import java.util.concurrent.*
+
+@RunWith(Parameterized::class)
+class RunBlockingCoroutineSchedulerLivenessStressTest(private val yieldMask: Int) : SchedulerTestBase() {
+    init {
+        corePoolSize = 1
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Array<Array<Any?>> {
+            return Array(16 * stressTestMultiplierSqrt) { arrayOf(it) }
+        }
+    }
+
+    @Test
+    fun testLivenessOfDefaultDispatcher(): Unit = testSchedulerLiveness(dispatcher, yieldMask)
+
+    @Test
+    fun testLivenessOfIoDispatcher(): Unit = testSchedulerLiveness(softBlockingDispatcher(1), yieldMask)
+
+    @Test
+    fun testLivenessOfSoftLimitedDispatcherOnTopOfDefaultDispatcher() =
+        testSchedulerLiveness(dispatcher.softLimitedParallelism(1), yieldMask)
+
+    @Test
+    fun testLivenessOfSoftLimitedDispatcherOnTopOfIoDispatcher() = testSchedulerLiveness(
+        // Important: inner limitedDispatcher will be on top of this LimitedDispatcher, so there are two Workers from
+        // two different LimitedDispatchers that must coordinate their permits, not just one.
+        // In other words, LimitedDispatcher's Worker should also respect BlockingDispatchAware on its inner tasks
+        softBlockingDispatcher.value.softLimitedParallelism(1), yieldMask
+    )
+
+    private fun testSchedulerLiveness(targetDispatcher: CoroutineDispatcher, yieldMask: Int = 0b1111): Unit = runBlocking {
+        val oldRunBlockings = LinkedList<Job>()
+        var maxOldRunBlockings = 0
+        var busyWaits = 0
+        repeat(5000 * stressTestMultiplierSqrt) {
+            if (it % 1000 == 0) {
+                System.err.println("======== $it, rb=${oldRunBlockings.size}, max rb=${maxOldRunBlockings}, busy=$busyWaits")
+            }
+            val barrier = CyclicBarrier(2)
+            val barrier2 = CompletableDeferred<Unit>()
+            val blocking = launch(targetDispatcher) {
+                barrier.await()
+                runBlocking {
+                    if ((yieldMask and 1) != 0) yield()
+                    barrier2.await()
+                    if ((yieldMask and 2) != 0) yield()
+                }
+            }
+            oldRunBlockings.addLast(blocking)
+            val task = async(targetDispatcher) {
+                if ((yieldMask and 4) != 0) yield()
+                42.also {
+                    if ((yieldMask and 8) != 0) yield()
+                }
+            }
+            barrier.await()
+            task.join()
+            barrier2.complete(Unit)
+
+            oldRunBlockings.removeIf(Job::isCompleted)
+            while (oldRunBlockings.size > 5) {
+                busyWaits++
+                oldRunBlockings.removeIf(Job::isCompleted)
+            }
+            if (oldRunBlockings.size > maxOldRunBlockings) {
+                maxOldRunBlockings = oldRunBlockings.size
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up on #4084 and #3983 and an implementation of a different approach.

In #4084 the main idea was to try to preserve the parallelism by transferring the computational permits from `runBlocking` thread and then returning it back. It failed because there are scenarios when we should not let go the permit at all, otherwise we may introduce a deadlock.

In this solution we implement a parallelism compensation mechanism: the main difference with the previous patch is that now `runBlocking` does not release the computational permit and instead increases the allowed parallelism limit of the associated coroutine dispatcher _for the duration of the park()_ (i.e., while it has nothing to process). An important detail here is that while it is easy to increase the parallelism limit, it is difficult to decrease it back and at the same time make sure that the effective parallelism stays within the limit. In this solution we allow coroutine dispatchers to exceed the instantaneous parallelism limit with the property that they take care of _eventually_ adjusting the effective parallelism to fit to the limit. `runBlocking` basically can increase the parallelism limit, but it can only request to reduce the parallelism limit back.

It is easy to notice that parallelism compensation cannot be implemented for `LimitedDispatcher`, because it would break its contract on "hard" parallelism limit. So parallelism compensation is not a general property of coroutine dispatchers, but we can for sure implement it for `Dispatchers.Default` and `Dispatchers.IO`. As an alternative to `.limitedParallelism`, `.softLimitedParallelism` is introduced which supports parallelism compensation. 

Performance considerations:
* The intuition behind increasing the parallelism limit only for the duration of the `park()` is that while the thread of `runBlocking` is parked, it is not actually using its permit, meaning that its thread is not executing and is not taking up a CPU (of course, it is not exactly so, but should be close enough to reality). So with compensation, the "factual" parallelism is expected to be close to the target parallelism. 
* The implementation of "decompensation" in `CoroutineScheduler` works like this: the worker holding a CPU permit checks if it should let go the permit after it completes each CPU task. If there are pending requests for decompensation, it releases its permit. 
  The "hot path" for CPU workers now includes checking the `cpuDecompensationRequests` atomic, which is expected to have non-zero value rarely. It is expected to change rather infrequently and thus should have negligible impact on performance in "good" case when there are no `runBlocking`s running on dispatcher threads.
* There is also an optimisation for the "`runBlocking`-heavy" case: before increasing the parallelism limit it first checks if it can instead remove one decompensation request. If it succeeds, it means that some CPU worker would just continue to run instead of first releasing the permit and then reacquiring it back (not always exactly so, but it is a good example).
  It is not a goal though to make "`runBlocking`-heavy" case performant, if code for some reason ends up in such situation, it is kinda already can't be (the most) performant.

One of the potential issues I see with this approach is that the theoretically unlimited inflation of the coroutine scheduler thread pool caused by `runBlocking` (even if it happens only occasionally) may hit performance of CPU workers due to longer searches in task stealing.

I ran the existing benchmarks and didn't see anything suspicious in the results, but I'm not a jmh guru. Probably it requires some additional research.

The main development branch is [here](https://github.com/JetBrains/intellij-deps-kotlinx.coroutines/tree/intellij/vadim.salavatov/IJPL-721-runBlocking-without-starvation), this one I prepared specifically for MR. I don't expect this to be a real MR to be merged, rather just a reference implementation.