### PR TITLE
Fix opt-in usage error shown in IntelliJ IDEA for some of the project files

### DIFF
--- a/buildSrc/src/main/kotlin/GlobalKotlinCompilerOptions.kt
+++ b/buildSrc/src/main/kotlin/GlobalKotlinCompilerOptions.kt
@@ -1,10 +1,9 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
 
 internal fun KotlinCommonCompilerOptions.configureGlobalKotlinArgumentsAndOptIns() {
-    freeCompilerArgs.addAll("-progressive", "-Xexpect-actual-classes")
+    freeCompilerArgs.addAll("-progressive")
     optIn.addAll(
         "kotlin.experimental.ExperimentalTypeInference",
-        "kotlin.ExperimentalMultiplatform",
         // our own opt-ins that we don't want to bother with in our own code:
         "kotlinx.coroutines.DelicateCoroutinesApi",
         "kotlinx.coroutines.ExperimentalCoroutinesApi",

--- a/buildSrc/src/main/kotlin/GlobalKotlinCompilerOptions.kt
+++ b/buildSrc/src/main/kotlin/GlobalKotlinCompilerOptions.kt
@@ -1,0 +1,15 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+
+internal fun KotlinCommonCompilerOptions.configureGlobalKotlinArgumentsAndOptIns() {
+    freeCompilerArgs.addAll("-progressive", "-Xexpect-actual-classes")
+    optIn.addAll(
+        "kotlin.experimental.ExperimentalTypeInference",
+        "kotlin.ExperimentalMultiplatform",
+        // our own opt-ins that we don't want to bother with in our own code:
+        "kotlinx.coroutines.DelicateCoroutinesApi",
+        "kotlinx.coroutines.ExperimentalCoroutinesApi",
+        "kotlinx.coroutines.ObsoleteCoroutinesApi",
+        "kotlinx.coroutines.InternalCoroutinesApi",
+        "kotlinx.coroutines.FlowPreview"
+    )
+}

--- a/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
@@ -1,7 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.*
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.*
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 configure(subprojects) {
     val project = this
@@ -39,17 +36,7 @@ configure(subprojects) {
                     "kotlin.experimental.ExperimentalNativeApi",
                 )
             }
-            freeCompilerArgs.addAll("-progressive", "-Xexpect-actual-classes")
-            optIn.addAll(
-                "kotlin.experimental.ExperimentalTypeInference",
-                "kotlin.ExperimentalMultiplatform",
-                // our own opt-ins that we don't want to bother with in our own code:
-                "kotlinx.coroutines.DelicateCoroutinesApi",
-                "kotlinx.coroutines.ExperimentalCoroutinesApi",
-                "kotlinx.coroutines.ObsoleteCoroutinesApi",
-                "kotlinx.coroutines.InternalCoroutinesApi",
-                "kotlinx.coroutines.FlowPreview"
-            )
+            configureGlobalKotlinArgumentsAndOptIns()
         }
 
     }

--- a/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/configure-compilation-conventions.gradle.kts
@@ -36,7 +36,6 @@ configure(subprojects) {
                     "kotlin.experimental.ExperimentalNativeApi",
                 )
             }
-            configureGlobalKotlinArgumentsAndOptIns()
         }
 
     }

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -15,6 +15,7 @@ java {
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_1_8
+        configureGlobalKotlinArgumentsAndOptIns()
     }
     jvmToolchain(jdkToolchainVersion)
 }

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -127,6 +127,8 @@ kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
         configureGlobalKotlinArgumentsAndOptIns()
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+        optIn.add("kotlin.ExperimentalMultiplatform")
     }
 }
 

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -123,6 +123,11 @@ kotlin {
         groupSourceSets("jsAndWasmJsShared", listOf("js", "wasmJs"), emptyList())
         groupSourceSets("jsAndWasmShared", listOf("jsAndWasmJsShared", "wasmWasi"), listOf("common"))
     }
+
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        configureGlobalKotlinArgumentsAndOptIns()
+    }
 }
 
 // Disable intermediate sourceSet compilation because we do not need js-wasm common artifact


### PR DESCRIPTION
Problem:
IntelliJ IDEA reports opt-in usage errors despite the fact that opt-ins are configured for all the compilations correctly. The reported error doesn't result in broken compilations or tests.

Motivation for the change:
The problem is not caused by the K2 IDE analysis mode, but it affects the K2 IDE quality gates.
See: https://youtrack.jetbrains.com/issue/KT-68642

Explanation:
Before the release of KGP 2.0.0 there was no clear way to set up compiler arguments for particular Kotlin multiplatform source sets: ones that participate in multiple compilations but are not a default source set for any compilation. Examples of such source sets are shared test source sets (they are not compiled into Kotlin metadata) and the unique `jdk8` source set used in `kotlinx-coroutines`. The 2.0.0 release provided a way to set up defaults for all multiplatform source sets in the whole Gradle project. They do behave as defaults and can still be overwritten by compilations.

Solution:
Use the new (experimental) Kotlin Gradle Plugin DSL to set up default compiler arguments and opt-ins for all multiplatform source sets. To keep arguments consistent between source sets and compilations, they have been extracted and shared between the multiplatform convention plugin and the compilation convention plugin.