### PR TITLE
Remove redundant `html_version` gradle property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ atomicfu_version=0.25.0
 junit_version=4.12
 junit5_version=5.7.0
 knit_version=0.5.0
-html_version=0.7.2
 lincheck_version=2.18.1
 dokka_version=1.9.20
 byte_buddy_version=1.10.9


### PR DESCRIPTION
Looks like property for [kotlinx.html](https://github.com/Kotlin/kotlinx.html), which isn't used in project