### PR TITLE
Simplify newFixedThreadPoolContext using apply and remove unused import

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -2,7 +2,6 @@ package kotlinx.coroutines
 
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.scheduling.*
-import kotlin.coroutines.*
 
 /**
  * Name of the property that defines the maximal number of threads that are used by [Dispatchers.IO] coroutines dispatcher.

--- a/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/ThreadPoolDispatcher.kt
@@ -10,9 +10,8 @@ public actual fun newFixedThreadPoolContext(nThreads: Int, name: String): Execut
     require(nThreads >= 1) { "Expected at least one thread, but $nThreads specified" }
     val threadNo = AtomicInteger()
     val executor = Executors.newScheduledThreadPool(nThreads) { runnable ->
-        val t = Thread(runnable, if (nThreads == 1) name else name + "-" + threadNo.incrementAndGet())
-        t.isDaemon = true
-        t
+        Thread(runnable, if (nThreads == 1) name else name + "-" + threadNo.incrementAndGet())
+            .apply { isDaemon = true }
     }
     return Executors.unconfigurableExecutorService(executor).asCoroutineDispatcher()
 }


### PR DESCRIPTION
- Simplify newFixedThreadPoolContext using a scope function
- Remove unused import