### PR TITLE
fix: handle cancelled scope and empty flow in `Flow.stateIn`

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
@@ -320,7 +320,7 @@ public fun <T> Flow<T>.stateIn(
  */
 public suspend fun <T> Flow<T>.stateIn(scope: CoroutineScope): StateFlow<T> {
     val config = configureSharing(1)
-    val result = CompletableDeferred<StateFlow<T>>()
+    val result = CompletableDeferred<StateFlow<T>>(scope.coroutineContext[Job])
     scope.launchSharingDeferred(config.context, config.upstream, result)
     return result.await()
 }

--- a/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
@@ -317,6 +317,7 @@ public fun <T> Flow<T>.stateIn(
  * with multiple downstream subscribers. See the [StateFlow] documentation for the general concepts of state flows.
  *
  * @param scope the coroutine scope in which sharing is started.
+ * @throws NoSuchElementException if the upstream flow does not emit any value.
  */
 public suspend fun <T> Flow<T>.stateIn(scope: CoroutineScope): StateFlow<T> {
     val config = configureSharing(1)
@@ -339,6 +340,9 @@ private fun <T> CoroutineScope.launchSharingDeferred(
                         result.complete(ReadonlyStateFlow(it, coroutineContext.job))
                     }
                 }
+            }
+            if (state == null) {
+                result.completeExceptionally(NoSuchElementException("Flow is empty"))
             }
         } catch (e: Throwable) {
             // Notify the waiter that the flow has failed

--- a/kotlinx-coroutines-core/common/test/flow/sharing/StateInTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/sharing/StateInTest.kt
@@ -98,4 +98,12 @@ class StateInTest : TestBase() {
             flow.stateIn(cancelledScope)
         }
     }
+
+    @Test
+    fun testThrowsNoSuchElementExceptionOnEmptyFlow() = runTest {
+        val flow = emptyFlow<Any>()
+        assertFailsWith<NoSuchElementException> {
+            flow.stateIn(GlobalScope)
+        }
+    }
 }

--- a/kotlinx-coroutines-core/common/test/flow/sharing/StateInTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/sharing/StateInTest.kt
@@ -3,6 +3,7 @@ package kotlinx.coroutines.flow
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import kotlin.coroutines.*
 import kotlin.test.*
 
 /**
@@ -87,5 +88,14 @@ class StateInTest : TestBase() {
     @Test
     fun testSubscriptionByFirstSuspensionInStateFlow() = runTest {
         testSubscriptionByFirstSuspensionInCollect(flowOf(1).stateIn(this@runTest)) { }
+    }
+
+    @Test
+    fun testRethrowsCEOnCancelledScope() = runTest {
+        val cancelledScope = CoroutineScope(EmptyCoroutineContext).apply { cancel("CancelMessageToken") }
+        val flow = flowOf(1, 2, 3)
+        assertFailsWith<CancellationException>("CancelMessageToken") {
+            flow.stateIn(cancelledScope)
+        }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/Kotlin/kotlinx.coroutines/issues/4322