### PR TITLE
Preparation commit for KT-70562

### DIFF
--- a/kotlinx-coroutines-core/common/src/CompletableDeferred.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableDeferred.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.selects.*
  * be safely invoked from concurrent coroutines without external synchronization.
  */
 @OptIn(ExperimentalSubclassOptIn::class)
-@SubclassOptInRequired(markerClass = InternalForInheritanceCoroutinesApi::class)
+@SubclassOptInRequired(InternalForInheritanceCoroutinesApi::class)
 public interface CompletableDeferred<T> : Deferred<T> {
     /**
      * Completes this deferred value with a given [value]. The result is `true` if this deferred was

--- a/kotlinx-coroutines-core/common/src/CompletableJob.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableJob.kt
@@ -11,7 +11,7 @@ package kotlinx.coroutines
  * as new methods might be added to this interface in the future, but is stable for use.
  */
 @OptIn(ExperimentalSubclassOptIn::class)
-@SubclassOptInRequired(markerClass = InternalForInheritanceCoroutinesApi::class)
+@SubclassOptInRequired(InternalForInheritanceCoroutinesApi::class)
 public interface CompletableJob : Job {
     /**
      * Completes this job. The result is `true` if this job was completed as a result of this invocation and

--- a/kotlinx-coroutines-core/common/src/Deferred.kt
+++ b/kotlinx-coroutines-core/common/src/Deferred.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.selects.*
  * be safely invoked from concurrent coroutines without external synchronization.
  */
 @OptIn(ExperimentalSubclassOptIn::class)
-@SubclassOptInRequired(markerClass = InternalForInheritanceCoroutinesApi::class)
+@SubclassOptInRequired(InternalForInheritanceCoroutinesApi::class)
 public interface Deferred<out T> : Job {
 
     /**

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -101,7 +101,7 @@ import kotlin.jvm.*
  * be safely invoked from concurrent coroutines without external synchronization.
  */
 @OptIn(ExperimentalSubclassOptIn::class)
-@SubclassOptInRequired(markerClass = InternalForInheritanceCoroutinesApi::class)
+@SubclassOptInRequired(InternalForInheritanceCoroutinesApi::class)
 public interface Job : CoroutineContext.Element {
     /**
      * Key for [Job] instance in the coroutine context.


### PR DESCRIPTION
The SubclassOptInRequired annotation will accept multiple markers in arguments. This fix is required to maintain source compatibility.