### PR TITLE
Enable '-Xjvm-default=disable' explicitly to prevent API dump changes

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -15,7 +15,10 @@ kotlin {
     jvm {
         compilations.all {
             compileTaskProvider.configure {
-                compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+                compilerOptions {
+                    jvmTarget = JvmTarget.JVM_1_8
+                    freeCompilerArgs.addAll("-Xjvm-default=disable")
+                }
             }
         }
     }


### PR DESCRIPTION
The default mode is changing from 'disable' to 'enable' in KT-71768. However, core libraries will migrate to the new '-jvm-default=enable' mode explicitly, once they update to Kotlin 2.2, see KT-72051.
