### PR TITLE
resolve conflicts of module-info.class on kotlinx-coroutine-debug

### DIFF
--- a/kotlinx-coroutines-debug/build.gradle.kts
+++ b/kotlinx-coroutines-debug/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.gradle.api.JavaVersion
-import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 
@@ -50,17 +49,7 @@ tasks.named<Jar>("jar") {
             )
         )
     }
-
-    // add module-info.class to the META-INF/versions/9/ directory.
-    dependsOn(tasks.compileModuleInfoJava)
-    from(tasks.compileModuleInfoJava.get().outputs.files.asFileTree.matching {
-        include("module-info.class")
-    }) {
-        this.duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        into("META-INF/versions/9")
-    }
 }
-
 
 kover {
     reports {


### PR DESCRIPTION
- From version 1.10.0, kotlinx-coroutines-debug no longer bundles bytebuddy and has stopped using its custom shadowJar task.
  - https://github.com/Kotlin/kotlinx.coroutines/pull/4266
- It now conflicts with build-logic that were configured globally for Java 9 module system.
  - https://github.com/Kotlin/kotlinx.coroutines/blob/ee92d16c4b48345648dcd8bb15f11ab9c3747f67/buildSrc/src/main/kotlin/Java9Modularity.kt#L137-L146
- This conflict of module-info.class causes issues in programs that use ASM-based tools like Jacoco, so it needs to be fixed.