### PR TITLE
Use -Xjvm-default instead of -jvm-default

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget = JvmTarget.JVM_1_8
-                    freeCompilerArgs.addAll("-jvm-default=disable")
+                    freeCompilerArgs.addAll("-Xjvm-default=disable")
                 }
             }
         }


### PR DESCRIPTION
Apparently this branch is used in user projects to build both 2.1.20 and 2.2.0, and 2.1.20 did not support the new `-jvm-default` (KT-73007).