### PR TITLE
Preserve the relative order of delayed and non-delayed tasks in event loops

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/EventLoopsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/EventLoopsTest.kt
@@ -126,6 +126,21 @@ class EventLoopsTest : TestBase() {
         finish(4)
     }
 
+    /**
+     * Tests that, when delayed tasks are due on an event loop, they will execute earlier than the newly-scheduled
+     * non-delayed tasks.
+     */
+    @Test
+    fun testPendingDelayedBeingDueEarlier() = runTest {
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            delay(1)
+            expect(1)
+        }
+        Thread.sleep(100)
+        yield()
+        finish(2)
+    }
+
     class EventSync {
         private val waitingThread = atomic<Thread?>(null)
         private val fired = atomic(false)


### PR DESCRIPTION
Fixes #4134