### PR TITLE
Remove star import of the packages, which contain conflicting declarations

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureTest.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.*
 import java.util.concurrent.atomic.*
 import java.util.concurrent.locks.*
 import java.util.function.*
-import kotlin.concurrent.*
+import kotlin.concurrent.withLock
 import kotlin.coroutines.*
 import kotlin.reflect.*
 import kotlin.test.*


### PR DESCRIPTION
Star imports of `java.util.concurrent.atomic.*` and `kotlin.concurrent.*` will lead to the compilation error: once Atomic classes are introduced in `kotlin.concurrent` package, they will conflict with Java atomic classes, which have the same names.