### PR TITLE
Rerun apiDump

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
@@ -7,101 +7,121 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.kotlinx:kotlinx-coroutines-core>
-abstract class <#A: in kotlin/Any?> kotlinx.coroutines/AbstractCoroutine : kotlin.coroutines/Continuation<#A>, kotlinx.coroutines/CoroutineScope, kotlinx.coroutines/Job, kotlinx.coroutines/JobSupport { // kotlinx.coroutines/AbstractCoroutine|null[0]
-    constructor <init>(kotlin.coroutines/CoroutineContext, kotlin/Boolean, kotlin/Boolean) // kotlinx.coroutines/AbstractCoroutine.<init>|<init>(kotlin.coroutines.CoroutineContext;kotlin.Boolean;kotlin.Boolean){}[0]
-    final fun <#A1: kotlin/Any?> start(kotlinx.coroutines/CoroutineStart, #A1, kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines/AbstractCoroutine.start|start(kotlinx.coroutines.CoroutineStart;0:0;kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
-    final fun onCompletionInternal(kotlin/Any?) // kotlinx.coroutines/AbstractCoroutine.onCompletionInternal|onCompletionInternal(kotlin.Any?){}[0]
-    final fun resumeWith(kotlin/Result<#A>) // kotlinx.coroutines/AbstractCoroutine.resumeWith|resumeWith(kotlin.Result<1:0>){}[0]
-    final val context // kotlinx.coroutines/AbstractCoroutine.context|{}context[0]
-        final fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/AbstractCoroutine.context.<get-context>|<get-context>(){}[0]
-    open fun afterResume(kotlin/Any?) // kotlinx.coroutines/AbstractCoroutine.afterResume|afterResume(kotlin.Any?){}[0]
-    open fun cancellationExceptionMessage(): kotlin/String // kotlinx.coroutines/AbstractCoroutine.cancellationExceptionMessage|cancellationExceptionMessage(){}[0]
-    open fun onCancelled(kotlin/Throwable, kotlin/Boolean) // kotlinx.coroutines/AbstractCoroutine.onCancelled|onCancelled(kotlin.Throwable;kotlin.Boolean){}[0]
-    open fun onCompleted(#A) // kotlinx.coroutines/AbstractCoroutine.onCompleted|onCompleted(1:0){}[0]
-    open val coroutineContext // kotlinx.coroutines/AbstractCoroutine.coroutineContext|{}coroutineContext[0]
-        open fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/AbstractCoroutine.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
-    open val isActive // kotlinx.coroutines/AbstractCoroutine.isActive|{}isActive[0]
-        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/AbstractCoroutine.isActive.<get-isActive>|<get-isActive>(){}[0]
+open annotation class kotlinx.coroutines/DelicateCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/DelicateCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/DelicateCoroutinesApi.<init>|<init>(){}[0]
 }
-abstract class <#A: kotlin/Any?> kotlinx.coroutines.flow.internal/ChannelFlow : kotlinx.coroutines.flow.internal/FusibleFlow<#A> { // kotlinx.coroutines.flow.internal/ChannelFlow|null[0]
-    abstract fun create(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow): kotlinx.coroutines.flow.internal/ChannelFlow<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.create|create(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
-    abstract suspend fun collectTo(kotlinx.coroutines.channels/ProducerScope<#A>) // kotlinx.coroutines.flow.internal/ChannelFlow.collectTo|collectTo(kotlinx.coroutines.channels.ProducerScope<1:0>){}[0]
-    constructor <init>(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow) // kotlinx.coroutines.flow.internal/ChannelFlow.<init>|<init>(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
-    final val capacity // kotlinx.coroutines.flow.internal/ChannelFlow.capacity|{}capacity[0]
-        final fun <get-capacity>(): kotlin/Int // kotlinx.coroutines.flow.internal/ChannelFlow.capacity.<get-capacity>|<get-capacity>(){}[0]
-    final val context // kotlinx.coroutines.flow.internal/ChannelFlow.context|{}context[0]
-        final fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.flow.internal/ChannelFlow.context.<get-context>|<get-context>(){}[0]
-    final val onBufferOverflow // kotlinx.coroutines.flow.internal/ChannelFlow.onBufferOverflow|{}onBufferOverflow[0]
-        final fun <get-onBufferOverflow>(): kotlinx.coroutines.channels/BufferOverflow // kotlinx.coroutines.flow.internal/ChannelFlow.onBufferOverflow.<get-onBufferOverflow>|<get-onBufferOverflow>(){}[0]
-    open fun additionalToStringProps(): kotlin/String? // kotlinx.coroutines.flow.internal/ChannelFlow.additionalToStringProps|additionalToStringProps(){}[0]
-    open fun dropChannelOperators(): kotlinx.coroutines.flow/Flow<#A>? // kotlinx.coroutines.flow.internal/ChannelFlow.dropChannelOperators|dropChannelOperators(){}[0]
-    open fun fuse(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow): kotlinx.coroutines.flow/Flow<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.fuse|fuse(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
-    open fun produceImpl(kotlinx.coroutines/CoroutineScope): kotlinx.coroutines.channels/ReceiveChannel<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.produceImpl|produceImpl(kotlinx.coroutines.CoroutineScope){}[0]
-    open fun toString(): kotlin/String // kotlinx.coroutines.flow.internal/ChannelFlow.toString|toString(){}[0]
-    open suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow.internal/ChannelFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+
+open annotation class kotlinx.coroutines/ExperimentalCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ExperimentalCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/ExperimentalCoroutinesApi.<init>|<init>(){}[0]
 }
-abstract class <#A: kotlin/Any?> kotlinx.coroutines.flow/AbstractFlow : kotlinx.coroutines.flow/CancellableFlow<#A>, kotlinx.coroutines.flow/Flow<#A> { // kotlinx.coroutines.flow/AbstractFlow|null[0]
-    abstract suspend fun collectSafely(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/AbstractFlow.collectSafely|collectSafely(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
-    constructor <init>() // kotlinx.coroutines.flow/AbstractFlow.<init>|<init>(){}[0]
-    final suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/AbstractFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+
+open annotation class kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi.<init>|<init>(){}[0]
 }
-abstract class kotlinx.coroutines/CloseableCoroutineDispatcher : kotlin/AutoCloseable, kotlinx.coroutines/CoroutineDispatcher { // kotlinx.coroutines/CloseableCoroutineDispatcher|null[0]
-    abstract fun close() // kotlinx.coroutines/CloseableCoroutineDispatcher.close|close(){}[0]
-    constructor <init>() // kotlinx.coroutines/CloseableCoroutineDispatcher.<init>|<init>(){}[0]
+
+open annotation class kotlinx.coroutines/FlowPreview : kotlin/Annotation { // kotlinx.coroutines/FlowPreview|null[0]
+    constructor <init>() // kotlinx.coroutines/FlowPreview.<init>|<init>(){}[0]
 }
-abstract class kotlinx.coroutines/CoroutineDispatcher : kotlin.coroutines/AbstractCoroutineContextElement, kotlin.coroutines/ContinuationInterceptor { // kotlinx.coroutines/CoroutineDispatcher|null[0]
-    abstract fun dispatch(kotlin.coroutines/CoroutineContext, kotlinx.coroutines/Runnable) // kotlinx.coroutines/CoroutineDispatcher.dispatch|dispatch(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.Runnable){}[0]
-    constructor <init>() // kotlinx.coroutines/CoroutineDispatcher.<init>|<init>(){}[0]
-    final fun <#A1: kotlin/Any?> interceptContinuation(kotlin.coroutines/Continuation<#A1>): kotlin.coroutines/Continuation<#A1> // kotlinx.coroutines/CoroutineDispatcher.interceptContinuation|interceptContinuation(kotlin.coroutines.Continuation<0:0>){0§<kotlin.Any?>}[0]
-    final fun plus(kotlinx.coroutines/CoroutineDispatcher): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.plus|plus(kotlinx.coroutines.CoroutineDispatcher){}[0]
-    final fun releaseInterceptedContinuation(kotlin.coroutines/Continuation<*>) // kotlinx.coroutines/CoroutineDispatcher.releaseInterceptedContinuation|releaseInterceptedContinuation(kotlin.coroutines.Continuation<*>){}[0]
-    final object Key : kotlin.coroutines/AbstractCoroutineContextKey<kotlin.coroutines/ContinuationInterceptor, kotlinx.coroutines/CoroutineDispatcher> // kotlinx.coroutines/CoroutineDispatcher.Key|null[0]
-    open fun dispatchYield(kotlin.coroutines/CoroutineContext, kotlinx.coroutines/Runnable) // kotlinx.coroutines/CoroutineDispatcher.dispatchYield|dispatchYield(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.Runnable){}[0]
-    open fun isDispatchNeeded(kotlin.coroutines/CoroutineContext): kotlin/Boolean // kotlinx.coroutines/CoroutineDispatcher.isDispatchNeeded|isDispatchNeeded(kotlin.coroutines.CoroutineContext){}[0]
-    open fun limitedParallelism(kotlin/Int): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int){}[0]
-    open fun limitedParallelism(kotlin/Int, kotlin/String? = ...): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int;kotlin.String?){}[0]
-    open fun toString(): kotlin/String // kotlinx.coroutines/CoroutineDispatcher.toString|toString(){}[0]
+
+open annotation class kotlinx.coroutines/InternalCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/InternalCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/InternalCoroutinesApi.<init>|<init>(){}[0]
 }
-abstract class kotlinx.coroutines/MainCoroutineDispatcher : kotlinx.coroutines/CoroutineDispatcher { // kotlinx.coroutines/MainCoroutineDispatcher|null[0]
-    abstract val immediate // kotlinx.coroutines/MainCoroutineDispatcher.immediate|{}immediate[0]
-        abstract fun <get-immediate>(): kotlinx.coroutines/MainCoroutineDispatcher // kotlinx.coroutines/MainCoroutineDispatcher.immediate.<get-immediate>|<get-immediate>(){}[0]
-    constructor <init>() // kotlinx.coroutines/MainCoroutineDispatcher.<init>|<init>(){}[0]
-    final fun toStringInternalImpl(): kotlin/String? // kotlinx.coroutines/MainCoroutineDispatcher.toStringInternalImpl|toStringInternalImpl(){}[0]
-    open fun limitedParallelism(kotlin/Int, kotlin/String?): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/MainCoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int;kotlin.String?){}[0]
-    open fun toString(): kotlin/String // kotlinx.coroutines/MainCoroutineDispatcher.toString|toString(){}[0]
+
+open annotation class kotlinx.coroutines/InternalForInheritanceCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/InternalForInheritanceCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/InternalForInheritanceCoroutinesApi.<init>|<init>(){}[0]
 }
+
+open annotation class kotlinx.coroutines/ObsoleteCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ObsoleteCoroutinesApi|null[0]
+    constructor <init>() // kotlinx.coroutines/ObsoleteCoroutinesApi.<init>|<init>(){}[0]
+}
+
+final enum class kotlinx.coroutines.channels/BufferOverflow : kotlin/Enum<kotlinx.coroutines.channels/BufferOverflow> { // kotlinx.coroutines.channels/BufferOverflow|null[0]
+    enum entry DROP_LATEST // kotlinx.coroutines.channels/BufferOverflow.DROP_LATEST|null[0]
+    enum entry DROP_OLDEST // kotlinx.coroutines.channels/BufferOverflow.DROP_OLDEST|null[0]
+    enum entry SUSPEND // kotlinx.coroutines.channels/BufferOverflow.SUSPEND|null[0]
+
+    final val entries // kotlinx.coroutines.channels/BufferOverflow.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines.channels/BufferOverflow> // kotlinx.coroutines.channels/BufferOverflow.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): kotlinx.coroutines.channels/BufferOverflow // kotlinx.coroutines.channels/BufferOverflow.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.coroutines.channels/BufferOverflow> // kotlinx.coroutines.channels/BufferOverflow.values|values#static(){}[0]
+}
+
+final enum class kotlinx.coroutines.flow/SharingCommand : kotlin/Enum<kotlinx.coroutines.flow/SharingCommand> { // kotlinx.coroutines.flow/SharingCommand|null[0]
+    enum entry START // kotlinx.coroutines.flow/SharingCommand.START|null[0]
+    enum entry STOP // kotlinx.coroutines.flow/SharingCommand.STOP|null[0]
+    enum entry STOP_AND_RESET_REPLAY_CACHE // kotlinx.coroutines.flow/SharingCommand.STOP_AND_RESET_REPLAY_CACHE|null[0]
+
+    final val entries // kotlinx.coroutines.flow/SharingCommand.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines.flow/SharingCommand> // kotlinx.coroutines.flow/SharingCommand.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): kotlinx.coroutines.flow/SharingCommand // kotlinx.coroutines.flow/SharingCommand.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.coroutines.flow/SharingCommand> // kotlinx.coroutines.flow/SharingCommand.values|values#static(){}[0]
+}
+
+final enum class kotlinx.coroutines/CoroutineStart : kotlin/Enum<kotlinx.coroutines/CoroutineStart> { // kotlinx.coroutines/CoroutineStart|null[0]
+    enum entry ATOMIC // kotlinx.coroutines/CoroutineStart.ATOMIC|null[0]
+    enum entry DEFAULT // kotlinx.coroutines/CoroutineStart.DEFAULT|null[0]
+    enum entry LAZY // kotlinx.coroutines/CoroutineStart.LAZY|null[0]
+    enum entry UNDISPATCHED // kotlinx.coroutines/CoroutineStart.UNDISPATCHED|null[0]
+
+    final val entries // kotlinx.coroutines/CoroutineStart.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines/CoroutineStart> // kotlinx.coroutines/CoroutineStart.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val isLazy // kotlinx.coroutines/CoroutineStart.isLazy|{}isLazy[0]
+        final fun <get-isLazy>(): kotlin/Boolean // kotlinx.coroutines/CoroutineStart.isLazy.<get-isLazy>|<get-isLazy>(){}[0]
+
+    final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> invoke(kotlin.coroutines/SuspendFunction1<#A1, #B1>, #A1, kotlin.coroutines/Continuation<#B1>) // kotlinx.coroutines/CoroutineStart.invoke|invoke(kotlin.coroutines.SuspendFunction1<0:0,0:1>;0:0;kotlin.coroutines.Continuation<0:1>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+    final fun valueOf(kotlin/String): kotlinx.coroutines/CoroutineStart // kotlinx.coroutines/CoroutineStart.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.coroutines/CoroutineStart> // kotlinx.coroutines/CoroutineStart.values|values#static(){}[0]
+}
+
 abstract fun interface <#A: in kotlin/Any?> kotlinx.coroutines.flow/FlowCollector { // kotlinx.coroutines.flow/FlowCollector|null[0]
     abstract suspend fun emit(#A) // kotlinx.coroutines.flow/FlowCollector.emit|emit(1:0){}[0]
 }
+
 abstract fun interface kotlinx.coroutines.flow/SharingStarted { // kotlinx.coroutines.flow/SharingStarted|null[0]
     abstract fun command(kotlinx.coroutines.flow/StateFlow<kotlin/Int>): kotlinx.coroutines.flow/Flow<kotlinx.coroutines.flow/SharingCommand> // kotlinx.coroutines.flow/SharingStarted.command|command(kotlinx.coroutines.flow.StateFlow<kotlin.Int>){}[0]
+
     final object Companion { // kotlinx.coroutines.flow/SharingStarted.Companion|null[0]
-        final fun WhileSubscribed(kotlin/Long = ..., kotlin/Long = ...): kotlinx.coroutines.flow/SharingStarted // kotlinx.coroutines.flow/SharingStarted.Companion.WhileSubscribed|WhileSubscribed(kotlin.Long;kotlin.Long){}[0]
         final val Eagerly // kotlinx.coroutines.flow/SharingStarted.Companion.Eagerly|{}Eagerly[0]
             final fun <get-Eagerly>(): kotlinx.coroutines.flow/SharingStarted // kotlinx.coroutines.flow/SharingStarted.Companion.Eagerly.<get-Eagerly>|<get-Eagerly>(){}[0]
         final val Lazily // kotlinx.coroutines.flow/SharingStarted.Companion.Lazily|{}Lazily[0]
             final fun <get-Lazily>(): kotlinx.coroutines.flow/SharingStarted // kotlinx.coroutines.flow/SharingStarted.Companion.Lazily.<get-Lazily>|<get-Lazily>(){}[0]
+
+        final fun WhileSubscribed(kotlin/Long = ..., kotlin/Long = ...): kotlinx.coroutines.flow/SharingStarted // kotlinx.coroutines.flow/SharingStarted.Companion.WhileSubscribed|WhileSubscribed(kotlin.Long;kotlin.Long){}[0]
     }
 }
+
 abstract fun interface kotlinx.coroutines/DisposableHandle { // kotlinx.coroutines/DisposableHandle|null[0]
     abstract fun dispose() // kotlinx.coroutines/DisposableHandle.dispose|dispose(){}[0]
 }
+
 abstract interface <#A: in kotlin/Any?> kotlinx.coroutines.channels/ProducerScope : kotlinx.coroutines.channels/SendChannel<#A>, kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines.channels/ProducerScope|null[0]
     abstract val channel // kotlinx.coroutines.channels/ProducerScope.channel|{}channel[0]
         abstract fun <get-channel>(): kotlinx.coroutines.channels/SendChannel<#A> // kotlinx.coroutines.channels/ProducerScope.channel.<get-channel>|<get-channel>(){}[0]
 }
+
 abstract interface <#A: in kotlin/Any?> kotlinx.coroutines.channels/SendChannel { // kotlinx.coroutines.channels/SendChannel|null[0]
-    abstract fun close(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/SendChannel.close|close(kotlin.Throwable?){}[0]
-    abstract fun invokeOnClose(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines.channels/SendChannel.invokeOnClose|invokeOnClose(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    abstract fun trySend(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/SendChannel.trySend|trySend(1:0){}[0]
-    abstract suspend fun send(#A) // kotlinx.coroutines.channels/SendChannel.send|send(1:0){}[0]
     abstract val isClosedForSend // kotlinx.coroutines.channels/SendChannel.isClosedForSend|{}isClosedForSend[0]
         abstract fun <get-isClosedForSend>(): kotlin/Boolean // kotlinx.coroutines.channels/SendChannel.isClosedForSend.<get-isClosedForSend>|<get-isClosedForSend>(){}[0]
     abstract val onSend // kotlinx.coroutines.channels/SendChannel.onSend|{}onSend[0]
         abstract fun <get-onSend>(): kotlinx.coroutines.selects/SelectClause2<#A, kotlinx.coroutines.channels/SendChannel<#A>> // kotlinx.coroutines.channels/SendChannel.onSend.<get-onSend>|<get-onSend>(){}[0]
+
+    abstract fun close(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/SendChannel.close|close(kotlin.Throwable?){}[0]
+    abstract fun invokeOnClose(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines.channels/SendChannel.invokeOnClose|invokeOnClose(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    abstract fun trySend(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/SendChannel.trySend|trySend(1:0){}[0]
+    abstract suspend fun send(#A) // kotlinx.coroutines.channels/SendChannel.send|send(1:0){}[0]
     open fun offer(#A): kotlin/Boolean // kotlinx.coroutines.channels/SendChannel.offer|offer(1:0){}[0]
 }
+
 abstract interface <#A: in kotlin/Any?> kotlinx.coroutines/CancellableContinuation : kotlin.coroutines/Continuation<#A> { // kotlinx.coroutines/CancellableContinuation|null[0]
+    abstract val isActive // kotlinx.coroutines/CancellableContinuation.isActive|{}isActive[0]
+        abstract fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isActive.<get-isActive>|<get-isActive>(){}[0]
+    abstract val isCancelled // kotlinx.coroutines/CancellableContinuation.isCancelled|{}isCancelled[0]
+        abstract fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
+    abstract val isCompleted // kotlinx.coroutines/CancellableContinuation.isCompleted|{}isCompleted[0]
+        abstract fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
+
     abstract fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatched(#A) // kotlinx.coroutines/CancellableContinuation.resumeUndispatched|resumeUndispatched@kotlinx.coroutines.CoroutineDispatcher(1:0){}[0]
     abstract fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatchedWithException(kotlin/Throwable) // kotlinx.coroutines/CancellableContinuation.resumeUndispatchedWithException|resumeUndispatchedWithException@kotlinx.coroutines.CoroutineDispatcher(kotlin.Throwable){}[0]
     abstract fun <#A1: #A> resume(#A1, kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuation.resume|resume(0:0;kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>?){0§<1:0>}[0]
@@ -113,18 +133,14 @@ abstract interface <#A: in kotlin/Any?> kotlinx.coroutines/CancellableContinuati
     abstract fun resume(#A, kotlin/Function1<kotlin/Throwable, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuation.resume|resume(1:0;kotlin.Function1<kotlin.Throwable,kotlin.Unit>?){}[0]
     abstract fun tryResume(#A, kotlin/Any? = ...): kotlin/Any? // kotlinx.coroutines/CancellableContinuation.tryResume|tryResume(1:0;kotlin.Any?){}[0]
     abstract fun tryResumeWithException(kotlin/Throwable): kotlin/Any? // kotlinx.coroutines/CancellableContinuation.tryResumeWithException|tryResumeWithException(kotlin.Throwable){}[0]
-    abstract val isActive // kotlinx.coroutines/CancellableContinuation.isActive|{}isActive[0]
-        abstract fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isActive.<get-isActive>|<get-isActive>(){}[0]
-    abstract val isCancelled // kotlinx.coroutines/CancellableContinuation.isCancelled|{}isCancelled[0]
-        abstract fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
-    abstract val isCompleted // kotlinx.coroutines/CancellableContinuation.isCompleted|{}isCompleted[0]
-        abstract fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuation.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines.channels/BroadcastChannel : kotlinx.coroutines.channels/SendChannel<#A> { // kotlinx.coroutines.channels/BroadcastChannel|null[0]
     abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/BroadcastChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
     abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/BroadcastChannel.cancel|cancel(kotlin.Throwable?){}[0]
     abstract fun openSubscription(): kotlinx.coroutines.channels/ReceiveChannel<#A> // kotlinx.coroutines.channels/BroadcastChannel.openSubscription|openSubscription(){}[0]
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines.channels/Channel : kotlinx.coroutines.channels/ReceiveChannel<#A>, kotlinx.coroutines.channels/SendChannel<#A> { // kotlinx.coroutines.channels/Channel|null[0]
     final object Factory { // kotlinx.coroutines.channels/Channel.Factory|null[0]
         final const val BUFFERED // kotlinx.coroutines.channels/Channel.Factory.BUFFERED|{}BUFFERED[0]
@@ -139,41 +155,44 @@ abstract interface <#A: kotlin/Any?> kotlinx.coroutines.channels/Channel : kotli
             final fun <get-UNLIMITED>(): kotlin/Int // kotlinx.coroutines.channels/Channel.Factory.UNLIMITED.<get-UNLIMITED>|<get-UNLIMITED>(){}[0]
     }
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines.flow.internal/FusibleFlow : kotlinx.coroutines.flow/Flow<#A> { // kotlinx.coroutines.flow.internal/FusibleFlow|null[0]
     abstract fun fuse(kotlin.coroutines/CoroutineContext = ..., kotlin/Int = ..., kotlinx.coroutines.channels/BufferOverflow = ...): kotlinx.coroutines.flow/Flow<#A> // kotlinx.coroutines.flow.internal/FusibleFlow.fuse|fuse(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines.flow/MutableSharedFlow : kotlinx.coroutines.flow/FlowCollector<#A>, kotlinx.coroutines.flow/SharedFlow<#A> { // kotlinx.coroutines.flow/MutableSharedFlow|null[0]
+    abstract val subscriptionCount // kotlinx.coroutines.flow/MutableSharedFlow.subscriptionCount|{}subscriptionCount[0]
+        abstract fun <get-subscriptionCount>(): kotlinx.coroutines.flow/StateFlow<kotlin/Int> // kotlinx.coroutines.flow/MutableSharedFlow.subscriptionCount.<get-subscriptionCount>|<get-subscriptionCount>(){}[0]
+
     abstract fun resetReplayCache() // kotlinx.coroutines.flow/MutableSharedFlow.resetReplayCache|resetReplayCache(){}[0]
     abstract fun tryEmit(#A): kotlin/Boolean // kotlinx.coroutines.flow/MutableSharedFlow.tryEmit|tryEmit(1:0){}[0]
     abstract suspend fun emit(#A) // kotlinx.coroutines.flow/MutableSharedFlow.emit|emit(1:0){}[0]
-    abstract val subscriptionCount // kotlinx.coroutines.flow/MutableSharedFlow.subscriptionCount|{}subscriptionCount[0]
-        abstract fun <get-subscriptionCount>(): kotlinx.coroutines.flow/StateFlow<kotlin/Int> // kotlinx.coroutines.flow/MutableSharedFlow.subscriptionCount.<get-subscriptionCount>|<get-subscriptionCount>(){}[0]
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines.flow/MutableStateFlow : kotlinx.coroutines.flow/MutableSharedFlow<#A>, kotlinx.coroutines.flow/StateFlow<#A> { // kotlinx.coroutines.flow/MutableStateFlow|null[0]
-    abstract fun compareAndSet(#A, #A): kotlin/Boolean // kotlinx.coroutines.flow/MutableStateFlow.compareAndSet|compareAndSet(1:0;1:0){}[0]
     abstract var value // kotlinx.coroutines.flow/MutableStateFlow.value|{}value[0]
         abstract fun <get-value>(): #A // kotlinx.coroutines.flow/MutableStateFlow.value.<get-value>|<get-value>(){}[0]
         abstract fun <set-value>(#A) // kotlinx.coroutines.flow/MutableStateFlow.value.<set-value>|<set-value>(1:0){}[0]
+
+    abstract fun compareAndSet(#A, #A): kotlin/Boolean // kotlinx.coroutines.flow/MutableStateFlow.compareAndSet|compareAndSet(1:0;1:0){}[0]
 }
+
 abstract interface <#A: kotlin/Any?> kotlinx.coroutines/CompletableDeferred : kotlinx.coroutines/Deferred<#A> { // kotlinx.coroutines/CompletableDeferred|null[0]
     abstract fun complete(#A): kotlin/Boolean // kotlinx.coroutines/CompletableDeferred.complete|complete(1:0){}[0]
     abstract fun completeExceptionally(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/CompletableDeferred.completeExceptionally|completeExceptionally(kotlin.Throwable){}[0]
 }
+
 abstract interface <#A: kotlin/Throwable & kotlinx.coroutines/CopyableThrowable<#A>> kotlinx.coroutines/CopyableThrowable { // kotlinx.coroutines/CopyableThrowable|null[0]
     abstract fun createCopy(): #A? // kotlinx.coroutines/CopyableThrowable.createCopy|createCopy(){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ChannelIterator { // kotlinx.coroutines.channels/ChannelIterator|null[0]
     abstract fun next(): #A // kotlinx.coroutines.channels/ChannelIterator.next|next(){}[0]
     abstract suspend fun hasNext(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelIterator.hasNext|hasNext(){}[0]
     open suspend fun next0(): #A // kotlinx.coroutines.channels/ChannelIterator.next0|next0(){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ReceiveChannel { // kotlinx.coroutines.channels/ReceiveChannel|null[0]
-    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.Throwable?){}[0]
-    abstract fun iterator(): kotlinx.coroutines.channels/ChannelIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.iterator|iterator(){}[0]
-    abstract fun tryReceive(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.tryReceive|tryReceive(){}[0]
-    abstract suspend fun receive(): #A // kotlinx.coroutines.channels/ReceiveChannel.receive|receive(){}[0]
-    abstract suspend fun receiveCatching(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.receiveCatching|receiveCatching(){}[0]
     abstract val isClosedForReceive // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive|{}isClosedForReceive[0]
         abstract fun <get-isClosedForReceive>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive.<get-isClosedForReceive>|<get-isClosedForReceive>(){}[0]
     abstract val isEmpty // kotlinx.coroutines.channels/ReceiveChannel.isEmpty|{}isEmpty[0]
@@ -182,82 +201,100 @@ abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ReceiveChan
         abstract fun <get-onReceive>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines.channels/ReceiveChannel.onReceive.<get-onReceive>|<get-onReceive>(){}[0]
     abstract val onReceiveCatching // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching|{}onReceiveCatching[0]
         abstract fun <get-onReceiveCatching>(): kotlinx.coroutines.selects/SelectClause1<kotlinx.coroutines.channels/ChannelResult<#A>> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching.<get-onReceiveCatching>|<get-onReceiveCatching>(){}[0]
+    open val onReceiveOrNull // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull|{}onReceiveOrNull[0]
+        open fun <get-onReceiveOrNull>(): kotlinx.coroutines.selects/SelectClause1<#A?> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull.<get-onReceiveOrNull>|<get-onReceiveOrNull>(){}[0]
+
+    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.Throwable?){}[0]
+    abstract fun iterator(): kotlinx.coroutines.channels/ChannelIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.iterator|iterator(){}[0]
+    abstract fun tryReceive(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.tryReceive|tryReceive(){}[0]
+    abstract suspend fun receive(): #A // kotlinx.coroutines.channels/ReceiveChannel.receive|receive(){}[0]
+    abstract suspend fun receiveCatching(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.receiveCatching|receiveCatching(){}[0]
     open fun cancel() // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(){}[0]
     open fun poll(): #A? // kotlinx.coroutines.channels/ReceiveChannel.poll|poll(){}[0]
     open suspend fun receiveOrNull(): #A? // kotlinx.coroutines.channels/ReceiveChannel.receiveOrNull|receiveOrNull(){}[0]
-    open val onReceiveOrNull // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull|{}onReceiveOrNull[0]
-        open fun <get-onReceiveOrNull>(): kotlinx.coroutines.selects/SelectClause1<#A?> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull.<get-onReceiveOrNull>|<get-onReceiveOrNull>(){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.flow/Flow { // kotlinx.coroutines.flow/Flow|null[0]
     abstract suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/Flow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.flow/SharedFlow : kotlinx.coroutines.flow/Flow<#A> { // kotlinx.coroutines.flow/SharedFlow|null[0]
-    abstract suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>): kotlin/Nothing // kotlinx.coroutines.flow/SharedFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
     abstract val replayCache // kotlinx.coroutines.flow/SharedFlow.replayCache|{}replayCache[0]
         abstract fun <get-replayCache>(): kotlin.collections/List<#A> // kotlinx.coroutines.flow/SharedFlow.replayCache.<get-replayCache>|<get-replayCache>(){}[0]
+
+    abstract suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>): kotlin/Nothing // kotlinx.coroutines.flow/SharedFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.flow/StateFlow : kotlinx.coroutines.flow/SharedFlow<#A> { // kotlinx.coroutines.flow/StateFlow|null[0]
     abstract val value // kotlinx.coroutines.flow/StateFlow.value|{}value[0]
         abstract fun <get-value>(): #A // kotlinx.coroutines.flow/StateFlow.value.<get-value>|<get-value>(){}[0]
 }
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines/Deferred : kotlinx.coroutines/Job { // kotlinx.coroutines/Deferred|null[0]
+    abstract val onAwait // kotlinx.coroutines/Deferred.onAwait|{}onAwait[0]
+        abstract fun <get-onAwait>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines/Deferred.onAwait.<get-onAwait>|<get-onAwait>(){}[0]
+
     abstract fun getCompleted(): #A // kotlinx.coroutines/Deferred.getCompleted|getCompleted(){}[0]
     abstract fun getCompletionExceptionOrNull(): kotlin/Throwable? // kotlinx.coroutines/Deferred.getCompletionExceptionOrNull|getCompletionExceptionOrNull(){}[0]
     abstract suspend fun await(): #A // kotlinx.coroutines/Deferred.await|await(){}[0]
-    abstract val onAwait // kotlinx.coroutines/Deferred.onAwait|{}onAwait[0]
-        abstract fun <get-onAwait>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines/Deferred.onAwait.<get-onAwait>|<get-onAwait>(){}[0]
 }
+
 abstract interface kotlinx.coroutines.sync/Mutex { // kotlinx.coroutines.sync/Mutex|null[0]
-    abstract fun holdsLock(kotlin/Any): kotlin/Boolean // kotlinx.coroutines.sync/Mutex.holdsLock|holdsLock(kotlin.Any){}[0]
-    abstract fun tryLock(kotlin/Any? = ...): kotlin/Boolean // kotlinx.coroutines.sync/Mutex.tryLock|tryLock(kotlin.Any?){}[0]
-    abstract fun unlock(kotlin/Any? = ...) // kotlinx.coroutines.sync/Mutex.unlock|unlock(kotlin.Any?){}[0]
-    abstract suspend fun lock(kotlin/Any? = ...) // kotlinx.coroutines.sync/Mutex.lock|lock(kotlin.Any?){}[0]
     abstract val isLocked // kotlinx.coroutines.sync/Mutex.isLocked|{}isLocked[0]
         abstract fun <get-isLocked>(): kotlin/Boolean // kotlinx.coroutines.sync/Mutex.isLocked.<get-isLocked>|<get-isLocked>(){}[0]
     abstract val onLock // kotlinx.coroutines.sync/Mutex.onLock|{}onLock[0]
         abstract fun <get-onLock>(): kotlinx.coroutines.selects/SelectClause2<kotlin/Any?, kotlinx.coroutines.sync/Mutex> // kotlinx.coroutines.sync/Mutex.onLock.<get-onLock>|<get-onLock>(){}[0]
+
+    abstract fun holdsLock(kotlin/Any): kotlin/Boolean // kotlinx.coroutines.sync/Mutex.holdsLock|holdsLock(kotlin.Any){}[0]
+    abstract fun tryLock(kotlin/Any? = ...): kotlin/Boolean // kotlinx.coroutines.sync/Mutex.tryLock|tryLock(kotlin.Any?){}[0]
+    abstract fun unlock(kotlin/Any? = ...) // kotlinx.coroutines.sync/Mutex.unlock|unlock(kotlin.Any?){}[0]
+    abstract suspend fun lock(kotlin/Any? = ...) // kotlinx.coroutines.sync/Mutex.lock|lock(kotlin.Any?){}[0]
 }
+
 abstract interface kotlinx.coroutines.sync/Semaphore { // kotlinx.coroutines.sync/Semaphore|null[0]
+    abstract val availablePermits // kotlinx.coroutines.sync/Semaphore.availablePermits|{}availablePermits[0]
+        abstract fun <get-availablePermits>(): kotlin/Int // kotlinx.coroutines.sync/Semaphore.availablePermits.<get-availablePermits>|<get-availablePermits>(){}[0]
+
     abstract fun release() // kotlinx.coroutines.sync/Semaphore.release|release(){}[0]
     abstract fun tryAcquire(): kotlin/Boolean // kotlinx.coroutines.sync/Semaphore.tryAcquire|tryAcquire(){}[0]
     abstract suspend fun acquire() // kotlinx.coroutines.sync/Semaphore.acquire|acquire(){}[0]
-    abstract val availablePermits // kotlinx.coroutines.sync/Semaphore.availablePermits|{}availablePermits[0]
-        abstract fun <get-availablePermits>(): kotlin/Int // kotlinx.coroutines.sync/Semaphore.availablePermits.<get-availablePermits>|<get-availablePermits>(){}[0]
 }
+
 abstract interface kotlinx.coroutines/ChildHandle : kotlinx.coroutines/DisposableHandle { // kotlinx.coroutines/ChildHandle|null[0]
-    abstract fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/ChildHandle.childCancelled|childCancelled(kotlin.Throwable){}[0]
     abstract val parent // kotlinx.coroutines/ChildHandle.parent|{}parent[0]
         abstract fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/ChildHandle.parent.<get-parent>|<get-parent>(){}[0]
+
+    abstract fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/ChildHandle.childCancelled|childCancelled(kotlin.Throwable){}[0]
 }
+
 abstract interface kotlinx.coroutines/ChildJob : kotlinx.coroutines/Job { // kotlinx.coroutines/ChildJob|null[0]
     abstract fun parentCancelled(kotlinx.coroutines/ParentJob) // kotlinx.coroutines/ChildJob.parentCancelled|parentCancelled(kotlinx.coroutines.ParentJob){}[0]
 }
+
 abstract interface kotlinx.coroutines/CompletableJob : kotlinx.coroutines/Job { // kotlinx.coroutines/CompletableJob|null[0]
     abstract fun complete(): kotlin/Boolean // kotlinx.coroutines/CompletableJob.complete|complete(){}[0]
     abstract fun completeExceptionally(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/CompletableJob.completeExceptionally|completeExceptionally(kotlin.Throwable){}[0]
 }
+
 abstract interface kotlinx.coroutines/CoroutineExceptionHandler : kotlin.coroutines/CoroutineContext.Element { // kotlinx.coroutines/CoroutineExceptionHandler|null[0]
     abstract fun handleException(kotlin.coroutines/CoroutineContext, kotlin/Throwable) // kotlinx.coroutines/CoroutineExceptionHandler.handleException|handleException(kotlin.coroutines.CoroutineContext;kotlin.Throwable){}[0]
+
     final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/CoroutineExceptionHandler> // kotlinx.coroutines/CoroutineExceptionHandler.Key|null[0]
 }
+
 abstract interface kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines/CoroutineScope|null[0]
     abstract val coroutineContext // kotlinx.coroutines/CoroutineScope.coroutineContext|{}coroutineContext[0]
         abstract fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/CoroutineScope.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
 }
+
 abstract interface kotlinx.coroutines/Delay { // kotlinx.coroutines/Delay|null[0]
     abstract fun scheduleResumeAfterDelay(kotlin/Long, kotlinx.coroutines/CancellableContinuation<kotlin/Unit>) // kotlinx.coroutines/Delay.scheduleResumeAfterDelay|scheduleResumeAfterDelay(kotlin.Long;kotlinx.coroutines.CancellableContinuation<kotlin.Unit>){}[0]
     open fun invokeOnTimeout(kotlin/Long, kotlinx.coroutines/Runnable, kotlin.coroutines/CoroutineContext): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/Delay.invokeOnTimeout|invokeOnTimeout(kotlin.Long;kotlinx.coroutines.Runnable;kotlin.coroutines.CoroutineContext){}[0]
     open suspend fun delay(kotlin/Long) // kotlinx.coroutines/Delay.delay|delay(kotlin.Long){}[0]
 }
+
 abstract interface kotlinx.coroutines/Job : kotlin.coroutines/CoroutineContext.Element { // kotlinx.coroutines/Job|null[0]
-    abstract fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/Job.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
-    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines/Job.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines/Job.cancel|cancel(kotlin.Throwable?){}[0]
-    abstract fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/Job.getCancellationException|getCancellationException(){}[0]
-    abstract fun invokeOnCompletion(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/Job.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    abstract fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/Job.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    abstract fun start(): kotlin/Boolean // kotlinx.coroutines/Job.start|start(){}[0]
-    abstract suspend fun join() // kotlinx.coroutines/Job.join|join(){}[0]
     abstract val children // kotlinx.coroutines/Job.children|{}children[0]
         abstract fun <get-children>(): kotlin.sequences/Sequence<kotlinx.coroutines/Job> // kotlinx.coroutines/Job.children.<get-children>|<get-children>(){}[0]
     abstract val isActive // kotlinx.coroutines/Job.isActive|{}isActive[0]
@@ -270,27 +307,146 @@ abstract interface kotlinx.coroutines/Job : kotlin.coroutines/CoroutineContext.E
         abstract fun <get-onJoin>(): kotlinx.coroutines.selects/SelectClause0 // kotlinx.coroutines/Job.onJoin.<get-onJoin>|<get-onJoin>(){}[0]
     abstract val parent // kotlinx.coroutines/Job.parent|{}parent[0]
         abstract fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/Job.parent.<get-parent>|<get-parent>(){}[0]
-    final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/Job> // kotlinx.coroutines/Job.Key|null[0]
+
+    abstract fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/Job.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
+    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines/Job.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines/Job.cancel|cancel(kotlin.Throwable?){}[0]
+    abstract fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/Job.getCancellationException|getCancellationException(){}[0]
+    abstract fun invokeOnCompletion(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/Job.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    abstract fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/Job.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    abstract fun start(): kotlin/Boolean // kotlinx.coroutines/Job.start|start(){}[0]
+    abstract suspend fun join() // kotlinx.coroutines/Job.join|join(){}[0]
     open fun cancel() // kotlinx.coroutines/Job.cancel|cancel(){}[0]
     open fun plus(kotlinx.coroutines/Job): kotlinx.coroutines/Job // kotlinx.coroutines/Job.plus|plus(kotlinx.coroutines.Job){}[0]
+
+    final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/Job> // kotlinx.coroutines/Job.Key|null[0]
 }
+
 abstract interface kotlinx.coroutines/ParentJob : kotlinx.coroutines/Job { // kotlinx.coroutines/ParentJob|null[0]
     abstract fun getChildJobCancellationCause(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/ParentJob.getChildJobCancellationCause|getChildJobCancellationCause(){}[0]
 }
+
 abstract interface kotlinx.coroutines/Runnable { // kotlinx.coroutines/Runnable|null[0]
     abstract fun run() // kotlinx.coroutines/Runnable.run|run(){}[0]
 }
+
+sealed interface <#A: in kotlin/Any?, #B: out kotlin/Any?> kotlinx.coroutines.selects/SelectClause2 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause2|null[0]
+
+sealed interface <#A: in kotlin/Any?> kotlinx.coroutines.selects/SelectBuilder { // kotlinx.coroutines.selects/SelectBuilder|null[0]
+    abstract fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+    abstract fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+    abstract fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
+    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1?, #B1>).invoke(kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0?,0:1>(kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+    open fun onTimeout(kotlin/Long, kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectBuilder.onTimeout|onTimeout(kotlin.Long;kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+}
+
+sealed interface <#A: in kotlin/Any?> kotlinx.coroutines.selects/SelectInstance { // kotlinx.coroutines.selects/SelectInstance|null[0]
+    abstract val context // kotlinx.coroutines.selects/SelectInstance.context|{}context[0]
+        abstract fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.selects/SelectInstance.context.<get-context>|<get-context>(){}[0]
+
+    abstract fun disposeOnCompletion(kotlinx.coroutines/DisposableHandle) // kotlinx.coroutines.selects/SelectInstance.disposeOnCompletion|disposeOnCompletion(kotlinx.coroutines.DisposableHandle){}[0]
+    abstract fun selectInRegistrationPhase(kotlin/Any?) // kotlinx.coroutines.selects/SelectInstance.selectInRegistrationPhase|selectInRegistrationPhase(kotlin.Any?){}[0]
+    abstract fun trySelect(kotlin/Any, kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.selects/SelectInstance.trySelect|trySelect(kotlin.Any;kotlin.Any?){}[0]
+}
+
+sealed interface <#A: out kotlin/Any?> kotlinx.coroutines.selects/SelectClause1 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause1|null[0]
+
+sealed interface kotlinx.coroutines.selects/SelectClause { // kotlinx.coroutines.selects/SelectClause|null[0]
+    abstract val clauseObject // kotlinx.coroutines.selects/SelectClause.clauseObject|{}clauseObject[0]
+        abstract fun <get-clauseObject>(): kotlin/Any // kotlinx.coroutines.selects/SelectClause.clauseObject.<get-clauseObject>|<get-clauseObject>(){}[0]
+    abstract val onCancellationConstructor // kotlinx.coroutines.selects/SelectClause.onCancellationConstructor|{}onCancellationConstructor[0]
+        abstract fun <get-onCancellationConstructor>(): kotlin/Function3<kotlinx.coroutines.selects/SelectInstance<*>, kotlin/Any?, kotlin/Any?, kotlin/Function3<kotlin/Throwable, kotlin/Any?, kotlin.coroutines/CoroutineContext, kotlin/Unit>>? // kotlinx.coroutines.selects/SelectClause.onCancellationConstructor.<get-onCancellationConstructor>|<get-onCancellationConstructor>(){}[0]
+    abstract val processResFunc // kotlinx.coroutines.selects/SelectClause.processResFunc|{}processResFunc[0]
+        abstract fun <get-processResFunc>(): kotlin/Function3<kotlin/Any, kotlin/Any?, kotlin/Any?, kotlin/Any?> // kotlinx.coroutines.selects/SelectClause.processResFunc.<get-processResFunc>|<get-processResFunc>(){}[0]
+    abstract val regFunc // kotlinx.coroutines.selects/SelectClause.regFunc|{}regFunc[0]
+        abstract fun <get-regFunc>(): kotlin/Function3<kotlin/Any, kotlinx.coroutines.selects/SelectInstance<*>, kotlin/Any?, kotlin/Unit> // kotlinx.coroutines.selects/SelectClause.regFunc.<get-regFunc>|<get-regFunc>(){}[0]
+}
+
+sealed interface kotlinx.coroutines.selects/SelectClause0 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause0|null[0]
+
+abstract class <#A: in kotlin/Any?> kotlinx.coroutines/AbstractCoroutine : kotlin.coroutines/Continuation<#A>, kotlinx.coroutines/CoroutineScope, kotlinx.coroutines/Job, kotlinx.coroutines/JobSupport { // kotlinx.coroutines/AbstractCoroutine|null[0]
+    constructor <init>(kotlin.coroutines/CoroutineContext, kotlin/Boolean, kotlin/Boolean) // kotlinx.coroutines/AbstractCoroutine.<init>|<init>(kotlin.coroutines.CoroutineContext;kotlin.Boolean;kotlin.Boolean){}[0]
+
+    final val context // kotlinx.coroutines/AbstractCoroutine.context|{}context[0]
+        final fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/AbstractCoroutine.context.<get-context>|<get-context>(){}[0]
+    open val coroutineContext // kotlinx.coroutines/AbstractCoroutine.coroutineContext|{}coroutineContext[0]
+        open fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/AbstractCoroutine.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
+    open val isActive // kotlinx.coroutines/AbstractCoroutine.isActive|{}isActive[0]
+        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/AbstractCoroutine.isActive.<get-isActive>|<get-isActive>(){}[0]
+
+    final fun <#A1: kotlin/Any?> start(kotlinx.coroutines/CoroutineStart, #A1, kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines/AbstractCoroutine.start|start(kotlinx.coroutines.CoroutineStart;0:0;kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
+    final fun onCompletionInternal(kotlin/Any?) // kotlinx.coroutines/AbstractCoroutine.onCompletionInternal|onCompletionInternal(kotlin.Any?){}[0]
+    final fun resumeWith(kotlin/Result<#A>) // kotlinx.coroutines/AbstractCoroutine.resumeWith|resumeWith(kotlin.Result<1:0>){}[0]
+    open fun afterResume(kotlin/Any?) // kotlinx.coroutines/AbstractCoroutine.afterResume|afterResume(kotlin.Any?){}[0]
+    open fun cancellationExceptionMessage(): kotlin/String // kotlinx.coroutines/AbstractCoroutine.cancellationExceptionMessage|cancellationExceptionMessage(){}[0]
+    open fun onCancelled(kotlin/Throwable, kotlin/Boolean) // kotlinx.coroutines/AbstractCoroutine.onCancelled|onCancelled(kotlin.Throwable;kotlin.Boolean){}[0]
+    open fun onCompleted(#A) // kotlinx.coroutines/AbstractCoroutine.onCompleted|onCompleted(1:0){}[0]
+}
+
+abstract class <#A: kotlin/Any?> kotlinx.coroutines.flow.internal/ChannelFlow : kotlinx.coroutines.flow.internal/FusibleFlow<#A> { // kotlinx.coroutines.flow.internal/ChannelFlow|null[0]
+    constructor <init>(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow) // kotlinx.coroutines.flow.internal/ChannelFlow.<init>|<init>(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
+
+    final val capacity // kotlinx.coroutines.flow.internal/ChannelFlow.capacity|{}capacity[0]
+        final fun <get-capacity>(): kotlin/Int // kotlinx.coroutines.flow.internal/ChannelFlow.capacity.<get-capacity>|<get-capacity>(){}[0]
+    final val context // kotlinx.coroutines.flow.internal/ChannelFlow.context|{}context[0]
+        final fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.flow.internal/ChannelFlow.context.<get-context>|<get-context>(){}[0]
+    final val onBufferOverflow // kotlinx.coroutines.flow.internal/ChannelFlow.onBufferOverflow|{}onBufferOverflow[0]
+        final fun <get-onBufferOverflow>(): kotlinx.coroutines.channels/BufferOverflow // kotlinx.coroutines.flow.internal/ChannelFlow.onBufferOverflow.<get-onBufferOverflow>|<get-onBufferOverflow>(){}[0]
+
+    abstract fun create(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow): kotlinx.coroutines.flow.internal/ChannelFlow<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.create|create(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
+    abstract suspend fun collectTo(kotlinx.coroutines.channels/ProducerScope<#A>) // kotlinx.coroutines.flow.internal/ChannelFlow.collectTo|collectTo(kotlinx.coroutines.channels.ProducerScope<1:0>){}[0]
+    open fun additionalToStringProps(): kotlin/String? // kotlinx.coroutines.flow.internal/ChannelFlow.additionalToStringProps|additionalToStringProps(){}[0]
+    open fun dropChannelOperators(): kotlinx.coroutines.flow/Flow<#A>? // kotlinx.coroutines.flow.internal/ChannelFlow.dropChannelOperators|dropChannelOperators(){}[0]
+    open fun fuse(kotlin.coroutines/CoroutineContext, kotlin/Int, kotlinx.coroutines.channels/BufferOverflow): kotlinx.coroutines.flow/Flow<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.fuse|fuse(kotlin.coroutines.CoroutineContext;kotlin.Int;kotlinx.coroutines.channels.BufferOverflow){}[0]
+    open fun produceImpl(kotlinx.coroutines/CoroutineScope): kotlinx.coroutines.channels/ReceiveChannel<#A> // kotlinx.coroutines.flow.internal/ChannelFlow.produceImpl|produceImpl(kotlinx.coroutines.CoroutineScope){}[0]
+    open fun toString(): kotlin/String // kotlinx.coroutines.flow.internal/ChannelFlow.toString|toString(){}[0]
+    open suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow.internal/ChannelFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+}
+
+abstract class <#A: kotlin/Any?> kotlinx.coroutines.flow/AbstractFlow : kotlinx.coroutines.flow/CancellableFlow<#A>, kotlinx.coroutines.flow/Flow<#A> { // kotlinx.coroutines.flow/AbstractFlow|null[0]
+    constructor <init>() // kotlinx.coroutines.flow/AbstractFlow.<init>|<init>(){}[0]
+
+    abstract suspend fun collectSafely(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/AbstractFlow.collectSafely|collectSafely(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+    final suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/AbstractFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+}
+
+abstract class kotlinx.coroutines/CloseableCoroutineDispatcher : kotlin/AutoCloseable, kotlinx.coroutines/CoroutineDispatcher { // kotlinx.coroutines/CloseableCoroutineDispatcher|null[0]
+    constructor <init>() // kotlinx.coroutines/CloseableCoroutineDispatcher.<init>|<init>(){}[0]
+
+    abstract fun close() // kotlinx.coroutines/CloseableCoroutineDispatcher.close|close(){}[0]
+}
+
+abstract class kotlinx.coroutines/CoroutineDispatcher : kotlin.coroutines/AbstractCoroutineContextElement, kotlin.coroutines/ContinuationInterceptor { // kotlinx.coroutines/CoroutineDispatcher|null[0]
+    constructor <init>() // kotlinx.coroutines/CoroutineDispatcher.<init>|<init>(){}[0]
+
+    abstract fun dispatch(kotlin.coroutines/CoroutineContext, kotlinx.coroutines/Runnable) // kotlinx.coroutines/CoroutineDispatcher.dispatch|dispatch(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.Runnable){}[0]
+    final fun <#A1: kotlin/Any?> interceptContinuation(kotlin.coroutines/Continuation<#A1>): kotlin.coroutines/Continuation<#A1> // kotlinx.coroutines/CoroutineDispatcher.interceptContinuation|interceptContinuation(kotlin.coroutines.Continuation<0:0>){0§<kotlin.Any?>}[0]
+    final fun plus(kotlinx.coroutines/CoroutineDispatcher): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.plus|plus(kotlinx.coroutines.CoroutineDispatcher){}[0]
+    final fun releaseInterceptedContinuation(kotlin.coroutines/Continuation<*>) // kotlinx.coroutines/CoroutineDispatcher.releaseInterceptedContinuation|releaseInterceptedContinuation(kotlin.coroutines.Continuation<*>){}[0]
+    open fun dispatchYield(kotlin.coroutines/CoroutineContext, kotlinx.coroutines/Runnable) // kotlinx.coroutines/CoroutineDispatcher.dispatchYield|dispatchYield(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.Runnable){}[0]
+    open fun isDispatchNeeded(kotlin.coroutines/CoroutineContext): kotlin/Boolean // kotlinx.coroutines/CoroutineDispatcher.isDispatchNeeded|isDispatchNeeded(kotlin.coroutines.CoroutineContext){}[0]
+    open fun limitedParallelism(kotlin/Int): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int){}[0]
+    open fun limitedParallelism(kotlin/Int, kotlin/String? = ...): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/CoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int;kotlin.String?){}[0]
+    open fun toString(): kotlin/String // kotlinx.coroutines/CoroutineDispatcher.toString|toString(){}[0]
+
+    final object Key : kotlin.coroutines/AbstractCoroutineContextKey<kotlin.coroutines/ContinuationInterceptor, kotlinx.coroutines/CoroutineDispatcher> // kotlinx.coroutines/CoroutineDispatcher.Key|null[0]
+}
+
+abstract class kotlinx.coroutines/MainCoroutineDispatcher : kotlinx.coroutines/CoroutineDispatcher { // kotlinx.coroutines/MainCoroutineDispatcher|null[0]
+    constructor <init>() // kotlinx.coroutines/MainCoroutineDispatcher.<init>|<init>(){}[0]
+
+    abstract val immediate // kotlinx.coroutines/MainCoroutineDispatcher.immediate|{}immediate[0]
+        abstract fun <get-immediate>(): kotlinx.coroutines/MainCoroutineDispatcher // kotlinx.coroutines/MainCoroutineDispatcher.immediate.<get-immediate>|<get-immediate>(){}[0]
+
+    final fun toStringInternalImpl(): kotlin/String? // kotlinx.coroutines/MainCoroutineDispatcher.toStringInternalImpl|toStringInternalImpl(){}[0]
+    open fun limitedParallelism(kotlin/Int, kotlin/String?): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/MainCoroutineDispatcher.limitedParallelism|limitedParallelism(kotlin.Int;kotlin.String?){}[0]
+    open fun toString(): kotlin/String // kotlinx.coroutines/MainCoroutineDispatcher.toString|toString(){}[0]
+}
+
 final class <#A: kotlin/Any?> kotlinx.coroutines.channels/ConflatedBroadcastChannel : kotlinx.coroutines.channels/BroadcastChannel<#A> { // kotlinx.coroutines.channels/ConflatedBroadcastChannel|null[0]
     constructor <init>(#A) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.<init>|<init>(1:0){}[0]
     constructor <init>() // kotlinx.coroutines.channels/ConflatedBroadcastChannel.<init>|<init>(){}[0]
-    final fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    final fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.cancel|cancel(kotlin.Throwable?){}[0]
-    final fun close(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.close|close(kotlin.Throwable?){}[0]
-    final fun invokeOnClose(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.invokeOnClose|invokeOnClose(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    final fun offer(#A): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.offer|offer(1:0){}[0]
-    final fun openSubscription(): kotlinx.coroutines.channels/ReceiveChannel<#A> // kotlinx.coroutines.channels/ConflatedBroadcastChannel.openSubscription|openSubscription(){}[0]
-    final fun trySend(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/ConflatedBroadcastChannel.trySend|trySend(1:0){}[0]
-    final suspend fun send(#A) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.send|send(1:0){}[0]
+
     final val isClosedForSend // kotlinx.coroutines.channels/ConflatedBroadcastChannel.isClosedForSend|{}isClosedForSend[0]
         final fun <get-isClosedForSend>(): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.isClosedForSend.<get-isClosedForSend>|<get-isClosedForSend>(){}[0]
     final val onSend // kotlinx.coroutines.channels/ConflatedBroadcastChannel.onSend|{}onSend[0]
@@ -299,86 +455,299 @@ final class <#A: kotlin/Any?> kotlinx.coroutines.channels/ConflatedBroadcastChan
         final fun <get-value>(): #A // kotlinx.coroutines.channels/ConflatedBroadcastChannel.value.<get-value>|<get-value>(){}[0]
     final val valueOrNull // kotlinx.coroutines.channels/ConflatedBroadcastChannel.valueOrNull|{}valueOrNull[0]
         final fun <get-valueOrNull>(): #A? // kotlinx.coroutines.channels/ConflatedBroadcastChannel.valueOrNull.<get-valueOrNull>|<get-valueOrNull>(){}[0]
+
+    final fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    final fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.cancel|cancel(kotlin.Throwable?){}[0]
+    final fun close(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.close|close(kotlin.Throwable?){}[0]
+    final fun invokeOnClose(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.invokeOnClose|invokeOnClose(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    final fun offer(#A): kotlin/Boolean // kotlinx.coroutines.channels/ConflatedBroadcastChannel.offer|offer(1:0){}[0]
+    final fun openSubscription(): kotlinx.coroutines.channels/ReceiveChannel<#A> // kotlinx.coroutines.channels/ConflatedBroadcastChannel.openSubscription|openSubscription(){}[0]
+    final fun trySend(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/ConflatedBroadcastChannel.trySend|trySend(1:0){}[0]
+    final suspend fun send(#A) // kotlinx.coroutines.channels/ConflatedBroadcastChannel.send|send(1:0){}[0]
 }
+
 final class <#A: kotlin/Any?> kotlinx.coroutines.flow.internal/SendingCollector : kotlinx.coroutines.flow/FlowCollector<#A> { // kotlinx.coroutines.flow.internal/SendingCollector|null[0]
     constructor <init>(kotlinx.coroutines.channels/SendChannel<#A>) // kotlinx.coroutines.flow.internal/SendingCollector.<init>|<init>(kotlinx.coroutines.channels.SendChannel<1:0>){}[0]
+
     final suspend fun emit(#A) // kotlinx.coroutines.flow.internal/SendingCollector.emit|emit(1:0){}[0]
 }
+
 final class <#A: kotlin/Any?> kotlinx.coroutines.selects/SelectBuilderImpl : kotlinx.coroutines.selects/SelectImplementation<#A> { // kotlinx.coroutines.selects/SelectBuilderImpl|null[0]
     constructor <init>(kotlin.coroutines/Continuation<#A>) // kotlinx.coroutines.selects/SelectBuilderImpl.<init>|<init>(kotlin.coroutines.Continuation<1:0>){}[0]
+
     final fun getResult(): kotlin/Any? // kotlinx.coroutines.selects/SelectBuilderImpl.getResult|getResult(){}[0]
     final fun handleBuilderException(kotlin/Throwable) // kotlinx.coroutines.selects/SelectBuilderImpl.handleBuilderException|handleBuilderException(kotlin.Throwable){}[0]
 }
+
 final class <#A: kotlin/Any?> kotlinx.coroutines.selects/UnbiasedSelectBuilderImpl : kotlinx.coroutines.selects/UnbiasedSelectImplementation<#A> { // kotlinx.coroutines.selects/UnbiasedSelectBuilderImpl|null[0]
     constructor <init>(kotlin.coroutines/Continuation<#A>) // kotlinx.coroutines.selects/UnbiasedSelectBuilderImpl.<init>|<init>(kotlin.coroutines.Continuation<1:0>){}[0]
+
     final fun handleBuilderException(kotlin/Throwable) // kotlinx.coroutines.selects/UnbiasedSelectBuilderImpl.handleBuilderException|handleBuilderException(kotlin.Throwable){}[0]
     final fun initSelectResult(): kotlin/Any? // kotlinx.coroutines.selects/UnbiasedSelectBuilderImpl.initSelectResult|initSelectResult(){}[0]
 }
+
 final class kotlinx.coroutines.channels/ClosedReceiveChannelException : kotlin/NoSuchElementException { // kotlinx.coroutines.channels/ClosedReceiveChannelException|null[0]
     constructor <init>(kotlin/String?) // kotlinx.coroutines.channels/ClosedReceiveChannelException.<init>|<init>(kotlin.String?){}[0]
 }
+
 final class kotlinx.coroutines.channels/ClosedSendChannelException : kotlin/IllegalStateException { // kotlinx.coroutines.channels/ClosedSendChannelException|null[0]
     constructor <init>(kotlin/String?) // kotlinx.coroutines.channels/ClosedSendChannelException.<init>|<init>(kotlin.String?){}[0]
 }
+
 final class kotlinx.coroutines/CompletionHandlerException : kotlin/RuntimeException { // kotlinx.coroutines/CompletionHandlerException|null[0]
     constructor <init>(kotlin/String, kotlin/Throwable) // kotlinx.coroutines/CompletionHandlerException.<init>|<init>(kotlin.String;kotlin.Throwable){}[0]
 }
+
 final class kotlinx.coroutines/CoroutineName : kotlin.coroutines/AbstractCoroutineContextElement { // kotlinx.coroutines/CoroutineName|null[0]
     constructor <init>(kotlin/String) // kotlinx.coroutines/CoroutineName.<init>|<init>(kotlin.String){}[0]
+
+    final val name // kotlinx.coroutines/CoroutineName.name|{}name[0]
+        final fun <get-name>(): kotlin/String // kotlinx.coroutines/CoroutineName.name.<get-name>|<get-name>(){}[0]
+
     final fun component1(): kotlin/String // kotlinx.coroutines/CoroutineName.component1|component1(){}[0]
     final fun copy(kotlin/String = ...): kotlinx.coroutines/CoroutineName // kotlinx.coroutines/CoroutineName.copy|copy(kotlin.String){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // kotlinx.coroutines/CoroutineName.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // kotlinx.coroutines/CoroutineName.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // kotlinx.coroutines/CoroutineName.toString|toString(){}[0]
+
     final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/CoroutineName> // kotlinx.coroutines/CoroutineName.Key|null[0]
-    final val name // kotlinx.coroutines/CoroutineName.name|{}name[0]
-        final fun <get-name>(): kotlin/String // kotlinx.coroutines/CoroutineName.name.<get-name>|<get-name>(){}[0]
 }
+
 final class kotlinx.coroutines/TimeoutCancellationException : kotlin.coroutines.cancellation/CancellationException, kotlinx.coroutines/CopyableThrowable<kotlinx.coroutines/TimeoutCancellationException> { // kotlinx.coroutines/TimeoutCancellationException|null[0]
     final fun createCopy(): kotlinx.coroutines/TimeoutCancellationException // kotlinx.coroutines/TimeoutCancellationException.createCopy|createCopy(){}[0]
 }
+
 final class kotlinx.coroutines/YieldContext : kotlin.coroutines/AbstractCoroutineContextElement { // kotlinx.coroutines/YieldContext|null[0]
     constructor <init>() // kotlinx.coroutines/YieldContext.<init>|<init>(){}[0]
-    final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/YieldContext> // kotlinx.coroutines/YieldContext.Key|null[0]
+
     final var dispatcherWasUnconfined // kotlinx.coroutines/YieldContext.dispatcherWasUnconfined|{}dispatcherWasUnconfined[0]
         final fun <get-dispatcherWasUnconfined>(): kotlin/Boolean // kotlinx.coroutines/YieldContext.dispatcherWasUnconfined.<get-dispatcherWasUnconfined>|<get-dispatcherWasUnconfined>(){}[0]
         final fun <set-dispatcherWasUnconfined>(kotlin/Boolean) // kotlinx.coroutines/YieldContext.dispatcherWasUnconfined.<set-dispatcherWasUnconfined>|<set-dispatcherWasUnconfined>(kotlin.Boolean){}[0]
+
+    final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines/YieldContext> // kotlinx.coroutines/YieldContext.Key|null[0]
 }
+
+final value class <#A: out kotlin/Any?> kotlinx.coroutines.channels/ChannelResult { // kotlinx.coroutines.channels/ChannelResult|null[0]
+    constructor <init>(kotlin/Any?) // kotlinx.coroutines.channels/ChannelResult.<init>|<init>(kotlin.Any?){}[0]
+
+    final val holder // kotlinx.coroutines.channels/ChannelResult.holder|{}holder[0]
+        final fun <get-holder>(): kotlin/Any? // kotlinx.coroutines.channels/ChannelResult.holder.<get-holder>|<get-holder>(){}[0]
+    final val isClosed // kotlinx.coroutines.channels/ChannelResult.isClosed|{}isClosed[0]
+        final fun <get-isClosed>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
+    final val isFailure // kotlinx.coroutines.channels/ChannelResult.isFailure|{}isFailure[0]
+        final fun <get-isFailure>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isFailure.<get-isFailure>|<get-isFailure>(){}[0]
+    final val isSuccess // kotlinx.coroutines.channels/ChannelResult.isSuccess|{}isSuccess[0]
+        final fun <get-isSuccess>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isSuccess.<get-isSuccess>|<get-isSuccess>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.equals|equals(kotlin.Any?){}[0]
+    final fun exceptionOrNull(): kotlin/Throwable? // kotlinx.coroutines.channels/ChannelResult.exceptionOrNull|exceptionOrNull(){}[0]
+    final fun getOrNull(): #A? // kotlinx.coroutines.channels/ChannelResult.getOrNull|getOrNull(){}[0]
+    final fun getOrThrow(): #A // kotlinx.coroutines.channels/ChannelResult.getOrThrow|getOrThrow(){}[0]
+    final fun hashCode(): kotlin/Int // kotlinx.coroutines.channels/ChannelResult.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // kotlinx.coroutines.channels/ChannelResult.toString|toString(){}[0]
+
+    final object Companion { // kotlinx.coroutines.channels/ChannelResult.Companion|null[0]
+        final fun <#A2: kotlin/Any?> closed(kotlin/Throwable?): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.closed|closed(kotlin.Throwable?){0§<kotlin.Any?>}[0]
+        final fun <#A2: kotlin/Any?> failure(): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.failure|failure(){0§<kotlin.Any?>}[0]
+        final fun <#A2: kotlin/Any?> success(#A2): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.success|success(0:0){0§<kotlin.Any?>}[0]
+    }
+}
+
+open class <#A: in kotlin/Any?> kotlinx.coroutines/CancellableContinuationImpl : kotlinx.coroutines.internal/CoroutineStackFrame, kotlinx.coroutines/CancellableContinuation<#A>, kotlinx.coroutines/DispatchedTask<#A>, kotlinx.coroutines/Waiter { // kotlinx.coroutines/CancellableContinuationImpl|null[0]
+    constructor <init>(kotlin.coroutines/Continuation<#A>, kotlin/Int) // kotlinx.coroutines/CancellableContinuationImpl.<init>|<init>(kotlin.coroutines.Continuation<1:0>;kotlin.Int){}[0]
+
+    open val callerFrame // kotlinx.coroutines/CancellableContinuationImpl.callerFrame|{}callerFrame[0]
+        open fun <get-callerFrame>(): kotlinx.coroutines.internal/CoroutineStackFrame? // kotlinx.coroutines/CancellableContinuationImpl.callerFrame.<get-callerFrame>|<get-callerFrame>(){}[0]
+    open val context // kotlinx.coroutines/CancellableContinuationImpl.context|{}context[0]
+        open fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/CancellableContinuationImpl.context.<get-context>|<get-context>(){}[0]
+    open val isActive // kotlinx.coroutines/CancellableContinuationImpl.isActive|{}isActive[0]
+        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isActive.<get-isActive>|<get-isActive>(){}[0]
+    open val isCancelled // kotlinx.coroutines/CancellableContinuationImpl.isCancelled|{}isCancelled[0]
+        open fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
+    open val isCompleted // kotlinx.coroutines/CancellableContinuationImpl.isCompleted|{}isCompleted[0]
+        open fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
+
+    final fun <#A1: kotlin/Any?> callOnCancellation(kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>, kotlin/Throwable, #A1) // kotlinx.coroutines/CancellableContinuationImpl.callOnCancellation|callOnCancellation(kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>;kotlin.Throwable;0:0){0§<kotlin.Any?>}[0]
+    final fun callCancelHandler(kotlinx.coroutines/CancelHandler, kotlin/Throwable?) // kotlinx.coroutines/CancellableContinuationImpl.callCancelHandler|callCancelHandler(kotlinx.coroutines.CancelHandler;kotlin.Throwable?){}[0]
+    final fun getResult(): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.getResult|getResult(){}[0]
+    open fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatched(#A) // kotlinx.coroutines/CancellableContinuationImpl.resumeUndispatched|resumeUndispatched@kotlinx.coroutines.CoroutineDispatcher(1:0){}[0]
+    open fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatchedWithException(kotlin/Throwable) // kotlinx.coroutines/CancellableContinuationImpl.resumeUndispatchedWithException|resumeUndispatchedWithException@kotlinx.coroutines.CoroutineDispatcher(kotlin.Throwable){}[0]
+    open fun <#A1: #A> resume(#A1, kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuationImpl.resume|resume(0:0;kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>?){0§<1:0>}[0]
+    open fun <#A1: #A> tryResume(#A1, kotlin/Any?, kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>?): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResume|tryResume(0:0;kotlin.Any?;kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>?){0§<1:0>}[0]
+    open fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.cancel|cancel(kotlin.Throwable?){}[0]
+    open fun completeResume(kotlin/Any) // kotlinx.coroutines/CancellableContinuationImpl.completeResume|completeResume(kotlin.Any){}[0]
+    open fun getContinuationCancellationCause(kotlinx.coroutines/Job): kotlin/Throwable // kotlinx.coroutines/CancellableContinuationImpl.getContinuationCancellationCause|getContinuationCancellationCause(kotlinx.coroutines.Job){}[0]
+    open fun getStackTraceElement(): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.getStackTraceElement|getStackTraceElement(){}[0]
+    open fun initCancellability() // kotlinx.coroutines/CancellableContinuationImpl.initCancellability|initCancellability(){}[0]
+    open fun invokeOnCancellation(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines/CancellableContinuationImpl.invokeOnCancellation|invokeOnCancellation(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    open fun invokeOnCancellation(kotlinx.coroutines.internal/Segment<*>, kotlin/Int) // kotlinx.coroutines/CancellableContinuationImpl.invokeOnCancellation|invokeOnCancellation(kotlinx.coroutines.internal.Segment<*>;kotlin.Int){}[0]
+    open fun nameString(): kotlin/String // kotlinx.coroutines/CancellableContinuationImpl.nameString|nameString(){}[0]
+    open fun resume(#A, kotlin/Function1<kotlin/Throwable, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuationImpl.resume|resume(1:0;kotlin.Function1<kotlin.Throwable,kotlin.Unit>?){}[0]
+    open fun resumeWith(kotlin/Result<#A>) // kotlinx.coroutines/CancellableContinuationImpl.resumeWith|resumeWith(kotlin.Result<1:0>){}[0]
+    open fun toString(): kotlin/String // kotlinx.coroutines/CancellableContinuationImpl.toString|toString(){}[0]
+    open fun tryResume(#A, kotlin/Any?): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResume|tryResume(1:0;kotlin.Any?){}[0]
+    open fun tryResumeWithException(kotlin/Throwable): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResumeWithException|tryResumeWithException(kotlin.Throwable){}[0]
+}
+
+open class <#A: kotlin/Any?> kotlinx.coroutines.selects/SelectImplementation : kotlinx.coroutines.selects/SelectBuilder<#A>, kotlinx.coroutines.selects/SelectInstanceInternal<#A>, kotlinx.coroutines/CancelHandler { // kotlinx.coroutines.selects/SelectImplementation|null[0]
+    constructor <init>(kotlin.coroutines/CoroutineContext) // kotlinx.coroutines.selects/SelectImplementation.<init>|<init>(kotlin.coroutines.CoroutineContext){}[0]
+
+    open val context // kotlinx.coroutines.selects/SelectImplementation.context|{}context[0]
+        open fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.selects/SelectImplementation.context.<get-context>|<get-context>(){}[0]
+
+    final fun trySelectDetailed(kotlin/Any, kotlin/Any?): kotlinx.coroutines.selects/TrySelectDetailedResult // kotlinx.coroutines.selects/SelectImplementation.trySelectDetailed|trySelectDetailed(kotlin.Any;kotlin.Any?){}[0]
+    open fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+    open fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
+    open fun disposeOnCompletion(kotlinx.coroutines/DisposableHandle) // kotlinx.coroutines.selects/SelectImplementation.disposeOnCompletion|disposeOnCompletion(kotlinx.coroutines.DisposableHandle){}[0]
+    open fun invoke(kotlin/Throwable?) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke(kotlin.Throwable?){}[0]
+    open fun invokeOnCancellation(kotlinx.coroutines.internal/Segment<*>, kotlin/Int) // kotlinx.coroutines.selects/SelectImplementation.invokeOnCancellation|invokeOnCancellation(kotlinx.coroutines.internal.Segment<*>;kotlin.Int){}[0]
+    open fun selectInRegistrationPhase(kotlin/Any?) // kotlinx.coroutines.selects/SelectImplementation.selectInRegistrationPhase|selectInRegistrationPhase(kotlin.Any?){}[0]
+    open fun trySelect(kotlin/Any, kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.selects/SelectImplementation.trySelect|trySelect(kotlin.Any;kotlin.Any?){}[0]
+    open suspend fun doSelect(): #A // kotlinx.coroutines.selects/SelectImplementation.doSelect|doSelect(){}[0]
+}
+
+open class <#A: kotlin/Any?> kotlinx.coroutines.selects/UnbiasedSelectImplementation : kotlinx.coroutines.selects/SelectImplementation<#A> { // kotlinx.coroutines.selects/UnbiasedSelectImplementation|null[0]
+    constructor <init>(kotlin.coroutines/CoroutineContext) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.<init>|<init>(kotlin.coroutines.CoroutineContext){}[0]
+
+    open fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+    open fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
+    open suspend fun doSelect(): #A // kotlinx.coroutines.selects/UnbiasedSelectImplementation.doSelect|doSelect(){}[0]
+}
+
+open class kotlinx.coroutines/JobImpl : kotlinx.coroutines/CompletableJob, kotlinx.coroutines/JobSupport { // kotlinx.coroutines/JobImpl|null[0]
+    constructor <init>(kotlinx.coroutines/Job?) // kotlinx.coroutines/JobImpl.<init>|<init>(kotlinx.coroutines.Job?){}[0]
+
+    open fun complete(): kotlin/Boolean // kotlinx.coroutines/JobImpl.complete|complete(){}[0]
+    open fun completeExceptionally(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobImpl.completeExceptionally|completeExceptionally(kotlin.Throwable){}[0]
+}
+
+open class kotlinx.coroutines/JobSupport : kotlinx.coroutines/ChildJob, kotlinx.coroutines/Job, kotlinx.coroutines/ParentJob { // kotlinx.coroutines/JobSupport|null[0]
+    constructor <init>(kotlin/Boolean) // kotlinx.coroutines/JobSupport.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val children // kotlinx.coroutines/JobSupport.children|{}children[0]
+        final fun <get-children>(): kotlin.sequences/Sequence<kotlinx.coroutines/Job> // kotlinx.coroutines/JobSupport.children.<get-children>|<get-children>(){}[0]
+    final val completionCause // kotlinx.coroutines/JobSupport.completionCause|{}completionCause[0]
+        final fun <get-completionCause>(): kotlin/Throwable? // kotlinx.coroutines/JobSupport.completionCause.<get-completionCause>|<get-completionCause>(){}[0]
+    final val completionCauseHandled // kotlinx.coroutines/JobSupport.completionCauseHandled|{}completionCauseHandled[0]
+        final fun <get-completionCauseHandled>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.completionCauseHandled.<get-completionCauseHandled>|<get-completionCauseHandled>(){}[0]
+    final val isCancelled // kotlinx.coroutines/JobSupport.isCancelled|{}isCancelled[0]
+        final fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
+    final val isCompleted // kotlinx.coroutines/JobSupport.isCompleted|{}isCompleted[0]
+        final fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
+    final val isCompletedExceptionally // kotlinx.coroutines/JobSupport.isCompletedExceptionally|{}isCompletedExceptionally[0]
+        final fun <get-isCompletedExceptionally>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCompletedExceptionally.<get-isCompletedExceptionally>|<get-isCompletedExceptionally>(){}[0]
+    final val key // kotlinx.coroutines/JobSupport.key|{}key[0]
+        final fun <get-key>(): kotlin.coroutines/CoroutineContext.Key<*> // kotlinx.coroutines/JobSupport.key.<get-key>|<get-key>(){}[0]
+    final val onAwaitInternal // kotlinx.coroutines/JobSupport.onAwaitInternal|{}onAwaitInternal[0]
+        final fun <get-onAwaitInternal>(): kotlinx.coroutines.selects/SelectClause1<*> // kotlinx.coroutines/JobSupport.onAwaitInternal.<get-onAwaitInternal>|<get-onAwaitInternal>(){}[0]
+    final val onJoin // kotlinx.coroutines/JobSupport.onJoin|{}onJoin[0]
+        final fun <get-onJoin>(): kotlinx.coroutines.selects/SelectClause0 // kotlinx.coroutines/JobSupport.onJoin.<get-onJoin>|<get-onJoin>(){}[0]
+    open val isActive // kotlinx.coroutines/JobSupport.isActive|{}isActive[0]
+        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isActive.<get-isActive>|<get-isActive>(){}[0]
+    open val isScopedCoroutine // kotlinx.coroutines/JobSupport.isScopedCoroutine|{}isScopedCoroutine[0]
+        open fun <get-isScopedCoroutine>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isScopedCoroutine.<get-isScopedCoroutine>|<get-isScopedCoroutine>(){}[0]
+    open val parent // kotlinx.coroutines/JobSupport.parent|{}parent[0]
+        open fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/JobSupport.parent.<get-parent>|<get-parent>(){}[0]
+
+    final fun (kotlin/Throwable).toCancellationException(kotlin/String? = ...): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.toCancellationException|toCancellationException@kotlin.Throwable(kotlin.String?){}[0]
+    final fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/JobSupport.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
+    final fun cancelCoroutine(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/JobSupport.cancelCoroutine|cancelCoroutine(kotlin.Throwable?){}[0]
+    final fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.getCancellationException|getCancellationException(){}[0]
+    final fun getCompletionExceptionOrNull(): kotlin/Throwable? // kotlinx.coroutines/JobSupport.getCompletionExceptionOrNull|getCompletionExceptionOrNull(){}[0]
+    final fun initParentJob(kotlinx.coroutines/Job?) // kotlinx.coroutines/JobSupport.initParentJob|initParentJob(kotlinx.coroutines.Job?){}[0]
+    final fun invokeOnCompletion(kotlin/Boolean, kotlin/Boolean, kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/JobSupport.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    final fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/JobSupport.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    final fun parentCancelled(kotlinx.coroutines/ParentJob) // kotlinx.coroutines/JobSupport.parentCancelled|parentCancelled(kotlinx.coroutines.ParentJob){}[0]
+    final fun start(): kotlin/Boolean // kotlinx.coroutines/JobSupport.start|start(){}[0]
+    final fun toDebugString(): kotlin/String // kotlinx.coroutines/JobSupport.toDebugString|toDebugString(){}[0]
+    final suspend fun awaitInternal(): kotlin/Any? // kotlinx.coroutines/JobSupport.awaitInternal|awaitInternal(){}[0]
+    final suspend fun join() // kotlinx.coroutines/JobSupport.join|join(){}[0]
+    open fun afterCompletion(kotlin/Any?) // kotlinx.coroutines/JobSupport.afterCompletion|afterCompletion(kotlin.Any?){}[0]
+    open fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines/JobSupport.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    open fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/JobSupport.cancel|cancel(kotlin.Throwable?){}[0]
+    open fun cancelInternal(kotlin/Throwable) // kotlinx.coroutines/JobSupport.cancelInternal|cancelInternal(kotlin.Throwable){}[0]
+    open fun cancellationExceptionMessage(): kotlin/String // kotlinx.coroutines/JobSupport.cancellationExceptionMessage|cancellationExceptionMessage(){}[0]
+    open fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobSupport.childCancelled|childCancelled(kotlin.Throwable){}[0]
+    open fun getChildJobCancellationCause(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.getChildJobCancellationCause|getChildJobCancellationCause(){}[0]
+    open fun handleJobException(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobSupport.handleJobException|handleJobException(kotlin.Throwable){}[0]
+    open fun onCancelling(kotlin/Throwable?) // kotlinx.coroutines/JobSupport.onCancelling|onCancelling(kotlin.Throwable?){}[0]
+    open fun onCompletionInternal(kotlin/Any?) // kotlinx.coroutines/JobSupport.onCompletionInternal|onCompletionInternal(kotlin.Any?){}[0]
+    open fun onStart() // kotlinx.coroutines/JobSupport.onStart|onStart(){}[0]
+    open fun toString(): kotlin/String // kotlinx.coroutines/JobSupport.toString|toString(){}[0]
+}
+
+final object kotlinx.coroutines/Dispatchers { // kotlinx.coroutines/Dispatchers|null[0]
+    final val Default // kotlinx.coroutines/Dispatchers.Default|{}Default[0]
+        final fun <get-Default>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/Dispatchers.Default.<get-Default>|<get-Default>(){}[0]
+    final val Main // kotlinx.coroutines/Dispatchers.Main|{}Main[0]
+        final fun <get-Main>(): kotlinx.coroutines/MainCoroutineDispatcher // kotlinx.coroutines/Dispatchers.Main.<get-Main>|<get-Main>(){}[0]
+    final val Unconfined // kotlinx.coroutines/Dispatchers.Unconfined|{}Unconfined[0]
+        final fun <get-Unconfined>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/Dispatchers.Unconfined.<get-Unconfined>|<get-Unconfined>(){}[0]
+
+    final fun injectMain(kotlinx.coroutines/MainCoroutineDispatcher) // kotlinx.coroutines/Dispatchers.injectMain|injectMain(kotlinx.coroutines.MainCoroutineDispatcher){}[0]
+}
+
+final object kotlinx.coroutines/GlobalScope : kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines/GlobalScope|null[0]
+    final val coroutineContext // kotlinx.coroutines/GlobalScope.coroutineContext|{}coroutineContext[0]
+        final fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/GlobalScope.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
+}
+
+final object kotlinx.coroutines/NonCancellable : kotlin.coroutines/AbstractCoroutineContextElement, kotlinx.coroutines/Job { // kotlinx.coroutines/NonCancellable|null[0]
+    final val children // kotlinx.coroutines/NonCancellable.children|{}children[0]
+        final fun <get-children>(): kotlin.sequences/Sequence<kotlinx.coroutines/Job> // kotlinx.coroutines/NonCancellable.children.<get-children>|<get-children>(){}[0]
+    final val isActive // kotlinx.coroutines/NonCancellable.isActive|{}isActive[0]
+        final fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isActive.<get-isActive>|<get-isActive>(){}[0]
+    final val isCancelled // kotlinx.coroutines/NonCancellable.isCancelled|{}isCancelled[0]
+        final fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
+    final val isCompleted // kotlinx.coroutines/NonCancellable.isCompleted|{}isCompleted[0]
+        final fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
+    final val onJoin // kotlinx.coroutines/NonCancellable.onJoin|{}onJoin[0]
+        final fun <get-onJoin>(): kotlinx.coroutines.selects/SelectClause0 // kotlinx.coroutines/NonCancellable.onJoin.<get-onJoin>|<get-onJoin>(){}[0]
+    final val parent // kotlinx.coroutines/NonCancellable.parent|{}parent[0]
+        final fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/NonCancellable.parent.<get-parent>|<get-parent>(){}[0]
+
+    final fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/NonCancellable.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
+    final fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines/NonCancellable.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    final fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/NonCancellable.cancel|cancel(kotlin.Throwable?){}[0]
+    final fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/NonCancellable.getCancellationException|getCancellationException(){}[0]
+    final fun invokeOnCompletion(kotlin/Boolean, kotlin/Boolean, kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/NonCancellable.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    final fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/NonCancellable.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
+    final fun start(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.start|start(){}[0]
+    final fun toString(): kotlin/String // kotlinx.coroutines/NonCancellable.toString|toString(){}[0]
+    final suspend fun join() // kotlinx.coroutines/NonCancellable.join|join(){}[0]
+}
+
+final object kotlinx.coroutines/NonDisposableHandle : kotlinx.coroutines/ChildHandle, kotlinx.coroutines/DisposableHandle { // kotlinx.coroutines/NonDisposableHandle|null[0]
+    final val parent // kotlinx.coroutines/NonDisposableHandle.parent|{}parent[0]
+        final fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/NonDisposableHandle.parent.<get-parent>|<get-parent>(){}[0]
+
+    final fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/NonDisposableHandle.childCancelled|childCancelled(kotlin.Throwable){}[0]
+    final fun dispose() // kotlinx.coroutines/NonDisposableHandle.dispose|dispose(){}[0]
+    final fun toString(): kotlin/String // kotlinx.coroutines/NonDisposableHandle.toString|toString(){}[0]
+}
+
 final const val kotlinx.coroutines.flow/DEFAULT_CONCURRENCY_PROPERTY_NAME // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY_PROPERTY_NAME|{}DEFAULT_CONCURRENCY_PROPERTY_NAME[0]
     final fun <get-DEFAULT_CONCURRENCY_PROPERTY_NAME>(): kotlin/String // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY_PROPERTY_NAME.<get-DEFAULT_CONCURRENCY_PROPERTY_NAME>|<get-DEFAULT_CONCURRENCY_PROPERTY_NAME>(){}[0]
 final const val kotlinx.coroutines/MODE_CANCELLABLE // kotlinx.coroutines/MODE_CANCELLABLE|{}MODE_CANCELLABLE[0]
     final fun <get-MODE_CANCELLABLE>(): kotlin/Int // kotlinx.coroutines/MODE_CANCELLABLE.<get-MODE_CANCELLABLE>|<get-MODE_CANCELLABLE>(){}[0]
-final enum class kotlinx.coroutines.channels/BufferOverflow : kotlin/Enum<kotlinx.coroutines.channels/BufferOverflow> { // kotlinx.coroutines.channels/BufferOverflow|null[0]
-    enum entry DROP_LATEST // kotlinx.coroutines.channels/BufferOverflow.DROP_LATEST|null[0]
-    enum entry DROP_OLDEST // kotlinx.coroutines.channels/BufferOverflow.DROP_OLDEST|null[0]
-    enum entry SUSPEND // kotlinx.coroutines.channels/BufferOverflow.SUSPEND|null[0]
-    final fun valueOf(kotlin/String): kotlinx.coroutines.channels/BufferOverflow // kotlinx.coroutines.channels/BufferOverflow.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.coroutines.channels/BufferOverflow> // kotlinx.coroutines.channels/BufferOverflow.values|values#static(){}[0]
-    final val entries // kotlinx.coroutines.channels/BufferOverflow.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines.channels/BufferOverflow> // kotlinx.coroutines.channels/BufferOverflow.entries.<get-entries>|<get-entries>#static(){}[0]
-}
-final enum class kotlinx.coroutines.flow/SharingCommand : kotlin/Enum<kotlinx.coroutines.flow/SharingCommand> { // kotlinx.coroutines.flow/SharingCommand|null[0]
-    enum entry START // kotlinx.coroutines.flow/SharingCommand.START|null[0]
-    enum entry STOP // kotlinx.coroutines.flow/SharingCommand.STOP|null[0]
-    enum entry STOP_AND_RESET_REPLAY_CACHE // kotlinx.coroutines.flow/SharingCommand.STOP_AND_RESET_REPLAY_CACHE|null[0]
-    final fun valueOf(kotlin/String): kotlinx.coroutines.flow/SharingCommand // kotlinx.coroutines.flow/SharingCommand.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.coroutines.flow/SharingCommand> // kotlinx.coroutines.flow/SharingCommand.values|values#static(){}[0]
-    final val entries // kotlinx.coroutines.flow/SharingCommand.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines.flow/SharingCommand> // kotlinx.coroutines.flow/SharingCommand.entries.<get-entries>|<get-entries>#static(){}[0]
-}
-final enum class kotlinx.coroutines/CoroutineStart : kotlin/Enum<kotlinx.coroutines/CoroutineStart> { // kotlinx.coroutines/CoroutineStart|null[0]
-    enum entry ATOMIC // kotlinx.coroutines/CoroutineStart.ATOMIC|null[0]
-    enum entry DEFAULT // kotlinx.coroutines/CoroutineStart.DEFAULT|null[0]
-    enum entry LAZY // kotlinx.coroutines/CoroutineStart.LAZY|null[0]
-    enum entry UNDISPATCHED // kotlinx.coroutines/CoroutineStart.UNDISPATCHED|null[0]
-    final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> invoke(kotlin.coroutines/SuspendFunction1<#A1, #B1>, #A1, kotlin.coroutines/Continuation<#B1>) // kotlinx.coroutines/CoroutineStart.invoke|invoke(kotlin.coroutines.SuspendFunction1<0:0,0:1>;0:0;kotlin.coroutines.Continuation<0:1>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
-    final fun valueOf(kotlin/String): kotlinx.coroutines/CoroutineStart // kotlinx.coroutines/CoroutineStart.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.coroutines/CoroutineStart> // kotlinx.coroutines/CoroutineStart.values|values#static(){}[0]
-    final val entries // kotlinx.coroutines/CoroutineStart.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.coroutines/CoroutineStart> // kotlinx.coroutines/CoroutineStart.entries.<get-entries>|<get-entries>#static(){}[0]
-    final val isLazy // kotlinx.coroutines/CoroutineStart.isLazy|{}isLazy[0]
-        final fun <get-isLazy>(): kotlin/Boolean // kotlinx.coroutines/CoroutineStart.isLazy.<get-isLazy>|<get-isLazy>(){}[0]
-}
+
+final val kotlinx.coroutines.flow/DEFAULT_CONCURRENCY // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY|{}DEFAULT_CONCURRENCY[0]
+    final fun <get-DEFAULT_CONCURRENCY>(): kotlin/Int // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY.<get-DEFAULT_CONCURRENCY>|<get-DEFAULT_CONCURRENCY>(){}[0]
+final val kotlinx.coroutines.flow/coroutineContext // kotlinx.coroutines.flow/coroutineContext|@kotlinx.coroutines.flow.FlowCollector<*>{}coroutineContext[0]
+    final fun (kotlinx.coroutines.flow/FlowCollector<*>).<get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.flow/coroutineContext.<get-coroutineContext>|<get-coroutineContext>@kotlinx.coroutines.flow.FlowCollector<*>(){}[0]
+final val kotlinx.coroutines.flow/isActive // kotlinx.coroutines.flow/isActive|@kotlinx.coroutines.flow.FlowCollector<*>{}isActive[0]
+    final fun (kotlinx.coroutines.flow/FlowCollector<*>).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines.flow/isActive.<get-isActive>|<get-isActive>@kotlinx.coroutines.flow.FlowCollector<*>(){}[0]
+final val kotlinx.coroutines/DefaultDelay // kotlinx.coroutines/DefaultDelay|{}DefaultDelay[0]
+    final fun <get-DefaultDelay>(): kotlinx.coroutines/Delay // kotlinx.coroutines/DefaultDelay.<get-DefaultDelay>|<get-DefaultDelay>(){}[0]
+final val kotlinx.coroutines/isActive // kotlinx.coroutines/isActive|@kotlin.coroutines.CoroutineContext{}isActive[0]
+    final fun (kotlin.coroutines/CoroutineContext).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines/isActive.<get-isActive>|<get-isActive>@kotlin.coroutines.CoroutineContext(){}[0]
+final val kotlinx.coroutines/isActive // kotlinx.coroutines/isActive|@kotlinx.coroutines.CoroutineScope{}isActive[0]
+    final fun (kotlinx.coroutines/CoroutineScope).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines/isActive.<get-isActive>|<get-isActive>@kotlinx.coroutines.CoroutineScope(){}[0]
+final val kotlinx.coroutines/job // kotlinx.coroutines/job|@kotlin.coroutines.CoroutineContext{}job[0]
+    final fun (kotlin.coroutines/CoroutineContext).<get-job>(): kotlinx.coroutines/Job // kotlinx.coroutines/job.<get-job>|<get-job>@kotlin.coroutines.CoroutineContext(){}[0]
+
 final fun (kotlin.coroutines/CoroutineContext).kotlinx.coroutines/cancel() // kotlinx.coroutines/cancel|cancel@kotlin.coroutines.CoroutineContext(){}[0]
 final fun (kotlin.coroutines/CoroutineContext).kotlinx.coroutines/cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines/cancel|cancel@kotlin.coroutines.CoroutineContext(kotlin.coroutines.cancellation.CancellationException?){}[0]
 final fun (kotlin.coroutines/CoroutineContext).kotlinx.coroutines/cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines/cancel|cancel@kotlin.coroutines.CoroutineContext(kotlin.Throwable?){}[0]
@@ -596,49 +965,6 @@ final inline fun <#A: reified kotlin/Any?> (kotlinx.coroutines.flow/Flow<*>).kot
 final inline fun kotlinx.coroutines.flow.internal/checkIndexOverflow(kotlin/Int): kotlin/Int // kotlinx.coroutines.flow.internal/checkIndexOverflow|checkIndexOverflow(kotlin.Int){}[0]
 final inline fun kotlinx.coroutines/CoroutineExceptionHandler(crossinline kotlin/Function2<kotlin.coroutines/CoroutineContext, kotlin/Throwable, kotlin/Unit>): kotlinx.coroutines/CoroutineExceptionHandler // kotlinx.coroutines/CoroutineExceptionHandler|CoroutineExceptionHandler(kotlin.Function2<kotlin.coroutines.CoroutineContext,kotlin.Throwable,kotlin.Unit>){}[0]
 final inline fun kotlinx.coroutines/Runnable(crossinline kotlin/Function0<kotlin/Unit>): kotlinx.coroutines/Runnable // kotlinx.coroutines/Runnable|Runnable(kotlin.Function0<kotlin.Unit>){}[0]
-final object kotlinx.coroutines/Dispatchers { // kotlinx.coroutines/Dispatchers|null[0]
-    final fun injectMain(kotlinx.coroutines/MainCoroutineDispatcher) // kotlinx.coroutines/Dispatchers.injectMain|injectMain(kotlinx.coroutines.MainCoroutineDispatcher){}[0]
-    final val Default // kotlinx.coroutines/Dispatchers.Default|{}Default[0]
-        final fun <get-Default>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/Dispatchers.Default.<get-Default>|<get-Default>(){}[0]
-    final val Main // kotlinx.coroutines/Dispatchers.Main|{}Main[0]
-        final fun <get-Main>(): kotlinx.coroutines/MainCoroutineDispatcher // kotlinx.coroutines/Dispatchers.Main.<get-Main>|<get-Main>(){}[0]
-    final val Unconfined // kotlinx.coroutines/Dispatchers.Unconfined|{}Unconfined[0]
-        final fun <get-Unconfined>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/Dispatchers.Unconfined.<get-Unconfined>|<get-Unconfined>(){}[0]
-}
-final object kotlinx.coroutines/GlobalScope : kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines/GlobalScope|null[0]
-    final val coroutineContext // kotlinx.coroutines/GlobalScope.coroutineContext|{}coroutineContext[0]
-        final fun <get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/GlobalScope.coroutineContext.<get-coroutineContext>|<get-coroutineContext>(){}[0]
-}
-final object kotlinx.coroutines/NonCancellable : kotlin.coroutines/AbstractCoroutineContextElement, kotlinx.coroutines/Job { // kotlinx.coroutines/NonCancellable|null[0]
-    final fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/NonCancellable.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
-    final fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines/NonCancellable.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    final fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/NonCancellable.cancel|cancel(kotlin.Throwable?){}[0]
-    final fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/NonCancellable.getCancellationException|getCancellationException(){}[0]
-    final fun invokeOnCompletion(kotlin/Boolean, kotlin/Boolean, kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/NonCancellable.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    final fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/NonCancellable.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    final fun start(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.start|start(){}[0]
-    final fun toString(): kotlin/String // kotlinx.coroutines/NonCancellable.toString|toString(){}[0]
-    final suspend fun join() // kotlinx.coroutines/NonCancellable.join|join(){}[0]
-    final val children // kotlinx.coroutines/NonCancellable.children|{}children[0]
-        final fun <get-children>(): kotlin.sequences/Sequence<kotlinx.coroutines/Job> // kotlinx.coroutines/NonCancellable.children.<get-children>|<get-children>(){}[0]
-    final val isActive // kotlinx.coroutines/NonCancellable.isActive|{}isActive[0]
-        final fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isActive.<get-isActive>|<get-isActive>(){}[0]
-    final val isCancelled // kotlinx.coroutines/NonCancellable.isCancelled|{}isCancelled[0]
-        final fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
-    final val isCompleted // kotlinx.coroutines/NonCancellable.isCompleted|{}isCompleted[0]
-        final fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/NonCancellable.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
-    final val onJoin // kotlinx.coroutines/NonCancellable.onJoin|{}onJoin[0]
-        final fun <get-onJoin>(): kotlinx.coroutines.selects/SelectClause0 // kotlinx.coroutines/NonCancellable.onJoin.<get-onJoin>|<get-onJoin>(){}[0]
-    final val parent // kotlinx.coroutines/NonCancellable.parent|{}parent[0]
-        final fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/NonCancellable.parent.<get-parent>|<get-parent>(){}[0]
-}
-final object kotlinx.coroutines/NonDisposableHandle : kotlinx.coroutines/ChildHandle, kotlinx.coroutines/DisposableHandle { // kotlinx.coroutines/NonDisposableHandle|null[0]
-    final fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/NonDisposableHandle.childCancelled|childCancelled(kotlin.Throwable){}[0]
-    final fun dispose() // kotlinx.coroutines/NonDisposableHandle.dispose|dispose(){}[0]
-    final fun toString(): kotlin/String // kotlinx.coroutines/NonDisposableHandle.toString|toString(){}[0]
-    final val parent // kotlinx.coroutines/NonDisposableHandle.parent|{}parent[0]
-        final fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/NonDisposableHandle.parent.<get-parent>|<get-parent>(){}[0]
-}
 final suspend fun (kotlin.collections/Collection<kotlinx.coroutines/Job>).kotlinx.coroutines/joinAll() // kotlinx.coroutines/joinAll|joinAll@kotlin.collections.Collection<kotlinx.coroutines.Job>(){}[0]
 final suspend fun (kotlinx.coroutines.channels/ProducerScope<*>).kotlinx.coroutines.channels/awaitClose(kotlin/Function0<kotlin/Unit> = ...) // kotlinx.coroutines.channels/awaitClose|awaitClose@kotlinx.coroutines.channels.ProducerScope<*>(kotlin.Function0<kotlin.Unit>){}[0]
 final suspend fun (kotlinx.coroutines.flow/Flow<*>).kotlinx.coroutines.flow/collect() // kotlinx.coroutines.flow/collect|collect@kotlinx.coroutines.flow.Flow<*>(){}[0]
@@ -722,232 +1048,52 @@ final suspend inline fun <#A: kotlin/Any?> kotlinx.coroutines.selects/selectUnbi
 final suspend inline fun <#A: kotlin/Any?> kotlinx.coroutines/suspendCancellableCoroutine(crossinline kotlin/Function1<kotlinx.coroutines/CancellableContinuation<#A>, kotlin/Unit>): #A // kotlinx.coroutines/suspendCancellableCoroutine|suspendCancellableCoroutine(kotlin.Function1<kotlinx.coroutines.CancellableContinuation<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
 final suspend inline fun kotlinx.coroutines.selects/whileSelect(crossinline kotlin/Function1<kotlinx.coroutines.selects/SelectBuilder<kotlin/Boolean>, kotlin/Unit>) // kotlinx.coroutines.selects/whileSelect|whileSelect(kotlin.Function1<kotlinx.coroutines.selects.SelectBuilder<kotlin.Boolean>,kotlin.Unit>){}[0]
 final suspend inline fun kotlinx.coroutines/currentCoroutineContext(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/currentCoroutineContext|currentCoroutineContext(){}[0]
-final val kotlinx.coroutines.flow/DEFAULT_CONCURRENCY // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY|{}DEFAULT_CONCURRENCY[0]
-    final fun <get-DEFAULT_CONCURRENCY>(): kotlin/Int // kotlinx.coroutines.flow/DEFAULT_CONCURRENCY.<get-DEFAULT_CONCURRENCY>|<get-DEFAULT_CONCURRENCY>(){}[0]
-final val kotlinx.coroutines.flow/coroutineContext // kotlinx.coroutines.flow/coroutineContext|@kotlinx.coroutines.flow.FlowCollector<*>{}coroutineContext[0]
-    final fun (kotlinx.coroutines.flow/FlowCollector<*>).<get-coroutineContext>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.flow/coroutineContext.<get-coroutineContext>|<get-coroutineContext>@kotlinx.coroutines.flow.FlowCollector<*>(){}[0]
-final val kotlinx.coroutines.flow/isActive // kotlinx.coroutines.flow/isActive|@kotlinx.coroutines.flow.FlowCollector<*>{}isActive[0]
-    final fun (kotlinx.coroutines.flow/FlowCollector<*>).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines.flow/isActive.<get-isActive>|<get-isActive>@kotlinx.coroutines.flow.FlowCollector<*>(){}[0]
-final val kotlinx.coroutines/DefaultDelay // kotlinx.coroutines/DefaultDelay|{}DefaultDelay[0]
-    final fun <get-DefaultDelay>(): kotlinx.coroutines/Delay // kotlinx.coroutines/DefaultDelay.<get-DefaultDelay>|<get-DefaultDelay>(){}[0]
-final val kotlinx.coroutines/isActive // kotlinx.coroutines/isActive|@kotlin.coroutines.CoroutineContext{}isActive[0]
-    final fun (kotlin.coroutines/CoroutineContext).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines/isActive.<get-isActive>|<get-isActive>@kotlin.coroutines.CoroutineContext(){}[0]
-final val kotlinx.coroutines/isActive // kotlinx.coroutines/isActive|@kotlinx.coroutines.CoroutineScope{}isActive[0]
-    final fun (kotlinx.coroutines/CoroutineScope).<get-isActive>(): kotlin/Boolean // kotlinx.coroutines/isActive.<get-isActive>|<get-isActive>@kotlinx.coroutines.CoroutineScope(){}[0]
-final val kotlinx.coroutines/job // kotlinx.coroutines/job|@kotlin.coroutines.CoroutineContext{}job[0]
-    final fun (kotlin.coroutines/CoroutineContext).<get-job>(): kotlinx.coroutines/Job // kotlinx.coroutines/job.<get-job>|<get-job>@kotlin.coroutines.CoroutineContext(){}[0]
-final value class <#A: out kotlin/Any?> kotlinx.coroutines.channels/ChannelResult { // kotlinx.coroutines.channels/ChannelResult|null[0]
-    constructor <init>(kotlin/Any?) // kotlinx.coroutines.channels/ChannelResult.<init>|<init>(kotlin.Any?){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.equals|equals(kotlin.Any?){}[0]
-    final fun exceptionOrNull(): kotlin/Throwable? // kotlinx.coroutines.channels/ChannelResult.exceptionOrNull|exceptionOrNull(){}[0]
-    final fun getOrNull(): #A? // kotlinx.coroutines.channels/ChannelResult.getOrNull|getOrNull(){}[0]
-    final fun getOrThrow(): #A // kotlinx.coroutines.channels/ChannelResult.getOrThrow|getOrThrow(){}[0]
-    final fun hashCode(): kotlin/Int // kotlinx.coroutines.channels/ChannelResult.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // kotlinx.coroutines.channels/ChannelResult.toString|toString(){}[0]
-    final object Companion { // kotlinx.coroutines.channels/ChannelResult.Companion|null[0]
-        final fun <#A2: kotlin/Any?> closed(kotlin/Throwable?): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.closed|closed(kotlin.Throwable?){0§<kotlin.Any?>}[0]
-        final fun <#A2: kotlin/Any?> failure(): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.failure|failure(){0§<kotlin.Any?>}[0]
-        final fun <#A2: kotlin/Any?> success(#A2): kotlinx.coroutines.channels/ChannelResult<#A2> // kotlinx.coroutines.channels/ChannelResult.Companion.success|success(0:0){0§<kotlin.Any?>}[0]
-    }
-    final val holder // kotlinx.coroutines.channels/ChannelResult.holder|{}holder[0]
-        final fun <get-holder>(): kotlin/Any? // kotlinx.coroutines.channels/ChannelResult.holder.<get-holder>|<get-holder>(){}[0]
-    final val isClosed // kotlinx.coroutines.channels/ChannelResult.isClosed|{}isClosed[0]
-        final fun <get-isClosed>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isClosed.<get-isClosed>|<get-isClosed>(){}[0]
-    final val isFailure // kotlinx.coroutines.channels/ChannelResult.isFailure|{}isFailure[0]
-        final fun <get-isFailure>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isFailure.<get-isFailure>|<get-isFailure>(){}[0]
-    final val isSuccess // kotlinx.coroutines.channels/ChannelResult.isSuccess|{}isSuccess[0]
-        final fun <get-isSuccess>(): kotlin/Boolean // kotlinx.coroutines.channels/ChannelResult.isSuccess.<get-isSuccess>|<get-isSuccess>(){}[0]
-}
-open annotation class kotlinx.coroutines/DelicateCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/DelicateCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/DelicateCoroutinesApi.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/ExperimentalCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ExperimentalCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/ExperimentalCoroutinesApi.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/ExperimentalForInheritanceCoroutinesApi.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/FlowPreview : kotlin/Annotation { // kotlinx.coroutines/FlowPreview|null[0]
-    constructor <init>() // kotlinx.coroutines/FlowPreview.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/InternalCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/InternalCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/InternalCoroutinesApi.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/InternalForInheritanceCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/InternalForInheritanceCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/InternalForInheritanceCoroutinesApi.<init>|<init>(){}[0]
-}
-open annotation class kotlinx.coroutines/ObsoleteCoroutinesApi : kotlin/Annotation { // kotlinx.coroutines/ObsoleteCoroutinesApi|null[0]
-    constructor <init>() // kotlinx.coroutines/ObsoleteCoroutinesApi.<init>|<init>(){}[0]
-}
-open class <#A: in kotlin/Any?> kotlinx.coroutines/CancellableContinuationImpl : kotlinx.coroutines.internal/CoroutineStackFrame, kotlinx.coroutines/CancellableContinuation<#A>, kotlinx.coroutines/DispatchedTask<#A>, kotlinx.coroutines/Waiter { // kotlinx.coroutines/CancellableContinuationImpl|null[0]
-    constructor <init>(kotlin.coroutines/Continuation<#A>, kotlin/Int) // kotlinx.coroutines/CancellableContinuationImpl.<init>|<init>(kotlin.coroutines.Continuation<1:0>;kotlin.Int){}[0]
-    final fun <#A1: kotlin/Any?> callOnCancellation(kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>, kotlin/Throwable, #A1) // kotlinx.coroutines/CancellableContinuationImpl.callOnCancellation|callOnCancellation(kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>;kotlin.Throwable;0:0){0§<kotlin.Any?>}[0]
-    final fun callCancelHandler(kotlinx.coroutines/CancelHandler, kotlin/Throwable?) // kotlinx.coroutines/CancellableContinuationImpl.callCancelHandler|callCancelHandler(kotlinx.coroutines.CancelHandler;kotlin.Throwable?){}[0]
-    final fun getResult(): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.getResult|getResult(){}[0]
-    open fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatched(#A) // kotlinx.coroutines/CancellableContinuationImpl.resumeUndispatched|resumeUndispatched@kotlinx.coroutines.CoroutineDispatcher(1:0){}[0]
-    open fun (kotlinx.coroutines/CoroutineDispatcher).resumeUndispatchedWithException(kotlin/Throwable) // kotlinx.coroutines/CancellableContinuationImpl.resumeUndispatchedWithException|resumeUndispatchedWithException@kotlinx.coroutines.CoroutineDispatcher(kotlin.Throwable){}[0]
-    open fun <#A1: #A> resume(#A1, kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuationImpl.resume|resume(0:0;kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>?){0§<1:0>}[0]
-    open fun <#A1: #A> tryResume(#A1, kotlin/Any?, kotlin/Function3<kotlin/Throwable, #A1, kotlin.coroutines/CoroutineContext, kotlin/Unit>?): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResume|tryResume(0:0;kotlin.Any?;kotlin.Function3<kotlin.Throwable,0:0,kotlin.coroutines.CoroutineContext,kotlin.Unit>?){0§<1:0>}[0]
-    open fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.cancel|cancel(kotlin.Throwable?){}[0]
-    open fun completeResume(kotlin/Any) // kotlinx.coroutines/CancellableContinuationImpl.completeResume|completeResume(kotlin.Any){}[0]
-    open fun getContinuationCancellationCause(kotlinx.coroutines/Job): kotlin/Throwable // kotlinx.coroutines/CancellableContinuationImpl.getContinuationCancellationCause|getContinuationCancellationCause(kotlinx.coroutines.Job){}[0]
-    open fun getStackTraceElement(): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.getStackTraceElement|getStackTraceElement(){}[0]
-    open fun initCancellability() // kotlinx.coroutines/CancellableContinuationImpl.initCancellability|initCancellability(){}[0]
-    open fun invokeOnCancellation(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // kotlinx.coroutines/CancellableContinuationImpl.invokeOnCancellation|invokeOnCancellation(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    open fun invokeOnCancellation(kotlinx.coroutines.internal/Segment<*>, kotlin/Int) // kotlinx.coroutines/CancellableContinuationImpl.invokeOnCancellation|invokeOnCancellation(kotlinx.coroutines.internal.Segment<*>;kotlin.Int){}[0]
-    open fun nameString(): kotlin/String // kotlinx.coroutines/CancellableContinuationImpl.nameString|nameString(){}[0]
-    open fun resume(#A, kotlin/Function1<kotlin/Throwable, kotlin/Unit>?) // kotlinx.coroutines/CancellableContinuationImpl.resume|resume(1:0;kotlin.Function1<kotlin.Throwable,kotlin.Unit>?){}[0]
-    open fun resumeWith(kotlin/Result<#A>) // kotlinx.coroutines/CancellableContinuationImpl.resumeWith|resumeWith(kotlin.Result<1:0>){}[0]
-    open fun toString(): kotlin/String // kotlinx.coroutines/CancellableContinuationImpl.toString|toString(){}[0]
-    open fun tryResume(#A, kotlin/Any?): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResume|tryResume(1:0;kotlin.Any?){}[0]
-    open fun tryResumeWithException(kotlin/Throwable): kotlin/Any? // kotlinx.coroutines/CancellableContinuationImpl.tryResumeWithException|tryResumeWithException(kotlin.Throwable){}[0]
-    open val callerFrame // kotlinx.coroutines/CancellableContinuationImpl.callerFrame|{}callerFrame[0]
-        open fun <get-callerFrame>(): kotlinx.coroutines.internal/CoroutineStackFrame? // kotlinx.coroutines/CancellableContinuationImpl.callerFrame.<get-callerFrame>|<get-callerFrame>(){}[0]
-    open val context // kotlinx.coroutines/CancellableContinuationImpl.context|{}context[0]
-        open fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/CancellableContinuationImpl.context.<get-context>|<get-context>(){}[0]
-    open val isActive // kotlinx.coroutines/CancellableContinuationImpl.isActive|{}isActive[0]
-        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isActive.<get-isActive>|<get-isActive>(){}[0]
-    open val isCancelled // kotlinx.coroutines/CancellableContinuationImpl.isCancelled|{}isCancelled[0]
-        open fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
-    open val isCompleted // kotlinx.coroutines/CancellableContinuationImpl.isCompleted|{}isCompleted[0]
-        open fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/CancellableContinuationImpl.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
-}
-open class <#A: kotlin/Any?> kotlinx.coroutines.selects/SelectImplementation : kotlinx.coroutines.selects/SelectBuilder<#A>, kotlinx.coroutines.selects/SelectInstanceInternal<#A>, kotlinx.coroutines/CancelHandler { // kotlinx.coroutines.selects/SelectImplementation|null[0]
-    constructor <init>(kotlin.coroutines/CoroutineContext) // kotlinx.coroutines.selects/SelectImplementation.<init>|<init>(kotlin.coroutines.CoroutineContext){}[0]
-    final fun trySelectDetailed(kotlin/Any, kotlin/Any?): kotlinx.coroutines.selects/TrySelectDetailedResult // kotlinx.coroutines.selects/SelectImplementation.trySelectDetailed|trySelectDetailed(kotlin.Any;kotlin.Any?){}[0]
-    open fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
-    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
-    open fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
-    open fun disposeOnCompletion(kotlinx.coroutines/DisposableHandle) // kotlinx.coroutines.selects/SelectImplementation.disposeOnCompletion|disposeOnCompletion(kotlinx.coroutines.DisposableHandle){}[0]
-    open fun invoke(kotlin/Throwable?) // kotlinx.coroutines.selects/SelectImplementation.invoke|invoke(kotlin.Throwable?){}[0]
-    open fun invokeOnCancellation(kotlinx.coroutines.internal/Segment<*>, kotlin/Int) // kotlinx.coroutines.selects/SelectImplementation.invokeOnCancellation|invokeOnCancellation(kotlinx.coroutines.internal.Segment<*>;kotlin.Int){}[0]
-    open fun selectInRegistrationPhase(kotlin/Any?) // kotlinx.coroutines.selects/SelectImplementation.selectInRegistrationPhase|selectInRegistrationPhase(kotlin.Any?){}[0]
-    open fun trySelect(kotlin/Any, kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.selects/SelectImplementation.trySelect|trySelect(kotlin.Any;kotlin.Any?){}[0]
-    open suspend fun doSelect(): #A // kotlinx.coroutines.selects/SelectImplementation.doSelect|doSelect(){}[0]
-    open val context // kotlinx.coroutines.selects/SelectImplementation.context|{}context[0]
-        open fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.selects/SelectImplementation.context.<get-context>|<get-context>(){}[0]
-}
-open class <#A: kotlin/Any?> kotlinx.coroutines.selects/UnbiasedSelectImplementation : kotlinx.coroutines.selects/SelectImplementation<#A> { // kotlinx.coroutines.selects/UnbiasedSelectImplementation|null[0]
-    constructor <init>(kotlin.coroutines/CoroutineContext) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.<init>|<init>(kotlin.coroutines.CoroutineContext){}[0]
-    open fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
-    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
-    open fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/UnbiasedSelectImplementation.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
-    open suspend fun doSelect(): #A // kotlinx.coroutines.selects/UnbiasedSelectImplementation.doSelect|doSelect(){}[0]
-}
-open class kotlinx.coroutines/JobImpl : kotlinx.coroutines/CompletableJob, kotlinx.coroutines/JobSupport { // kotlinx.coroutines/JobImpl|null[0]
-    constructor <init>(kotlinx.coroutines/Job?) // kotlinx.coroutines/JobImpl.<init>|<init>(kotlinx.coroutines.Job?){}[0]
-    open fun complete(): kotlin/Boolean // kotlinx.coroutines/JobImpl.complete|complete(){}[0]
-    open fun completeExceptionally(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobImpl.completeExceptionally|completeExceptionally(kotlin.Throwable){}[0]
-}
-open class kotlinx.coroutines/JobSupport : kotlinx.coroutines/ChildJob, kotlinx.coroutines/Job, kotlinx.coroutines/ParentJob { // kotlinx.coroutines/JobSupport|null[0]
-    constructor <init>(kotlin/Boolean) // kotlinx.coroutines/JobSupport.<init>|<init>(kotlin.Boolean){}[0]
-    final fun (kotlin/Throwable).toCancellationException(kotlin/String? = ...): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.toCancellationException|toCancellationException@kotlin.Throwable(kotlin.String?){}[0]
-    final fun attachChild(kotlinx.coroutines/ChildJob): kotlinx.coroutines/ChildHandle // kotlinx.coroutines/JobSupport.attachChild|attachChild(kotlinx.coroutines.ChildJob){}[0]
-    final fun cancelCoroutine(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/JobSupport.cancelCoroutine|cancelCoroutine(kotlin.Throwable?){}[0]
-    final fun getCancellationException(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.getCancellationException|getCancellationException(){}[0]
-    final fun getCompletionExceptionOrNull(): kotlin/Throwable? // kotlinx.coroutines/JobSupport.getCompletionExceptionOrNull|getCompletionExceptionOrNull(){}[0]
-    final fun initParentJob(kotlinx.coroutines/Job?) // kotlinx.coroutines/JobSupport.initParentJob|initParentJob(kotlinx.coroutines.Job?){}[0]
-    final fun invokeOnCompletion(kotlin/Boolean, kotlin/Boolean, kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/JobSupport.invokeOnCompletion|invokeOnCompletion(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    final fun invokeOnCompletion(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines/JobSupport.invokeOnCompletion|invokeOnCompletion(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
-    final fun parentCancelled(kotlinx.coroutines/ParentJob) // kotlinx.coroutines/JobSupport.parentCancelled|parentCancelled(kotlinx.coroutines.ParentJob){}[0]
-    final fun start(): kotlin/Boolean // kotlinx.coroutines/JobSupport.start|start(){}[0]
-    final fun toDebugString(): kotlin/String // kotlinx.coroutines/JobSupport.toDebugString|toDebugString(){}[0]
-    final suspend fun awaitInternal(): kotlin/Any? // kotlinx.coroutines/JobSupport.awaitInternal|awaitInternal(){}[0]
-    final suspend fun join() // kotlinx.coroutines/JobSupport.join|join(){}[0]
-    final val children // kotlinx.coroutines/JobSupport.children|{}children[0]
-        final fun <get-children>(): kotlin.sequences/Sequence<kotlinx.coroutines/Job> // kotlinx.coroutines/JobSupport.children.<get-children>|<get-children>(){}[0]
-    final val completionCause // kotlinx.coroutines/JobSupport.completionCause|{}completionCause[0]
-        final fun <get-completionCause>(): kotlin/Throwable? // kotlinx.coroutines/JobSupport.completionCause.<get-completionCause>|<get-completionCause>(){}[0]
-    final val completionCauseHandled // kotlinx.coroutines/JobSupport.completionCauseHandled|{}completionCauseHandled[0]
-        final fun <get-completionCauseHandled>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.completionCauseHandled.<get-completionCauseHandled>|<get-completionCauseHandled>(){}[0]
-    final val isCancelled // kotlinx.coroutines/JobSupport.isCancelled|{}isCancelled[0]
-        final fun <get-isCancelled>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCancelled.<get-isCancelled>|<get-isCancelled>(){}[0]
-    final val isCompleted // kotlinx.coroutines/JobSupport.isCompleted|{}isCompleted[0]
-        final fun <get-isCompleted>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCompleted.<get-isCompleted>|<get-isCompleted>(){}[0]
-    final val isCompletedExceptionally // kotlinx.coroutines/JobSupport.isCompletedExceptionally|{}isCompletedExceptionally[0]
-        final fun <get-isCompletedExceptionally>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isCompletedExceptionally.<get-isCompletedExceptionally>|<get-isCompletedExceptionally>(){}[0]
-    final val key // kotlinx.coroutines/JobSupport.key|{}key[0]
-        final fun <get-key>(): kotlin.coroutines/CoroutineContext.Key<*> // kotlinx.coroutines/JobSupport.key.<get-key>|<get-key>(){}[0]
-    final val onAwaitInternal // kotlinx.coroutines/JobSupport.onAwaitInternal|{}onAwaitInternal[0]
-        final fun <get-onAwaitInternal>(): kotlinx.coroutines.selects/SelectClause1<*> // kotlinx.coroutines/JobSupport.onAwaitInternal.<get-onAwaitInternal>|<get-onAwaitInternal>(){}[0]
-    final val onJoin // kotlinx.coroutines/JobSupport.onJoin|{}onJoin[0]
-        final fun <get-onJoin>(): kotlinx.coroutines.selects/SelectClause0 // kotlinx.coroutines/JobSupport.onJoin.<get-onJoin>|<get-onJoin>(){}[0]
-    open fun afterCompletion(kotlin/Any?) // kotlinx.coroutines/JobSupport.afterCompletion|afterCompletion(kotlin.Any?){}[0]
-    open fun cancel(kotlin.coroutines.cancellation/CancellationException?) // kotlinx.coroutines/JobSupport.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    open fun cancel(kotlin/Throwable?): kotlin/Boolean // kotlinx.coroutines/JobSupport.cancel|cancel(kotlin.Throwable?){}[0]
-    open fun cancelInternal(kotlin/Throwable) // kotlinx.coroutines/JobSupport.cancelInternal|cancelInternal(kotlin.Throwable){}[0]
-    open fun cancellationExceptionMessage(): kotlin/String // kotlinx.coroutines/JobSupport.cancellationExceptionMessage|cancellationExceptionMessage(){}[0]
-    open fun childCancelled(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobSupport.childCancelled|childCancelled(kotlin.Throwable){}[0]
-    open fun getChildJobCancellationCause(): kotlin.coroutines.cancellation/CancellationException // kotlinx.coroutines/JobSupport.getChildJobCancellationCause|getChildJobCancellationCause(){}[0]
-    open fun handleJobException(kotlin/Throwable): kotlin/Boolean // kotlinx.coroutines/JobSupport.handleJobException|handleJobException(kotlin.Throwable){}[0]
-    open fun onCancelling(kotlin/Throwable?) // kotlinx.coroutines/JobSupport.onCancelling|onCancelling(kotlin.Throwable?){}[0]
-    open fun onCompletionInternal(kotlin/Any?) // kotlinx.coroutines/JobSupport.onCompletionInternal|onCompletionInternal(kotlin.Any?){}[0]
-    open fun onStart() // kotlinx.coroutines/JobSupport.onStart|onStart(){}[0]
-    open fun toString(): kotlin/String // kotlinx.coroutines/JobSupport.toString|toString(){}[0]
-    open val isActive // kotlinx.coroutines/JobSupport.isActive|{}isActive[0]
-        open fun <get-isActive>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isActive.<get-isActive>|<get-isActive>(){}[0]
-    open val isScopedCoroutine // kotlinx.coroutines/JobSupport.isScopedCoroutine|{}isScopedCoroutine[0]
-        open fun <get-isScopedCoroutine>(): kotlin/Boolean // kotlinx.coroutines/JobSupport.isScopedCoroutine.<get-isScopedCoroutine>|<get-isScopedCoroutine>(){}[0]
-    open val parent // kotlinx.coroutines/JobSupport.parent|{}parent[0]
-        open fun <get-parent>(): kotlinx.coroutines/Job? // kotlinx.coroutines/JobSupport.parent.<get-parent>|<get-parent>(){}[0]
-}
-sealed interface <#A: in kotlin/Any?, #B: out kotlin/Any?> kotlinx.coroutines.selects/SelectClause2 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause2|null[0]
-sealed interface <#A: in kotlin/Any?> kotlinx.coroutines.selects/SelectBuilder { // kotlinx.coroutines.selects/SelectBuilder|null[0]
-    abstract fun (kotlinx.coroutines.selects/SelectClause0).invoke(kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause0(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
-    abstract fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1, #B1>).invoke(#A1, kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0,0:1>(0:0;kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
-    abstract fun <#A1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause1<#A1>).invoke(kotlin.coroutines/SuspendFunction1<#A1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause1<0:0>(kotlin.coroutines.SuspendFunction1<0:0,1:0>){0§<kotlin.Any?>}[0]
-    open fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlinx.coroutines.selects/SelectClause2<#A1?, #B1>).invoke(kotlin.coroutines/SuspendFunction1<#B1, #A>) // kotlinx.coroutines.selects/SelectBuilder.invoke|invoke@kotlinx.coroutines.selects.SelectClause2<0:0?,0:1>(kotlin.coroutines.SuspendFunction1<0:1,1:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
-    open fun onTimeout(kotlin/Long, kotlin.coroutines/SuspendFunction0<#A>) // kotlinx.coroutines.selects/SelectBuilder.onTimeout|onTimeout(kotlin.Long;kotlin.coroutines.SuspendFunction0<1:0>){}[0]
-}
-sealed interface <#A: in kotlin/Any?> kotlinx.coroutines.selects/SelectInstance { // kotlinx.coroutines.selects/SelectInstance|null[0]
-    abstract fun disposeOnCompletion(kotlinx.coroutines/DisposableHandle) // kotlinx.coroutines.selects/SelectInstance.disposeOnCompletion|disposeOnCompletion(kotlinx.coroutines.DisposableHandle){}[0]
-    abstract fun selectInRegistrationPhase(kotlin/Any?) // kotlinx.coroutines.selects/SelectInstance.selectInRegistrationPhase|selectInRegistrationPhase(kotlin.Any?){}[0]
-    abstract fun trySelect(kotlin/Any, kotlin/Any?): kotlin/Boolean // kotlinx.coroutines.selects/SelectInstance.trySelect|trySelect(kotlin.Any;kotlin.Any?){}[0]
-    abstract val context // kotlinx.coroutines.selects/SelectInstance.context|{}context[0]
-        abstract fun <get-context>(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines.selects/SelectInstance.context.<get-context>|<get-context>(){}[0]
-}
-sealed interface <#A: out kotlin/Any?> kotlinx.coroutines.selects/SelectClause1 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause1|null[0]
-sealed interface kotlinx.coroutines.selects/SelectClause { // kotlinx.coroutines.selects/SelectClause|null[0]
-    abstract val clauseObject // kotlinx.coroutines.selects/SelectClause.clauseObject|{}clauseObject[0]
-        abstract fun <get-clauseObject>(): kotlin/Any // kotlinx.coroutines.selects/SelectClause.clauseObject.<get-clauseObject>|<get-clauseObject>(){}[0]
-    abstract val onCancellationConstructor // kotlinx.coroutines.selects/SelectClause.onCancellationConstructor|{}onCancellationConstructor[0]
-        abstract fun <get-onCancellationConstructor>(): kotlin/Function3<kotlinx.coroutines.selects/SelectInstance<*>, kotlin/Any?, kotlin/Any?, kotlin/Function3<kotlin/Throwable, kotlin/Any?, kotlin.coroutines/CoroutineContext, kotlin/Unit>>? // kotlinx.coroutines.selects/SelectClause.onCancellationConstructor.<get-onCancellationConstructor>|<get-onCancellationConstructor>(){}[0]
-    abstract val processResFunc // kotlinx.coroutines.selects/SelectClause.processResFunc|{}processResFunc[0]
-        abstract fun <get-processResFunc>(): kotlin/Function3<kotlin/Any, kotlin/Any?, kotlin/Any?, kotlin/Any?> // kotlinx.coroutines.selects/SelectClause.processResFunc.<get-processResFunc>|<get-processResFunc>(){}[0]
-    abstract val regFunc // kotlinx.coroutines.selects/SelectClause.regFunc|{}regFunc[0]
-        abstract fun <get-regFunc>(): kotlin/Function3<kotlin/Any, kotlinx.coroutines.selects/SelectInstance<*>, kotlin/Any?, kotlin/Unit> // kotlinx.coroutines.selects/SelectClause.regFunc.<get-regFunc>|<get-regFunc>(){}[0]
-}
-sealed interface kotlinx.coroutines.selects/SelectClause0 : kotlinx.coroutines.selects/SelectClause // kotlinx.coroutines.selects/SelectClause0|null[0]
-// Targets: [native]
-final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/SendChannel<#A>).kotlinx.coroutines.channels/sendBlocking(#A) // kotlinx.coroutines.channels/sendBlocking|sendBlocking@kotlinx.coroutines.channels.SendChannel<0:0>(0:0){0§<kotlin.Any?>}[0]
-// Targets: [native]
-final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/SendChannel<#A>).kotlinx.coroutines.channels/trySendBlocking(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/trySendBlocking|trySendBlocking@kotlinx.coroutines.channels.SendChannel<0:0>(0:0){0§<kotlin.Any?>}[0]
-// Targets: [native]
-final fun <#A: kotlin/Any?> kotlinx.coroutines/runBlocking(kotlin.coroutines/CoroutineContext = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): #A // kotlinx.coroutines/runBlocking|runBlocking(kotlin.coroutines.CoroutineContext;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
-// Targets: [native]
-final fun kotlinx.coroutines/newFixedThreadPoolContext(kotlin/Int, kotlin/String): kotlinx.coroutines/CloseableCoroutineDispatcher // kotlinx.coroutines/newFixedThreadPoolContext|newFixedThreadPoolContext(kotlin.Int;kotlin.String){}[0]
-// Targets: [native]
-final fun kotlinx.coroutines/newSingleThreadContext(kotlin/String): kotlinx.coroutines/CloseableCoroutineDispatcher // kotlinx.coroutines/newSingleThreadContext|newSingleThreadContext(kotlin.String){}[0]
+
 // Targets: [native]
 final val kotlinx.coroutines/IO // kotlinx.coroutines/IO|@kotlinx.coroutines.Dispatchers{}IO[0]
     final fun (kotlinx.coroutines/Dispatchers).<get-IO>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/IO.<get-IO>|<get-IO>@kotlinx.coroutines.Dispatchers(){}[0]
+
+// Targets: [native]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/SendChannel<#A>).kotlinx.coroutines.channels/sendBlocking(#A) // kotlinx.coroutines.channels/sendBlocking|sendBlocking@kotlinx.coroutines.channels.SendChannel<0:0>(0:0){0§<kotlin.Any?>}[0]
+
+// Targets: [native]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/SendChannel<#A>).kotlinx.coroutines.channels/trySendBlocking(#A): kotlinx.coroutines.channels/ChannelResult<kotlin/Unit> // kotlinx.coroutines.channels/trySendBlocking|trySendBlocking@kotlinx.coroutines.channels.SendChannel<0:0>(0:0){0§<kotlin.Any?>}[0]
+
+// Targets: [native]
+final fun <#A: kotlin/Any?> kotlinx.coroutines/runBlocking(kotlin.coroutines/CoroutineContext = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): #A // kotlinx.coroutines/runBlocking|runBlocking(kotlin.coroutines.CoroutineContext;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
+
+// Targets: [native]
+final fun kotlinx.coroutines/newFixedThreadPoolContext(kotlin/Int, kotlin/String): kotlinx.coroutines/CloseableCoroutineDispatcher // kotlinx.coroutines/newFixedThreadPoolContext|newFixedThreadPoolContext(kotlin.Int;kotlin.String){}[0]
+
+// Targets: [native]
+final fun kotlinx.coroutines/newSingleThreadContext(kotlin/String): kotlinx.coroutines/CloseableCoroutineDispatcher // kotlinx.coroutines/newSingleThreadContext|newSingleThreadContext(kotlin.String){}[0]
+
 // Targets: [js]
 final fun (org.w3c.dom/Window).kotlinx.coroutines/asCoroutineDispatcher(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/asCoroutineDispatcher|asCoroutineDispatcher@org.w3c.dom.Window(){}[0]
+
 // Targets: [js]
 final fun <#A: kotlin/Any?> (kotlin.js/Promise<#A>).kotlinx.coroutines/asDeferred(): kotlinx.coroutines/Deferred<#A> // kotlinx.coroutines/asDeferred|asDeferred@kotlin.js.Promise<0:0>(){0§<kotlin.Any?>}[0]
+
 // Targets: [js]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/CoroutineScope).kotlinx.coroutines/promise(kotlin.coroutines/CoroutineContext = ..., kotlinx.coroutines/CoroutineStart = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): kotlin.js/Promise<#A> // kotlinx.coroutines/promise|promise@kotlinx.coroutines.CoroutineScope(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.CoroutineStart;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
+
 // Targets: [js]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/Deferred<#A>).kotlinx.coroutines/asPromise(): kotlin.js/Promise<#A> // kotlinx.coroutines/asPromise|asPromise@kotlinx.coroutines.Deferred<0:0>(){0§<kotlin.Any?>}[0]
+
 // Targets: [js]
 final suspend fun (org.w3c.dom/Window).kotlinx.coroutines/awaitAnimationFrame(): kotlin/Double // kotlinx.coroutines/awaitAnimationFrame|awaitAnimationFrame@org.w3c.dom.Window(){}[0]
+
 // Targets: [js]
 final suspend fun <#A: kotlin/Any?> (kotlin.js/Promise<#A>).kotlinx.coroutines/await(): #A // kotlinx.coroutines/await|await@kotlin.js.Promise<0:0>(){0§<kotlin.Any?>}[0]
+
 // Targets: [wasmJs]
 final fun <#A: kotlin/Any?> (kotlin.js/Promise<kotlin.js/JsAny?>).kotlinx.coroutines/asDeferred(): kotlinx.coroutines/Deferred<#A> // kotlinx.coroutines/asDeferred|asDeferred@kotlin.js.Promise<kotlin.js.JsAny?>(){0§<kotlin.Any?>}[0]
+
 // Targets: [wasmJs]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/CoroutineScope).kotlinx.coroutines/promise(kotlin.coroutines/CoroutineContext = ..., kotlinx.coroutines/CoroutineStart = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): kotlin.js/Promise<kotlin.js/JsAny?> // kotlinx.coroutines/promise|promise@kotlinx.coroutines.CoroutineScope(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.CoroutineStart;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
+
 // Targets: [wasmJs]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/Deferred<#A>).kotlinx.coroutines/asPromise(): kotlin.js/Promise<kotlin.js/JsAny?> // kotlinx.coroutines/asPromise|asPromise@kotlinx.coroutines.Deferred<0:0>(){0§<kotlin.Any?>}[0]
+
 // Targets: [wasmJs]
 final suspend fun <#A: kotlin/Any?> (kotlin.js/Promise<kotlin.js/JsAny?>).kotlinx.coroutines/await(): #A // kotlinx.coroutines/await|await@kotlin.js.Promise<kotlin.js.JsAny?>(){0§<kotlin.Any?>}[0]

--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.klib.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.klib.api
@@ -7,25 +7,48 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.kotlinx:kotlinx-coroutines-test>
+sealed interface kotlinx.coroutines.test/TestScope : kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines.test/TestScope|null[0]
+    abstract val backgroundScope // kotlinx.coroutines.test/TestScope.backgroundScope|{}backgroundScope[0]
+        abstract fun <get-backgroundScope>(): kotlinx.coroutines/CoroutineScope // kotlinx.coroutines.test/TestScope.backgroundScope.<get-backgroundScope>|<get-backgroundScope>(){}[0]
+    abstract val testScheduler // kotlinx.coroutines.test/TestScope.testScheduler|{}testScheduler[0]
+        abstract fun <get-testScheduler>(): kotlinx.coroutines.test/TestCoroutineScheduler // kotlinx.coroutines.test/TestScope.testScheduler.<get-testScheduler>|<get-testScheduler>(){}[0]
+}
+
 abstract class kotlinx.coroutines.test/TestDispatcher : kotlinx.coroutines/CoroutineDispatcher, kotlinx.coroutines/Delay, kotlinx.coroutines/DelayWithTimeoutDiagnostics { // kotlinx.coroutines.test/TestDispatcher|null[0]
     abstract val scheduler // kotlinx.coroutines.test/TestDispatcher.scheduler|{}scheduler[0]
         abstract fun <get-scheduler>(): kotlinx.coroutines.test/TestCoroutineScheduler // kotlinx.coroutines.test/TestDispatcher.scheduler.<get-scheduler>|<get-scheduler>(){}[0]
+
     open fun invokeOnTimeout(kotlin/Long, kotlinx.coroutines/Runnable, kotlin.coroutines/CoroutineContext): kotlinx.coroutines/DisposableHandle // kotlinx.coroutines.test/TestDispatcher.invokeOnTimeout|invokeOnTimeout(kotlin.Long;kotlinx.coroutines.Runnable;kotlin.coroutines.CoroutineContext){}[0]
     open fun scheduleResumeAfterDelay(kotlin/Long, kotlinx.coroutines/CancellableContinuation<kotlin/Unit>) // kotlinx.coroutines.test/TestDispatcher.scheduleResumeAfterDelay|scheduleResumeAfterDelay(kotlin.Long;kotlinx.coroutines.CancellableContinuation<kotlin.Unit>){}[0]
     open fun timeoutMessage(kotlin.time/Duration): kotlin/String // kotlinx.coroutines.test/TestDispatcher.timeoutMessage|timeoutMessage(kotlin.time.Duration){}[0]
 }
+
 final class kotlinx.coroutines.test/TestCoroutineScheduler : kotlin.coroutines/AbstractCoroutineContextElement, kotlin.coroutines/CoroutineContext.Element { // kotlinx.coroutines.test/TestCoroutineScheduler|null[0]
     constructor <init>() // kotlinx.coroutines.test/TestCoroutineScheduler.<init>|<init>(){}[0]
+
+    final val timeSource // kotlinx.coroutines.test/TestCoroutineScheduler.timeSource|{}timeSource[0]
+        final fun <get-timeSource>(): kotlin.time/TimeSource.WithComparableMarks // kotlinx.coroutines.test/TestCoroutineScheduler.timeSource.<get-timeSource>|<get-timeSource>(){}[0]
+
+    final var currentTime // kotlinx.coroutines.test/TestCoroutineScheduler.currentTime|{}currentTime[0]
+        final fun <get-currentTime>(): kotlin/Long // kotlinx.coroutines.test/TestCoroutineScheduler.currentTime.<get-currentTime>|<get-currentTime>(){}[0]
+
     final fun advanceTimeBy(kotlin.time/Duration) // kotlinx.coroutines.test/TestCoroutineScheduler.advanceTimeBy|advanceTimeBy(kotlin.time.Duration){}[0]
     final fun advanceTimeBy(kotlin/Long) // kotlinx.coroutines.test/TestCoroutineScheduler.advanceTimeBy|advanceTimeBy(kotlin.Long){}[0]
     final fun advanceUntilIdle() // kotlinx.coroutines.test/TestCoroutineScheduler.advanceUntilIdle|advanceUntilIdle(){}[0]
     final fun runCurrent() // kotlinx.coroutines.test/TestCoroutineScheduler.runCurrent|runCurrent(){}[0]
+
     final object Key : kotlin.coroutines/CoroutineContext.Key<kotlinx.coroutines.test/TestCoroutineScheduler> // kotlinx.coroutines.test/TestCoroutineScheduler.Key|null[0]
-    final val timeSource // kotlinx.coroutines.test/TestCoroutineScheduler.timeSource|{}timeSource[0]
-        final fun <get-timeSource>(): kotlin.time/TimeSource.WithComparableMarks // kotlinx.coroutines.test/TestCoroutineScheduler.timeSource.<get-timeSource>|<get-timeSource>(){}[0]
-    final var currentTime // kotlinx.coroutines.test/TestCoroutineScheduler.currentTime|{}currentTime[0]
-        final fun <get-currentTime>(): kotlin/Long // kotlinx.coroutines.test/TestCoroutineScheduler.currentTime.<get-currentTime>|<get-currentTime>(){}[0]
 }
+
+final val kotlinx.coroutines.test/currentTime // kotlinx.coroutines.test/currentTime|@kotlinx.coroutines.test.TestScope{}currentTime[0]
+    final fun (kotlinx.coroutines.test/TestScope).<get-currentTime>(): kotlin/Long // kotlinx.coroutines.test/currentTime.<get-currentTime>|<get-currentTime>@kotlinx.coroutines.test.TestScope(){}[0]
+final val kotlinx.coroutines.test/testTimeSource // kotlinx.coroutines.test/testTimeSource|@kotlinx.coroutines.test.TestScope{}testTimeSource[0]
+    final fun (kotlinx.coroutines.test/TestScope).<get-testTimeSource>(): kotlin.time/TimeSource.WithComparableMarks // kotlinx.coroutines.test/testTimeSource.<get-testTimeSource>|<get-testTimeSource>@kotlinx.coroutines.test.TestScope(){}[0]
+
+final var kotlinx.coroutines.test/catchNonTestRelatedExceptions // kotlinx.coroutines.test/catchNonTestRelatedExceptions|{}catchNonTestRelatedExceptions[0]
+    final fun <get-catchNonTestRelatedExceptions>(): kotlin/Boolean // kotlinx.coroutines.test/catchNonTestRelatedExceptions.<get-catchNonTestRelatedExceptions>|<get-catchNonTestRelatedExceptions>(){}[0]
+    final fun <set-catchNonTestRelatedExceptions>(kotlin/Boolean) // kotlinx.coroutines.test/catchNonTestRelatedExceptions.<set-catchNonTestRelatedExceptions>|<set-catchNonTestRelatedExceptions>(kotlin.Boolean){}[0]
+
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/advanceTimeBy(kotlin.time/Duration) // kotlinx.coroutines.test/advanceTimeBy|advanceTimeBy@kotlinx.coroutines.test.TestScope(kotlin.time.Duration){}[0]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/advanceTimeBy(kotlin/Long) // kotlinx.coroutines.test/advanceTimeBy|advanceTimeBy@kotlinx.coroutines.test.TestScope(kotlin.Long){}[0]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/advanceUntilIdle() // kotlinx.coroutines.test/advanceUntilIdle|advanceUntilIdle@kotlinx.coroutines.test.TestScope(){}[0]
@@ -35,48 +58,50 @@ final fun (kotlinx.coroutines/Dispatchers).kotlinx.coroutines.test/setMain(kotli
 final fun kotlinx.coroutines.test/StandardTestDispatcher(kotlinx.coroutines.test/TestCoroutineScheduler? = ..., kotlin/String? = ...): kotlinx.coroutines.test/TestDispatcher // kotlinx.coroutines.test/StandardTestDispatcher|StandardTestDispatcher(kotlinx.coroutines.test.TestCoroutineScheduler?;kotlin.String?){}[0]
 final fun kotlinx.coroutines.test/TestScope(kotlin.coroutines/CoroutineContext = ...): kotlinx.coroutines.test/TestScope // kotlinx.coroutines.test/TestScope|TestScope(kotlin.coroutines.CoroutineContext){}[0]
 final fun kotlinx.coroutines.test/UnconfinedTestDispatcher(kotlinx.coroutines.test/TestCoroutineScheduler? = ..., kotlin/String? = ...): kotlinx.coroutines.test/TestDispatcher // kotlinx.coroutines.test/UnconfinedTestDispatcher|UnconfinedTestDispatcher(kotlinx.coroutines.test.TestCoroutineScheduler?;kotlin.String?){}[0]
-final val kotlinx.coroutines.test/currentTime // kotlinx.coroutines.test/currentTime|@kotlinx.coroutines.test.TestScope{}currentTime[0]
-    final fun (kotlinx.coroutines.test/TestScope).<get-currentTime>(): kotlin/Long // kotlinx.coroutines.test/currentTime.<get-currentTime>|<get-currentTime>@kotlinx.coroutines.test.TestScope(){}[0]
-final val kotlinx.coroutines.test/testTimeSource // kotlinx.coroutines.test/testTimeSource|@kotlinx.coroutines.test.TestScope{}testTimeSource[0]
-    final fun (kotlinx.coroutines.test/TestScope).<get-testTimeSource>(): kotlin.time/TimeSource.WithComparableMarks // kotlinx.coroutines.test/testTimeSource.<get-testTimeSource>|<get-testTimeSource>@kotlinx.coroutines.test.TestScope(){}[0]
-final var kotlinx.coroutines.test/catchNonTestRelatedExceptions // kotlinx.coroutines.test/catchNonTestRelatedExceptions|{}catchNonTestRelatedExceptions[0]
-    final fun <get-catchNonTestRelatedExceptions>(): kotlin/Boolean // kotlinx.coroutines.test/catchNonTestRelatedExceptions.<get-catchNonTestRelatedExceptions>|<get-catchNonTestRelatedExceptions>(){}[0]
-    final fun <set-catchNonTestRelatedExceptions>(kotlin/Boolean) // kotlinx.coroutines.test/catchNonTestRelatedExceptions.<set-catchNonTestRelatedExceptions>|<set-catchNonTestRelatedExceptions>(kotlin.Boolean){}[0]
-sealed interface kotlinx.coroutines.test/TestScope : kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines.test/TestScope|null[0]
-    abstract val backgroundScope // kotlinx.coroutines.test/TestScope.backgroundScope|{}backgroundScope[0]
-        abstract fun <get-backgroundScope>(): kotlinx.coroutines/CoroutineScope // kotlinx.coroutines.test/TestScope.backgroundScope.<get-backgroundScope>|<get-backgroundScope>(){}[0]
-    abstract val testScheduler // kotlinx.coroutines.test/TestScope.testScheduler|{}testScheduler[0]
-        abstract fun <get-testScheduler>(): kotlinx.coroutines.test/TestCoroutineScheduler // kotlinx.coroutines.test/TestScope.testScheduler.<get-testScheduler>|<get-testScheduler>(){}[0]
-}
+
 // Targets: [native, wasmWasi]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTest(kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>) // kotlinx.coroutines.test/runTest|runTest@kotlinx.coroutines.test.TestScope(kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [native, wasmWasi]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTest(kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>) // kotlinx.coroutines.test/runTest|runTest@kotlinx.coroutines.test.TestScope(kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [native, wasmWasi]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTestLegacy(kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>, kotlin/Int, kotlin/Any?) // kotlinx.coroutines.test/runTestLegacy|runTestLegacy@kotlinx.coroutines.test.TestScope(kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>;kotlin.Int;kotlin.Any?){}[0]
+
 // Targets: [native, wasmWasi]
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>) // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [native, wasmWasi]
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>) // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [js, wasmJs]
 final class kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting { // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting|null[0]
     constructor <init>() // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.<init>|<init>(){}[0]
+
     // Targets: [js]
     final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>){}[0]
+
     // Targets: [js]
     final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>, kotlin/Function1<kotlin/Throwable, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>;kotlin.Function1<kotlin.Throwable,kotlin.Unit>){}[0]
+
     // Targets: [wasmJs]
     final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
+
     // Targets: [wasmJs]
     final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>, kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>;kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
 }
+
 // Targets: [js, wasmJs]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTest(kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest@kotlinx.coroutines.test.TestScope(kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [js, wasmJs]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTest(kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest@kotlinx.coroutines.test.TestScope(kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [js, wasmJs]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTestLegacy(kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>, kotlin/Int, kotlin/Any?): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTestLegacy|runTestLegacy@kotlinx.coroutines.test.TestScope(kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>;kotlin.Int;kotlin.Any?){}[0]
+
 // Targets: [js, wasmJs]
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
 // Targets: [js, wasmJs]
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]


### PR DESCRIPTION
Refresh the API dump without code changes. Fix the order of items in the dump after updating to a newer version of the compatibility-validator. Version updates without dump refreshing were possible due to https://github.com/Kotlin/binary-compatibility-validator/issues/260