### PR TITLE
Remove unnecessary lambda pointer from first(predicate) error message.

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
+++ b/kotlinx-coroutines-core/common/src/flow/terminal/Reduce.kt
@@ -107,7 +107,7 @@ public suspend fun <T> Flow<T>.first(predicate: suspend (T) -> Boolean): T {
             true
         }
     }
-    if (result === NULL) throw NoSuchElementException("Expected at least one element matching the predicate $predicate")
+    if (result === NULL) throw NoSuchElementException("Expected at least one element matching the predicate")
     return result as T
 }
 


### PR DESCRIPTION
When `first` is called on a flow that doesn't satisfy the predicate it throws a `NoSuchElementException` with the message `"Expected at least one element matching the predicate $predicate"`. The use of `$predicate` implies printing out the lambda however, the lambda's pointer is printed instead.

As far as I know, getting the lambda's string representation is not feasible. Therefore I feel it is best to remove `$predicate` from the error message to make it more readable and remove unnecessary information.

For example, running
`flowOf(1, 2, 3).first {it > 4}` https://pl.kotl.in/jjalTWjTt
returns the error message
```
Exception in thread "main" java.util.NoSuchElementException: Expected at least one element matching the predicate Function2&amp;lt;java.lang.Integer, kotlin.coroutines.Continuation&amp;lt;? super java.lang.Boolean&amp;gt;, java.lang.Object&amp;gt;
 at kotlinx.coroutines.flow.FlowKt__ReduceKt.first (Reduce.kt:114) 
 at kotlinx.coroutines.flow.FlowKt.first (:1) 
 at kotlinx.coroutines.guide.exampleFlow07.FileKt.main (File.kt:8) 
```

Where the predicate `flowOf(1, 2, 3).first {it > 4}` evaluates too `Function2&amp;lt;java.lang.Integer, kotlin.coroutines.Continuation&amp;lt;? super java.lang.Boolean&amp;gt;, java.lang.Object&amp;gt;`

I feel that there is no added value from the lambda pointer being printed. It seems better for the developer to use the line number and read the lambda from source code.