### PR TITLE
Fix a flaky test

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/JobChildStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/JobChildStressTest.kt
@@ -89,10 +89,14 @@ class JobChildStressTest : TestBase() {
                 launch(pool + deferred) {
                     deferred.complete(Unit) // Transition deferred into "completing" state waiting for current child
                     // **Asynchronously** submit task that launches a child so it races with completion
-                    pool.executor.execute {
-                        rogueJob.set(launch(pool + deferred) {
-                            throw TestException("isCancelled: ${coroutineContext.job.isCancelled}")
-                        })
+                    try {
+                        pool.executor.execute {
+                            rogueJob.set(launch(pool + deferred) {
+                                throw TestException("isCancelled: ${coroutineContext.job.isCancelled}")
+                            })
+                        }
+                    } catch (_: RejectedExecutionException) {
+                        // This is expected if the pool is closed
                     }
                 }
 


### PR DESCRIPTION
The failure was:
```
java.lang.IllegalStateException: Expected no uncaught exceptions, but got [java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@74b39729[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@151f06ce[Wrapped task = DispatchedContinuation[ThreadPoolDispatcher[3, JobChildStressTest], Continuation at kotlinx.coroutines.JobChildStressTest$testChildAttachmentRacingWithLastChildCompletion$1$1$2$1$1.invokeSuspend(JobChildStressTest.kt)@501d9a09]]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@6187288d[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 29998]]
  at kotlinx.coroutines.testing.TestBase_commonKt.error(TestBase.common.kt:167)
  at kotlinx.coroutines.testing.TestBase_commonKt.error$default(TestBase.common.kt:166)
  at kotlinx.coroutines.testing.TestBase.onCompletion(TestBase.kt:125)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:566)
  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
  at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
  at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
  at org.junit.internal.runners.statements.RunAfters.invokeMethod(RunAfters.java:46)
  at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
  at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
  at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
  at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
  at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
  at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
  at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
  at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
  at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
  at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
  at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
  at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
  at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
  at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
  at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
  at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
  at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:566)
  at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
  at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
  at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
  at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
  at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
  at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
  at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
  at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
  at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
  at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
  at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
  at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
  at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
  at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
------- Stdout: -------
Exception in thread Thread[JobChildStressTest-2,5,main]: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@74b39729[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@151f06ce[Wrapped task = DispatchedContinuation[ThreadPoolDispatcher[3, JobChildStressTest], Continuation at kotlinx.coroutines.JobChildStressTest$testChildAttachmentRacingWithLastChildCompletion$1$1$2$1$1.invokeSuspend(JobChildStressTest.kt)@501d9a09]]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@6187288d[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 29998]
------- Stderr: -------
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@74b39729[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@151f06ce[Wrapped task = DispatchedContinuation[ThreadPoolDispatcher[3, JobChildStressTest], Continuation at kotlinx.coroutines.JobChildStressTest$testChildAttachmentRacingWithLastChildCompletion$1$1$2$1$1.invokeSuspend(JobChildStressTest.kt)@501d9a09]]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@6187288d[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 29998]
  at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2055)
  at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:825)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:562)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.execute(ScheduledThreadPoolExecutor.java:705)
  at kotlinx.coroutines.ClosedAfterGuideTestDispatcher.dispatch(ClosedAfterGuideTestExecutor.kt:31)
  at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:302)
  at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
  at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
  at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:124)
  at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
  at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
  at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
  at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
  at kotlinx.coroutines.JobChildStressTest$testChildAttachmentRacingWithLastChildCompletion$1$1$2.invokeSuspend$lambda$0(JobChildStressTest.kt:93)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  at java.base/java.lang.Thread.run(Thread.java:829)
  Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [CoroutineId(669013), "coroutine#669013":StandaloneCoroutine{Cancelling}@6176fee, ThreadPoolDispatcher[3, JobChildStressTest]]
```