### PR TITLE
Optimize dumpCoroutinesInfoAsJsonAndReferences

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -184,14 +184,14 @@ internal object DebugProbesImpl {
         val coroutinesInfoAsJson = ArrayList<String>(size)
         for (info in coroutinesInfo) {
             val context = info.context
-            val name = context[CoroutineName.Key]?.name
-            val dispatcher = context[CoroutineDispatcher.Key]
+            val name = context[CoroutineName.Key]?.name?.toStringRepr()
+            val dispatcher = context[CoroutineDispatcher.Key]?.toStringRepr()
             coroutinesInfoAsJson.add(
                 """
                 {
-                    "name": "$name",
+                    "name": $name,
                     "id": ${context[CoroutineId.Key]?.id},
-                    "dispatcher": "$dispatcher",
+                    "dispatcher": $dispatcher,
                     "sequenceNumber": ${info.sequenceNumber},
                     "state": "${info.state}"
                 } 

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.internal.ScopeCoroutine
 import java.io.*
 import java.lang.StackTraceElement
 import java.text.*
-import java.util.concurrent.locks.*
 import kotlin.collections.ArrayList
 import kotlin.concurrent.*
 import kotlin.coroutines.*
@@ -185,18 +184,18 @@ internal object DebugProbesImpl {
         val coroutinesInfoAsJson = ArrayList<String>(size)
         for (info in coroutinesInfo) {
             val context = info.context
-            val name = context[CoroutineName.Key]?.name?.toStringRepr()
-            val dispatcher = context[CoroutineDispatcher.Key]?.toStringRepr()
+            val name = context[CoroutineName.Key]?.name
+            val dispatcher = context[CoroutineDispatcher.Key]
             coroutinesInfoAsJson.add(
                 """
                 {
-                    "name": $name,
+                    "name": "$name",
                     "id": ${context[CoroutineId.Key]?.id},
-                    "dispatcher": $dispatcher,
+                    "dispatcher": "$dispatcher",
                     "sequenceNumber": ${info.sequenceNumber},
                     "state": "${info.state}"
                 } 
-                """.trimIndent()
+                """
             )
             lastObservedFrames.add(info.lastObservedFrame)
             lastObservedThreads.add(info.lastObservedThread)


### PR DESCRIPTION
I've removed `trimIndent` and `toStringRepr` calls, made during the composition of coroutine dump json.

The motivation: Intellij IDEA Debugger supports the Coroutine View, which can show the hierarchy of all the available coroutines. This View struggled of sever performance issues ([IDEA-335303](https://youtrack.jetbrains.com/issue/IDEA-335303)). There were reasons for that on the debugger side, like fetching additional information for each coroutine. But other than that, the invocation of `dumpCoroutinesInfoAsJsonAndReferences` took significant amount of time.

I made some dumb performance measurements on the dumps of ~5000 coroutines, the absolute time is irrelevant ofc, just % of time of the parent call are:

1. Original version, most of time is taken by `trimIndent`:
<img width="1544" alt="Screenshot 2025-01-07 at 16 56 44" src="https://github.com/user-attachments/assets/03a8224d-577d-4208-a24f-450a5c7317ed" />

2. Without `trimIndent` invocation:
<img width="1247" alt="Screenshot 2025-01-07 at 16 57 09" src="https://github.com/user-attachments/assets/2835cc13-a610-4867-a623-9fe7bd066cb1" />

3. Without `toStringRepr` invocation as well, it finally makes sense and shows `dumpCoroutineInfos` as the next significant call:
 
<img width="594" alt="Screenshot 2025-01-07 at 16 50 38" src="https://github.com/user-attachments/assets/d8bc610d-9376-4c32-b6c2-b65b765731d9" />


It's not necessary to call `trimIndent` on every piece of this JSON, so that it could be parsed on the debugger side. So, I suggest to optimize this code.