### PR TITLE
Turn off optimization mode when compiling tests for K/N

### DIFF
--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -95,13 +95,8 @@ kotlin {
      * All new MM targets are build with optimize = true to have stress tests properly run.
      */
     targets.withType(KotlinNativeTargetWithTests::class).configureEach {
-        binaries.getTest(DEBUG).apply {
-            optimized = true
-        }
-
         binaries.test("workerTest", listOf(DEBUG)) {
             val thisTest = this
-            optimized = true
             freeCompilerArgs = freeCompilerArgs + listOf("-e", "kotlinx.coroutines.mainBackground")
             testRuns.create("workerTest") {
                 this as KotlinTaskTestRun<*, *>

--- a/kotlinx-coroutines-test/build.gradle.kts
+++ b/kotlinx-coroutines-test/build.gradle.kts
@@ -2,12 +2,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
 
 kotlin {
-    targets.withType(KotlinNativeTargetWithTests::class.java).configureEach {
-        binaries.getTest("DEBUG").apply {
-            optimized = true
-        }
-    }
-
     sourceSets {
         jvmTest {
             dependencies {


### PR DESCRIPTION
Optimization was turned on due to performance problems. However, with new K/N memory manager these performance problems seem to be fixed. On the other hand, compiling in optimized mode significantly increases the compiler's memory consumption, so it's better to turn it off.
In particular, we (in K/N team) are having some problems with updating to LLVM 16 due to increased memory consumption (it's still being investigated what causes it), more details here: https://youtrack.jetbrains.com/issue/KT-68418/Native-updating-to-LLVM-16-makes-kotlinx.coroutines-build-in-Aggregate-unstable. This commit workarounds it.