### PR TITLE
Fix too many `the` and `it` on some comments

### DIFF
--- a/docs/topics/channels.md
+++ b/docs/topics/channels.md
@@ -364,7 +364,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 >
 {type="note"}
 
-The output will be similar to the the following one, albeit the processor ids that receive
+The output will be similar to the following one, albeit the processor ids that receive
 each specific integer may be different:
 
 ```text

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -90,7 +90,7 @@ public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = noImpl()
  *        }
  * }
  * ```
- * Opposed to subscribeOn, it it **possible** to use multiple `flowOn` operators in the one flow
+ * Opposed to subscribeOn, it **possible** to use multiple `flowOn` operators in the one flow
  * @suppress
  */
 @Deprecated(message = "Use 'flowOn' instead", level = DeprecationLevel.ERROR)

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -90,7 +90,7 @@ public fun <T> Flow<T>.publishOn(context: CoroutineContext): Flow<T> = noImpl()
  *        }
  * }
  * ```
- * Opposed to subscribeOn, it **possible** to use multiple `flowOn` operators in the one flow
+ * Opposed to subscribeOn, it is **possible** to use multiple `flowOn` operators in the one flow
  * @suppress
  */
 @Deprecated(message = "Use 'flowOn' instead", level = DeprecationLevel.ERROR)

--- a/kotlinx-coroutines-core/common/src/flow/operators/Limit.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Limit.kt
@@ -123,7 +123,7 @@ internal suspend inline fun <T> Flow<T>.collectWhile(crossinline predicate: susp
     val collector = object : FlowCollector<T> {
         override suspend fun emit(value: T) {
             // Note: we are checking predicate first, then throw. If the predicate does suspend (calls emit, for example)
-            // the the resulting code is never tail-suspending and produces a state-machine
+            // the resulting code is never tail-suspending and produces a state-machine
             if (!predicate(value)) {
                 throw AbortFlowException(this)
             }


### PR DESCRIPTION
I think that the double use of `the` and `it` in this part in English is grammatically incorrect, except for the intentional emphasis.  
And, it doesn't seems to be something that needed to be emphasized.
So, I didn't think it was an intentional mistake, so I fixed it.