### PR TITLE
Fix TestScope factory KDoc formatting

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestScope.kt
@@ -139,9 +139,9 @@ public val TestScope.testTimeSource: TimeSource.WithComparableMarks get() = test
  * It ensures that all the test module machinery is properly initialized.
  * - If [context] doesn't provide a [TestCoroutineScheduler] for orchestrating the virtual time used for delay-skipping,
  *   a new one is created, unless either
- *   - a [TestDispatcher] is provided, in which case [TestDispatcher.scheduler] is used;
- *   - at the moment of the creation of the scope, [Dispatchers.Main] is delegated to a [TestDispatcher], in which case
- *     its [TestCoroutineScheduler] is used.
+ *     - a [TestDispatcher] is provided, in which case [TestDispatcher.scheduler] is used;
+ *     - at the moment of the creation of the scope, [Dispatchers.Main] is delegated to a [TestDispatcher], in which case
+ *       its [TestCoroutineScheduler] is used.
  * - If [context] doesn't have a [TestDispatcher], a [StandardTestDispatcher] is created.
  * - A [CoroutineExceptionHandler] is created that makes [TestCoroutineScope.cleanupTestCoroutines] throw if there were
  *   any uncaught exceptions, or forwards the exceptions further in a platform-specific manner if the cleanup was


### PR DESCRIPTION
The [docs for the `TestScope` factory function](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-scope.html) are supposed to include a nested list, but the indentation is wrong so the KDoc is a bit confusing.

Before:

<img width="1166" alt="Screenshot 2025-01-05 at 13 10 15" src="https://github.com/user-attachments/assets/e345a8ce-f783-4ca8-b829-e11eacf30293" />

After:

<img width="1139" alt="Screenshot 2025-01-05 at 13 10 22" src="https://github.com/user-attachments/assets/92efe989-04ed-4c81-9f3d-f615953bbd16" />