### PR TITLE
Temporarily disable Native IR transformations, the fix will be provided in 2.1.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,4 +47,5 @@ kotlinx.atomicfu.enableJvmIrTransformation=true
 # When the flag below is set to `true`, AtomicFU cannot process
 # usages of `moveForward` in `ConcurrentLinkedList.kt` correctly.
 kotlinx.atomicfu.enableJsIrTransformation=false
-kotlinx.atomicfu.enableNativeIrTransformation=true
+# Temporarily disable Native IR transformation, the fix will be provided in 2.1.10: KT-73865
+kotlinx.atomicfu.enableNativeIrTransformation=false


### PR DESCRIPTION
The corresponding issue: [KT-73865](https://youtrack.jetbrains.com/issue/KT-73865/Incorrect-type-is-generated-for-irPropertyReference-during-K-N-transformation)

I'll provide the fix for this issue in `2.1.10`, if the release of coroutines is not planned with Kotlin 2.1.0, then we can leave this PR unmerged.