### PR TITLE
Fix documentation of runBlocking

### DIFF
--- a/kotlinx-coroutines-core/native/src/Builders.kt
+++ b/kotlinx-coroutines-core/native/src/Builders.kt
@@ -7,7 +7,7 @@ import kotlin.coroutines.*
 import kotlin.native.concurrent.*
 
 /**
- * Runs new coroutine and **blocks** current thread _interruptibly_ until its completion.
+ * Runs a new coroutine and **blocks** the current thread _interruptibly_ until its completion.
  *
  * It is designed to bridge regular blocking code to libraries that are written in suspending style, to be used in
  * `main` functions and in tests.
@@ -25,21 +25,21 @@ import kotlin.native.concurrent.*
  * Here, instead of releasing the thread on which `loadConfiguration` runs if `fetchConfigurationData` suspends, it will
  * block, potentially leading to thread starvation issues.
  *
- * The default [CoroutineDispatcher] for this builder in an implementation of [EventLoop] that processes continuations
+ * The default [CoroutineDispatcher] for this builder is an internal implementation of event loop that processes continuations
  * in this blocked thread until the completion of this coroutine.
  * See [CoroutineDispatcher] for the other implementations that are provided by `kotlinx.coroutines`.
  *
  * When [CoroutineDispatcher] is explicitly specified in the [context], then the new coroutine runs in the context of
- * the specified dispatcher while the current thread is blocked. If the specified dispatcher implements [EventLoop]
- * interface and this `runBlocking` invocation is performed from inside of the this event loop's thread, then
- * this event loop is processed using its [processNextEvent][EventLoop.processNextEvent] method until coroutine completes.
+ * the specified dispatcher while the current thread is blocked. If the specified dispatcher is an event loop of another `runBlocking`,
+ * then this invocation uses the outer event loop.
  *
  * If this blocked thread is interrupted (see [Thread.interrupt]), then the coroutine job is cancelled and
  * this `runBlocking` invocation throws [InterruptedException].
  *
- * See [newCoroutineContext] for a description of debugging facilities that are available for newly created coroutine.
+ * See [newCoroutineContext][CoroutineScope.newCoroutineContext] for a description of debugging facilities that are available
+ * for a newly created coroutine.
  *
- * @param context context of the coroutine. The default value is an implementation of [EventLoop].
+ * @param context the context of the coroutine. The default value is an event loop on the current thread.
  * @param block the coroutine code.
  */
 public actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {


### PR DESCRIPTION
kotlinx-coroutines-core/jvm/src/Builders.kt documentation looked rather strange and had incorrect grammar, replaced with kotlinx-coroutines-core/native/src/Builders.kt documentation for runBlocking.

This should be correct. If I have made a mistake, I apologize in advance.