### PR TITLE
Specify Automatic-Module-Name for kotlinx-coroutines-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Add dependencies (you can also add other modules that you need):
 ```xml
 <dependency>
     <groupId>org.jetbrains.kotlinx</groupId>
-    <artifactId>kotlinx-coroutines-core</artifactId>
+    <artifactId>kotlinx-coroutines-core-jvm</artifactId>
     <version>1.10.1</version>
 </dependency>
 ```

--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.testing.*
-import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.targets.native.tasks.*
 import org.jetbrains.kotlin.gradle.tasks.*
@@ -182,15 +180,23 @@ val jvmJar by tasks.getting(Jar::class) { setupManifest(this) }
  * This manifest contains reference to AgentPremain that belongs to
  * kotlinx-coroutines-core-jvm, but our resolving machinery guarantees that
  * any JVM project that depends on -core artifact also depends on -core-jvm one.
+ *
+ * To avoid a conflict with a JPMS module provided by kotlinx-coroutines-core-jvm,
+ * an explicit automatic module name has to be specified in the manifest.
  */
-val allMetadataJar by tasks.getting(Jar::class) { setupManifest(this) }
+val allMetadataJar by tasks.getting(Jar::class) {
+    setupManifest(this, "kotlinx.coroutines.core.trampoline")
+}
 
-fun setupManifest(jar: Jar) {
+fun setupManifest(jar: Jar, autoModuleName: String? = null) {
     jar.manifest {
-        attributes(mapOf(
+        attributes(
             "Premain-Class" to "kotlinx.coroutines.debug.internal.AgentPremain",
-            "Can-Retransform-Classes" to "true",
-        ))
+            "Can-Retransform-Classes" to "true"
+        )
+        autoModuleName?.also {
+            attributes("Automatic-Module-Name" to it)
+        }
     }
 }
 


### PR DESCRIPTION
Open questions are:
- [ ] The proper module name. Perhaps, `kotlinx.coroutines.core.metadata` will be better.
- [ ] Should we continue suggesting to use `kotlinx-coroutines-core` dependency in the readme file? I don't see any immediate benefits, but I see a downside: `-core` dependency adds an extra dep resolution step.

Fixes #3842