### PR TITLE
Depend on the stdlib's probeCoroutineResumed in ProbesSupport instead…

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/ProbesSupport.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ProbesSupport.kt
@@ -8,5 +8,5 @@ internal actual inline fun <T> probeCoroutineCreated(completion: Continuation<T>
     kotlin.coroutines.jvm.internal.probeCoroutineCreated(completion)
 
 internal actual inline fun <T> probeCoroutineResumed(completion: Continuation<T>) {
-    kotlinx.coroutines.debug.internal.probeCoroutineResumed(completion)
+    kotlin.coroutines.jvm.internal.probeCoroutineResumed(completion)
 }


### PR DESCRIPTION
… of the unconditional reference of 'kotlinx.coroutines.debug.internal'

Was accidentally introduced in #4058

Fixes #4152