### PR TITLE
Fix links to external documentation in Timeout

### DIFF
--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -27,7 +27,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * even right before the return from inside the timeout [block]. Keep this in mind if you open or acquire some
  * resource inside the [block] that needs closing or release outside the block.
  * See the
- * [Asynchronous timeout and resources][https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources]
+ * [Asynchronous timeout and resources](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources)
  * section of the coroutines guide for details.
  *
  * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].
@@ -59,7 +59,7 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  * even right before the return from inside the timeout [block]. Keep this in mind if you open or acquire some
  * resource inside the [block] that needs closing or release outside the block.
  * See the
- * [Asynchronous timeout and resources][https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources]
+ * [Asynchronous timeout and resources](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources)
  * section of the coroutines guide for details.
  *
  * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].
@@ -86,7 +86,7 @@ public suspend fun <T> withTimeout(timeout: Duration, block: suspend CoroutineSc
  * even right before the return from inside the timeout [block]. Keep this in mind if you open or acquire some
  * resource inside the [block] that needs closing or release outside the block.
  * See the
- * [Asynchronous timeout and resources][https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources]
+ * [Asynchronous timeout and resources](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources)
  * section of the coroutines guide for details.
  *
  * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].
@@ -127,7 +127,7 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
  * even right before the return from inside the timeout [block]. Keep this in mind if you open or acquire some
  * resource inside the [block] that needs closing or release outside the block.
  * See the
- * [Asynchronous timeout and resources][https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources]
+ * [Asynchronous timeout and resources](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#asynchronous-timeout-and-resources)
  * section of the coroutines guide for details.
  *
  * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].


### PR DESCRIPTION
Currently, it ends up rendering wrong in the [API reference](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout.html).

![image](https://github.com/Kotlin/kotlinx.coroutines/assets/998408/b17ad41b-a686-4df3-85ab-73d6f29fbd02)
