### PR TITLE
Fix typo in CoroutineScope KDocs

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -123,7 +123,7 @@ public fun MainScope(): CoroutineScope = ContextScope(SupervisorJob() + Dispatch
 /**
  * Returns `true` when the current [Job] is still active (has not completed and was not cancelled yet).
  *
- * Coroutine cancallation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
+ * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * and normally, it's checked if a coroutine is cancelled when it *suspends*, for example,
  * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
  *
@@ -318,7 +318,7 @@ public fun CoroutineScope.cancel(message: String, cause: Throwable? = null): Uni
 /**
  * Throws the [CancellationException] that was the scope's cancellation cause if the scope is no longer [active][CoroutineScope.isActive].
  *
- * Coroutine cancallation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
+ * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * and normally, it's checked if a coroutine is cancelled when it *suspends*, for example,
  * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
  *


### PR DESCRIPTION
`cancallation` -> `cancellation`