### PR TITLE
Do not initialize non-mocked Dispatchers.Main unnecessarily

### DIFF
--- a/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
+++ b/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
@@ -10,7 +10,21 @@ internal class TestMainDispatcherFactory : MainDispatcherFactory {
         val secondBestFactory = otherFactories.maxByOrNull { it.loadPriority } ?: MissingMainCoroutineDispatcherFactory
         /* Do not immediately create the alternative dispatcher, as with `SUPPORT_MISSING` set to `false`,
         it will throw an exception. Instead, create it lazily. */
-        return TestMainDispatcher({ secondBestFactory.tryCreateDispatcher(otherFactories) })
+        return TestMainDispatcher({
+            val dispatcher = try {
+                secondBestFactory.tryCreateDispatcher(otherFactories)
+            } catch (e: Throwable) {
+                reportMissingMainCoroutineDispatcher(e)
+            }
+            if (dispatcher.isMissing()) {
+                reportMissingMainCoroutineDispatcher(runCatching {
+                    // attempt to dispatch something to the missing dispatcher to trigger the exception.
+                    dispatcher.dispatch(dispatcher, Runnable { })
+                }.exceptionOrNull()) // can not be null, but it does not matter.
+            } else {
+                dispatcher
+            }
+        })
     }
 
     /**
@@ -25,4 +39,14 @@ internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher {
     val mainDispatcher = Main
     require(mainDispatcher is TestMainDispatcher) { "TestMainDispatcher is not set as main dispatcher, have $mainDispatcher instead." }
     return mainDispatcher
+}
+
+private fun reportMissingMainCoroutineDispatcher(e: Throwable? = null): Nothing {
+    throw IllegalStateException(
+        "Dispatchers.Main was accessed when the platform dispatcher was absent " +
+            "and the test dispatcher was unset. Please make sure that Dispatchers.setMain() is called " +
+            "before accessing Dispatchers.Main and that Dispatchers.Main is not accessed after " +
+            "Dispatchers.resetMain().",
+        e
+    )
 }

--- a/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
+++ b/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
@@ -8,8 +8,9 @@ internal class TestMainDispatcherFactory : MainDispatcherFactory {
     override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
         val otherFactories = allFactories.filter { it !== this }
         val secondBestFactory = otherFactories.maxByOrNull { it.loadPriority } ?: MissingMainCoroutineDispatcherFactory
-        val dispatcher = secondBestFactory.tryCreateDispatcher(otherFactories)
-        return TestMainDispatcher(dispatcher)
+        /* Do not immediately create the alternative dispatcher, as with `SUPPORT_MISSING` set to `false`,
+        it will throw an exception. Instead, create it lazily. */
+        return TestMainDispatcher({ secondBestFactory.tryCreateDispatcher(otherFactories) })
     }
 
     /**

--- a/ui/kotlinx-coroutines-android/android-unit-tests/test/ordered/tests/FirstMockedMainTest.kt
+++ b/ui/kotlinx-coroutines-android/android-unit-tests/test/ordered/tests/FirstMockedMainTest.kt
@@ -35,7 +35,7 @@ open class FirstMockedMainTest : TestBase() {
             component.launchSomething()
             throw component.caughtException
         } catch (e: IllegalStateException) {
-            assertTrue(e.message!!.contains("Dispatchers.setMain from kotlinx-coroutines-test"))
+            assertTrue(e.message!!.contains("Dispatchers.setMain"))
         }
     }
 }


### PR DESCRIPTION
Before this change, the following could happen on the JVM:
* `kotlinx.coroutines.test` accesses `Dispatchers.Main` before `setMain` is called.
* `Dispatchers.Main` attempts to initialize *some other* Main dispatcher in addition to the `kotlinx-coroutines-test` Main dispatcher, if there is one.
* If the `kotlinx-coroutines-android` artifact is present + its R8 rules are used to minify the tests, it's illegal to attempt to fail to create a `Main` dispatcher. `SUPPORT_MISSING = false` ensures that attempting to create a Main dispatcher fails immediately, in the call frame that attempts the creation, not waiting for `Dispatchers.Main` to be meaningfully used.

In total, `kotlinx-coroutines-test` + `kotlinx-coroutines-android` + R8 minification of tests leads to some patterns of `kotlinx-coroutines-test` usage to crash.

Fixes #4297