### PR TITLE
Clarify documentation of `launchIn`

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/terminal/Collect.kt
+++ b/kotlinx-coroutines-core/common/src/flow/terminal/Collect.kt
@@ -40,7 +40,7 @@ public suspend fun Flow<*>.collect(): Unit = collect(NopCollector)
  *     .launchIn(uiScope)
  * ```
  *
- * Note that the resulting value of [launchIn] is not used and the provided scope takes care of cancellation.
+ * In this example, note that the `job` returned by [launchIn] is not used, and the provided scope takes care of cancellation.
  */
 public fun <T> Flow<T>.launchIn(scope: CoroutineScope): Job = scope.launch {
     collect() // tail-call


### PR DESCRIPTION
This line of the `launchIn` documentation is a bit confusing: I think it applies to all general usage of `launchIn`, which left me wondering why the returned `Job` is ignored. 

This is a really small tweak to make this clear. As an alternate, I think we can also just remove the line altogether and avoid any confusion. 

See also: https://kotlinlang.slack.com/archives/CRJCTR5PD/p1717093849474799