### PR TITLE
fix(jvm): make job cancellation hashcode not fail after deserialization

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -61,6 +61,6 @@ internal actual class JobCancellationException public actual constructor(
     override fun equals(other: Any?): Boolean =
         other === this ||
             other is JobCancellationException && other.message == message && other.job == job && other.cause == cause
-    override fun hashCode(): Int =
-        (message!!.hashCode() * 31 + job.hashCode()) * 31 + (cause?.hashCode() ?: 0)
+    override fun hashCode(): Int = /* since job is transient it is indeed nullable after deserialization */
+        (message!!.hashCode() * 31 + (job?.hashCode() ?: 0)) * 31 + (cause?.hashCode() ?: 0)
 }

--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -61,6 +61,10 @@ internal actual class JobCancellationException public actual constructor(
     override fun equals(other: Any?): Boolean =
         other === this ||
             other is JobCancellationException && other.message == message && other.job == job && other.cause == cause
-    override fun hashCode(): Int = /* since job is transient it is indeed nullable after deserialization */
-        (message!!.hashCode() * 31 + (job?.hashCode() ?: 0)) * 31 + (cause?.hashCode() ?: 0)
+
+    override fun hashCode(): Int {
+        // since job is transient it is indeed nullable after deserialization
+        @Suppress("UNNECESSARY_SAFE_CALL")
+        return (message!!.hashCode() * 31 + (job?.hashCode() ?: 0)) * 31 + (cause?.hashCode() ?: 0)
+    }
 }

--- a/kotlinx-coroutines-core/jvm/test/JobCancellationExceptionSerializerTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/JobCancellationExceptionSerializerTest.kt
@@ -41,16 +41,15 @@ class JobCancellationExceptionSerializerTest : TestBase() {
     fun testHashCodeAfterDeserialization() = runTest {
         try {
             coroutineScope {
-                val job = launch {
-                    hang {}
-                }
+                expect(1)
                 throw JobCancellationException(
                     message = "Job Cancelled",
-                    job = job,
+                    job = Job(),
                     cause = null,
                 )
             }
         } catch (e: Throwable) {
+            finish(2)
             val outputStream = ByteArrayOutputStream()
             ObjectOutputStream(outputStream).use {
                 it.writeObject(e)

--- a/kotlinx-coroutines-core/jvm/test/JobCancellationExceptionSerializerTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/JobCancellationExceptionSerializerTest.kt
@@ -36,4 +36,31 @@ class JobCancellationExceptionSerializerTest : TestBase() {
             finish(4)
         }
     }
+
+    @Test
+    fun testHashCodeAfterDeserialization() = runTest {
+        try {
+            coroutineScope {
+                val job = launch {
+                    hang {}
+                }
+                throw JobCancellationException(
+                    message = "Job Cancelled",
+                    job = job,
+                    cause = null,
+                )
+            }
+        } catch (e: Throwable) {
+            val outputStream = ByteArrayOutputStream()
+            ObjectOutputStream(outputStream).use {
+                it.writeObject(e)
+            }
+            val deserializedException =
+                ObjectInputStream(outputStream.toByteArray().inputStream()).use {
+                it.readObject() as JobCancellationException
+            }
+            // verify hashCode does not fail even though Job is transient
+            assert(deserializedException.hashCode() != 0)
+        }
+    }
 }


### PR DESCRIPTION
### Summary

On JVM `JobCancellationException` is Serializable, but `job` field is nullable and Transient:

```kt
@JvmField @Transient internal actual val job: Job
```

as a result `job` is null after deserialization, so when `hashCode()` is ran on the exception, it results in null pointer exception. This change is to fix this issue by handling nullability of the `job` field.

Exception from Production while running Apache Flink:

```
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "this.job" is null
	at kotlinx.coroutines.JobCancellationException.hashCode(Exceptions.kt:65)
	at java.base/java.util.HashMap.hash(Unknown Source)
	at java.base/java.util.HashMap.put(Unknown Source)
	at java.base/java.util.HashSet.add(Unknown Source)
	at org.apache.flink.util.SerializedThrowable.<init>(SerializedThrowable.java:91)
	at org.apache.flink.util.SerializedThrowable.<init>(SerializedThrowable.java:93)
	at org.apache.flink.util.SerializedThrowable.<init>(SerializedThrowable.java:62)
	at org.apache.flink.runtime.executiongraph.ErrorInfo.<init>(ErrorInfo.java:72)
	at org.apache.flink.runtime.executiongraph.ErrorInfo.createErrorInfoWithNullableCause(ErrorInfo.java:52)
	at org.apache.flink.runtime.executiongraph.Execution.processFail(Execution.java:1154)
	at org.apache.flink.runtime.executiongraph.Execution.markFailed(Execution.java:933)
	at org.apache.flink.runtime.executiongraph.DefaultExecutionGraph.updateStateInternal(DefaultExecutionGraph.java:1396)
	at org.apache.flink.runtime.executiongraph.DefaultExecutionGraph.updateState(DefaultExecutionGraph.java:1355)
	at org.apache.flink.runtime.scheduler.SchedulerBase.updateTaskExecutionState(SchedulerBase.java:763)
	at org.apache.flink.runtime.scheduler.SchedulerNG.updateTaskExecutionState(SchedulerNG.java:83)
	at org.apache.flink.runtime.jobmaster.JobMaster.updateTaskExecutionState(JobMaster.java:488)
```