### PR TITLE
Redispatch local tasks before thread parking in runBlocking

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/RunBlockingDispatchLocalTasksTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/RunBlockingDispatchLocalTasksTest.kt
@@ -1,0 +1,36 @@
+package kotlinx.coroutines
+
+import java.util.concurrent.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+import kotlin.test.*
+
+class RunBlockingDispatchLocalTasksTest {
+
+    // A coroutine deadlock occurs if there is a task in the local queue
+    // of the blocking thread before it is parked by the nested runBlocking
+    @Test(timeout = 1000)
+    fun testEmptyLocalTasksBeforePark() {
+        runBlocking(Dispatchers.IO) {
+            val latch = CountDownLatch(1)
+            lateinit var launchContinuation: Continuation<Unit>
+            lateinit var runBlockingContinuation: Continuation<Unit>
+            CoroutineScope(Dispatchers.IO).launch {
+                suspendCoroutineUninterceptedOrReturn {
+                    launchContinuation = it
+                    latch.countDown()
+                    COROUTINE_SUSPENDED
+                }
+                yield()
+                runBlockingContinuation.resume(Unit)
+            }
+            latch.await()
+            runBlocking {
+                suspendCancellableCoroutine {
+                    runBlockingContinuation = it
+                    launchContinuation.resume(Unit)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The original issue is in Ktor [KTOR-7986](https://youtrack.jetbrains.com/issue/KTOR-7986/). A coroutine deadlock occurs when `runBlocking` is used inside coroutines (unsurprisingly). While it is widely discouraged to call `runBlocking` from a suspend function, the deadlock in this case is not a typical thread deadlock (see technical details below).

Unlike most other deadlocks, there is a potential solution to prevent this type of deadlock. I propose redispatching coroutine tasks from the local queue of the current worker thread before it is parked. I think having an imperfect but functional solution (redispatching local tasks) is better than one that strictly adheres to best practices but fails in real practice (do not use `runBlocking` inside coroutines).

As described in the original issue the function that uses `runBlocking` is not a suspend function in the Ktor project. A coroutine context only appears in the test environment. While this is not good, as noted in the Ktor issue, such a scenario can arise in large projects with complex interactions, where a non-suspend function containing `runBlocking` is called inside a coroutine context in a certain non-standard case.

### Technical details from the Ktor issue:

The following is a simplified version of the Ktor code (used in `ActorSelectorManager` and `SocketImpl`):
```kotlin
import java.util.concurrent.CountDownLatch
import kotlinx.coroutines.*
import kotlin.coroutines.*
import kotlin.coroutines.intrinsics.*
import kotlin.test.Test

class DeadlockTest {
    
    @Test(timeout = 1000)
    fun testDeadlock() {
        runBlocking(Dispatchers.IO + CoroutineName("testApplication")) {
            val latch = CountDownLatch(1)
            lateinit var contSelector: Continuation<Unit>
            lateinit var contSocket: Continuation<Unit>
            CoroutineScope(Dispatchers.IO + CoroutineName("selector")).launch {
                suspendCoroutineUninterceptedOrReturn {
                    contSelector = it
                    latch.countDown()
                    COROUTINE_SUSPENDED
                }
                yield()
                contSocket.resume(Unit)
            }
            latch.await()
            runBlocking(CoroutineName("socket")) {
                suspendCancellableCoroutine {
                    contSocket = it
                    contSelector.resume(Unit)
                }
            }
        }
    }
}
```

Since an unintercepted `Continuation` is used, the selector coroutine resumes synchronously in the same stack frame and hence the same thread, behaving similarly to the `Unconfined` dispatcher. The `yield()` function dispatches a new coroutine task to the local queue of the current worker thread because it belongs to the same dispatcher specified for the selector coroutine (`Dispatchers.IO`). Next, the selector coroutine is suspended, and the thread is released. However, this thread is subsequently blocked by `runBlocking(CoroutineName("socket"))`. As a result, the previously created coroutine task gets stuck in the local queue of the blocked thread.
