### PR TITLE
Replace a usage of deprecated String.toLowerCase()

### DIFF
--- a/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/ShakespearePlaysScrabble.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/ShakespearePlaysScrabble.kt
@@ -66,7 +66,7 @@ abstract class ShakespearePlaysScrabble {
 
     private fun readResource(path: String) =
         BufferedReader(InputStreamReader(GZIPInputStream(this.javaClass.classLoader.getResourceAsStream(path)))).lines()
-            .map { it.toLowerCase() }.collect(Collectors.toSet())
+            .map { it.lowercase() }.collect(Collectors.toSet())
 
     init {
         val expected = listOf(120 to listOf("jezebel", "quickly"),


### PR DESCRIPTION
The function was deprecated with warning in Kotlin 1.5. In Kotlin 2.1 the deprecation level will be raised to error.

This is a blocker for https://youtrack.jetbrains.com/issue/KT-71628