### PR TITLE
Update the documentation for the Channel interface

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferOverflow.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferOverflow.kt
@@ -13,7 +13,7 @@ package kotlinx.coroutines.channels
  */
 public enum class BufferOverflow {
     /**
-     * Suspend on buffer overflow.
+     * Suspend until free space appears in the buffer.
      *
      * Use this to create backpressure, forcing the producers to slow down creation of new values in response to
      * consumers not being able to process the incoming values in time.

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1185,7 +1185,7 @@ public interface ChannelIterator<out E> {
  * which can happen in the following cases:
  *
  * - When an element is dropped due to the limited buffer capacity.
- *   This can happen when the overflow strategy is [BufferOverflow.DROP_LATEST] and [BufferOverflow.DROP_OLDEST].
+ *   This can happen when the overflow strategy is [BufferOverflow.DROP_LATEST] or [BufferOverflow.DROP_OLDEST].
  * - When the sending operations like [send][SendChannel.send] or [onSend][SendChannel.onSend]
  *   throw an exception because it was cancelled
  *   before it had a chance to actually send the element

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -403,7 +403,7 @@ public interface ReceiveChannel<out E> {
      * ```
      * // DANGER! THIS CHECK IS NOT RELIABLE!
      * while (!channel.isEmpty) {
-     *     // can still suspend in other `receive` happens in parallel!
+     *     // can still suspend if other `receive` happens in parallel!
      *     val element = channel.receive()
      *     println(element)
      * }

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1070,7 +1070,7 @@ public interface ChannelIterator<out E> {
      *
      * Note that this function does not check for cancellation when it is not suspended, that is,
      * if the next element is immediately available.
-     * Use [yield] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
+     * Use [ensureActive] or [CoroutineScope.isActive] to periodically check for cancellation in tight loops if needed.
      */
     public suspend operator fun hasNext(): Boolean
 

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -475,7 +475,7 @@ public interface ReceiveChannel<out E> {
      * ## Related
      *
      * This function can be used in [select] invocations with the [onReceive] clause.
-     * Use [tryReceive] to try receiving from this channel without waiting.
+     * Use [tryReceive] to try receiving from this channel without waiting and throwing.
      * Use [receiveCatching] to receive from this channel without throwing.
      */
     public suspend fun receive(): E

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -652,7 +652,7 @@ public interface ReceiveChannel<out E> {
      * }
      * ```
      *
-     * Note that is an early return happens from the `for` loop, the channel does not get cancelled.
+     * Note that if an early return happens from the `for` loop, the channel does not get cancelled.
      * To forbid sending new elements after the iteration is completed, use [consumeEach] or
      * call [close] manually.
      */

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -906,7 +906,7 @@ public value class ChannelResult<out T>
      *  }
      *  ```
      *
-     *  @throws IllegalStateException if the operation failed, but the channel was not claused with a cause.
+     *  @throws IllegalStateException if the operation failed, but the channel was not closed with a cause.
      */
     public fun getOrThrow(): T {
         @Suppress("UNCHECKED_CAST")

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -585,7 +585,7 @@ public interface ReceiveChannel<out E> {
      * ## Related
      *
      * This function can be used in [select] invocations with the [onReceiveCatching] clause.
-     * Use [tryReceive] to try receiving from this channel without waiting.
+     * Use [tryReceive] to try receiving from this channel without waiting and throwing.
      * Use [receive] to receive from this channel and throw exceptions on error.
      */
     public suspend fun receiveCatching(): ChannelResult<E>

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1174,7 +1174,7 @@ public interface ChannelIterator<out E> {
  * it can be successfully extracted from the channel,
  * but still be lost if the receiving operation is cancelled in parallel.
  *
- * The `Channel()` constructor function has the optional parameter `onUndeliveredElement`.
+ * The `Channel()` factory function has the optional parameter `onUndeliveredElement`.
  * When that parameter is set, the corresponding function is called once for each element
  * that was sent to the channel with the call to the [send][SendChannel.send] function but failed to be delivered,
  * which can happen in the following cases:

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1319,7 +1319,7 @@ public interface Channel<E> : SendChannel<E>, ReceiveChannel<E> {
          * }
          * channel.close()
          * // The check can fail if the default buffer capacity is changed
-         * check(channel.toList() == (0 until 64).toList())
+         * check(channel.toList() == (0..<64).toList())
          * ```
          *
          * If a different [BufferOverflow] is specified, `Channel(BUFFERED)` creates a channel with a buffer of size 1:

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -654,7 +654,7 @@ public interface ReceiveChannel<out E> {
      *
      * Note that if an early return happens from the `for` loop, the channel does not get cancelled.
      * To forbid sending new elements after the iteration is completed, use [consumeEach] or
-     * call [close] manually.
+     * call [cancel] manually.
      */
     public operator fun iterator(): ChannelIterator<E>
 

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -115,9 +115,9 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * channel.cancel()
  * ```
  *
- * If this coroutine finishes with an exception, it will close the channel with that exception as the cause and
- * the resulting channel will become _failed_, so after receiving all the existing elements, all further attempts
- * to receive from it will throw the exception with which the coroutine finished.
+ * If this coroutine finishes with an exception, it will close the channel with that exception as the cause,
+ * so after receiving all the existing elements,
+ * all further attempts to receive from it will throw the exception with which the coroutine finished.
  *
  * ```
  * val produceJob = Job()
@@ -151,8 +151,7 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * } // throws a `CancellationException` exception after reaching -1
  * ```
  *
- * Note that cancelling `produce` via structured concurrency closes the channel with a cause,
- * making it a _failed_ channel.
+ * Note that cancelling `produce` via structured concurrency closes the channel with a cause.
  *
  * The behavior around coroutine cancellation and error handling is experimental and may change in a future release.
  *

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -81,6 +81,7 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * The kind of the resulting channel depends on the specified [capacity] parameter.
  * See the [Channel] interface documentation for details.
  * By default, an unbuffered channel is created.
+ * If an invalid [capacity] value is specified, an [IllegalArgumentException] is thrown.
  *
  * ### Behavior on termination
  *

--- a/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/BufferedChannelTest.kt
@@ -5,6 +5,20 @@ import kotlinx.coroutines.*
 import kotlin.test.*
 
 class BufferedChannelTest : TestBase() {
+
+    /** Tests that a buffered channel does not consume enough memory to fail with an OOM. */
+    @Test
+    fun testMemoryConsumption() = runTest {
+        val largeChannel = Channel<Int>(Int.MAX_VALUE / 2)
+        repeat(10_000) {
+            largeChannel.send(it)
+        }
+        repeat(10_000) {
+            val element = largeChannel.receive()
+            assertEquals(it, element)
+        }
+    }
+
     @Test
     fun testIteratorHasNextIsIdempotent() = runTest {
         val q = Channel<Int>()

--- a/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/ProduceTest.kt
@@ -266,6 +266,13 @@ class ProduceTest : TestBase() {
         }
     }
 
+    @Test
+    fun testProduceWithInvalidCapacity() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            produce<Int>(capacity = -3) { }
+        }
+    }
+
     private suspend fun cancelOnCompletion(coroutineContext: CoroutineContext) = CoroutineScope(coroutineContext).apply {
         val source = Channel<Int>()
         expect(1)

--- a/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/channels/RendezvousChannelTest.kt
@@ -273,4 +273,24 @@ class RendezvousChannelTest : TestBase() {
         channel.cancel(TestCancellationException())
         channel.receiveCatching().getOrThrow()
     }
+
+    /** Tests that [BufferOverflow.DROP_OLDEST] takes precedence over [Channel.RENDEZVOUS]. */
+    @Test
+    fun testDropOldest() = runTest {
+        val channel = Channel<Int>(Channel.RENDEZVOUS, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+        channel.send(1)
+        channel.send(2)
+        channel.send(3)
+        assertEquals(3, channel.receive())
+    }
+
+    /** Tests that [BufferOverflow.DROP_LATEST] takes precedence over [Channel.RENDEZVOUS]. */
+    @Test
+    fun testDropLatest() = runTest {
+        val channel = Channel<Int>(Channel.RENDEZVOUS, onBufferOverflow = BufferOverflow.DROP_LATEST)
+        channel.send(1)
+        channel.send(2)
+        channel.send(3)
+        assertEquals(1, channel.receive())
+    }
 }

--- a/kotlinx-coroutines-core/common/test/selects/SelectRendezvousChannelTest.kt
+++ b/kotlinx-coroutines-core/common/test/selects/SelectRendezvousChannelTest.kt
@@ -419,10 +419,10 @@ class SelectRendezvousChannelTest : TestBase() {
     fun testSelectSendWhenClosed() = runTest {
         expect(1)
         val c = Channel<Int>(Channel.RENDEZVOUS)
-        val sender = launch(start = CoroutineStart.UNDISPATCHED) {
+        launch(start = CoroutineStart.UNDISPATCHED) {
             expect(2)
             c.send(1) // enqueue sender
-            expectUnreached()
+            finish(4)
         }
         c.close() // then close
         assertFailsWith<ClosedSendChannelException> {
@@ -434,8 +434,7 @@ class SelectRendezvousChannelTest : TestBase() {
                 }
             }
         }
-        sender.cancel()
-        finish(4)
+        assertEquals(1, c.receive())
     }
 
     // only for debugging

--- a/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
+++ b/kotlinx-coroutines-core/jvm/src/channels/Actor.kt
@@ -45,8 +45,8 @@ public interface ActorScope<E> : CoroutineScope, ReceiveChannel<E> {
  * it will be started implicitly on the first message
  * [sent][SendChannel.send] to this actors's mailbox channel.
  *
- * Uncaught exceptions in this coroutine close the channel with this exception as a cause and
- * the resulting channel becomes _failed_, so that any attempt to send to such a channel throws exception.
+ * Uncaught exceptions in this coroutine close the channel with this exception as a cause,
+ * so that any attempt to send to such a channel throws exception.
  *
  * The kind of the resulting channel depends on the specified [capacity] parameter.
  * See [Channel] interface documentation for details.

--- a/kotlinx-coroutines-core/jvm/test/channels/CancelledChannelLeakTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/CancelledChannelLeakTest.kt
@@ -1,0 +1,27 @@
+package kotlinx.coroutines.channels
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.testing.*
+import kotlin.test.*
+
+class CancelledChannelLeakTest : TestBase() {
+    /**
+     * Tests that cancellation removes the elements from the channel's buffer.
+     */
+    @Test
+    fun testBufferedChannelLeak() = runTest {
+        for (capacity in listOf(Channel.CONFLATED, Channel.RENDEZVOUS, 1, 2, 5, 10)) {
+            val channel = Channel<X>(capacity)
+            val value = X()
+            launch(start = CoroutineStart.UNDISPATCHED) {
+                channel.send(value)
+            }
+            FieldWalker.assertReachableCount(1, channel) { it === value }
+            channel.cancel()
+            // the element must be removed so that there is no memory leak
+            FieldWalker.assertReachableCount(0, channel) { it === value }
+        }
+    }
+
+    class X
+}


### PR DESCRIPTION
Note: a major piece of terminology that's changed in this is that when a channel is closed with a cause, it's no longer called a "failed channel". I found it immensely confusing to have `channelResult.isClosed` that means "the channel is closed", but `channelResult.isFailed` that doesn't mean "the channel is failed". Also, every cancelled channel is a "failed" channel by the definition of being closed with a cause, which doesn't seem to be the intention. So, I suggest that we remove mentions of "failed channels" throughout and replace them with "closed with a cause". Luckily, it's only relevant in a limited number of places.