### PR TITLE
Fix the explanation of flow emit constraints

### DIFF
--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -23,7 +23,7 @@ fun MavenPom.configureMavenCentralMetadata(project: Project) {
 
     licenses {
         license {
-            name = "The Apache Software License, Version 2.0"
+            name = "Apache-2.0"
             url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
             distribution = "repo"
         }

--- a/docs/topics/cancellation-and-timeouts.md
+++ b/docs/topics/cancellation-and-timeouts.md
@@ -7,8 +7,8 @@ This section covers coroutine cancellation and timeouts.
 
 ## Cancelling coroutine execution
 
-In a long-running application you might need fine-grained control on your background coroutines.
-For example, a user might have closed the page that launched a coroutine and now its result
+In a long-running application, you might need fine-grained control on your background coroutines.
+For example, a user might have closed the page that launched a coroutine, and now its result
 is no longer needed and its operation can be cancelled. 
 The [launch] function returns a [Job] that can be used to cancel the running coroutine:
 
@@ -142,9 +142,12 @@ which does not rethrow [CancellationException].
 
 ## Making computation code cancellable
 
-There are two approaches to making computation code cancellable. The first one is to periodically 
-invoke a suspending function that checks for cancellation. There is a [yield] function that is a good choice for that purpose.
-The other one is to explicitly check the cancellation status. Let us try the latter approach. 
+There are two approaches to making computation code cancellable.
+The first one is periodically invoking a suspending function that checks for cancellation.
+There are the [yield] and [ensureActive]
+functions, which are great choices for that purpose.
+The other one is explicitly checking the cancellation status using [isActive].
+Let us try the latter approach.
 
 Replace `while (i < 5)` in the previous example with `while (isActive)` and rerun it. 
 
@@ -158,7 +161,7 @@ fun main() = runBlocking {
         var nextPrintTime = startTime
         var i = 0
         while (isActive) { // cancellable computation loop
-            // print a message twice a second
+            // prints a message twice a second
             if (System.currentTimeMillis() >= nextPrintTime) {
                 println("job: I'm sleeping ${i++} ...")
                 nextPrintTime += 500L
@@ -192,8 +195,10 @@ main: Now I can quit.
 ## Closing resources with finally
 
 Cancellable suspending functions throw [CancellationException] on cancellation, which can be handled in 
-the usual way. For example, the `try {...} finally {...}` expression and Kotlin's `use` function execute their
-finalization actions normally when a coroutine is cancelled:
+the usual way.
+For example,
+the `try {...} finally {...}` expression and Kotlin's [use](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.io/use.html)
+function execute their finalization actions normally when a coroutine is cancelled:
 
 ```kotlin
 import kotlinx.coroutines.*
@@ -241,7 +246,7 @@ main: Now I can quit.
 
 Any attempt to use a suspending function in the `finally` block of the previous example causes
 [CancellationException], because the coroutine running this code is cancelled. Usually, this is not a 
-problem, since all well-behaving closing operations (closing a file, cancelling a job, or closing any kind of a 
+problem, since all well-behaved closing operations (closing a file, cancelling a job, or closing any kind of 
 communication channel) are usually non-blocking and do not involve any suspending functions. However, in the 
 rare case when you need to suspend in a cancelled coroutine you can wrap the corresponding code in
 `withContext(NonCancellable) {...}` using [withContext] function and [NonCancellable] context as the following example shows:
@@ -327,7 +332,7 @@ Exception in thread "main" kotlinx.coroutines.TimeoutCancellationException: Time
 
 <!--- TEST STARTS_WITH -->
 
-The `TimeoutCancellationException` that is thrown by [withTimeout] is a subclass of [CancellationException].
+The [TimeoutCancellationException] that is thrown by [withTimeout] is a subclass of [CancellationException].
 We have not seen its stack trace printed on the console before. That is because
 inside a cancelled coroutine `CancellationException` is considered to be a normal reason for coroutine completion. 
 However, in this example we have used `withTimeout` right inside the `main` function. 
@@ -489,11 +494,13 @@ This example always prints zero. Resources do not leak.
 [Job.join]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-job/join.html
 [CancellationException]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-cancellation-exception/index.html
 [yield]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/yield.html
+[ensureActive]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/ensure-active.html
 [isActive]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/is-active.html
 [CoroutineScope]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/index.html
 [withContext]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-context.html
 [NonCancellable]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-non-cancellable/index.html
 [withTimeout]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout.html
+[TimeoutCancellationException]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-timeout-cancellation-exception/index.html
 [withTimeoutOrNull]: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout-or-null.html
 
 <!--- END -->

--- a/docs/topics/composing-suspending-functions.md
+++ b/docs/topics/composing-suspending-functions.md
@@ -186,7 +186,9 @@ Note that if we just call [await][Deferred.await] in `println` without first cal
 coroutines, this will lead to sequential behavior, since [await][Deferred.await] starts the coroutine 
 execution and waits for its finish, which is not the intended use-case for laziness. 
 The use-case for `async(start = CoroutineStart.LAZY)` is a replacement for the 
-standard `lazy` function in cases when computation of the value involves suspending functions.
+standard [lazy](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/lazy.html) function in cases
+when computation of the value involves suspending functions.
+
 
 ## Async-style functions
 
@@ -291,10 +293,10 @@ concurrency, as shown in the section below.
 
 ## Structured concurrency with async 
 
-Let us take the [Concurrent using async](#concurrent-using-async) example and extract a function that 
-concurrently performs `doSomethingUsefulOne` and `doSomethingUsefulTwo` and returns the sum of their results.
-Because the [async] coroutine builder is defined as an extension on [CoroutineScope], we need to have it in the 
-scope and that is what the [coroutineScope][_coroutineScope] function provides:
+Let's refactor the [Concurrent using async](#concurrent-using-async) example into a function that runs 
+`doSomethingUsefulOne` and `doSomethingUsefulTwo` concurrently and returns their combined results.
+Since [async] is a [CoroutineScope] extension,
+we'll use the [coroutineScope][_coroutineScope] function to provide the necessary scope:
 
 ```kotlin
 suspend fun concurrentSum(): Int = coroutineScope {

--- a/docs/topics/coroutines-basics.md
+++ b/docs/topics/coroutines-basics.md
@@ -212,8 +212,8 @@ Done
 ## An explicit job
 
 A [launch] coroutine builder returns a [Job] object that is a handle to the launched coroutine and can be 
-used to explicitly wait for its completion. For example, you can wait for completion of the child coroutine
-and then print "Done" string:
+used to wait for its completion explicitly.
+For example, you can wait for the completion of the child coroutine and then print the "Done" string:
 
 ```kotlin
 import kotlinx.coroutines.*

--- a/docs/topics/debug-coroutines-with-idea.md
+++ b/docs/topics/debug-coroutines-with-idea.md
@@ -108,7 +108,7 @@ Using IntelliJ IDEA debugger, you can dig deeper into each coroutine to debug yo
 
 If you use `suspend` functions, in the debugger, you might see the "was optimized out" text next to a variable's name:
 
-![Variable "a" was optimized out](variable-optimised-out.png)
+![Variable "a" was optimized out](variable-optimised-out.png){width=480}
 
 This text means that the variable's lifetime was decreased, and the variable doesn't exist anymore.
 It is difficult to debug code with optimized variables because you don't see their values.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=c16d517b50dd28b3f5838f0e844b7520b8f1eb610f2f29de7e4e04a1b7c9c79b
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/kotlinx-coroutines-core/common/src/CompletableJob.kt
+++ b/kotlinx-coroutines-core/common/src/CompletableJob.kt
@@ -32,12 +32,13 @@ public interface CompletableJob : Job {
      *
      * Subsequent invocations of this function have no effect and always produce `false`.
      *
-     * This function transitions this job into _cancelled_ state if it was not completed or cancelled yet.
-     * However, that if this job has children, then it transitions into _cancelling_ state and becomes _cancelled_
+     * This function transitions this job into the _cancelled_ state if it has not been _completed_ or _cancelled_ yet.
+     * However, if this job has children, then it transitions into the _cancelling_ state and becomes _cancelled_
      * once all its children are [complete][isCompleted]. See [Job] for details.
      *
-     * Its responsibility of the caller to properly handle and report the given [exception], all job's children will receive
-     * a [CancellationException] with the [exception] as a cause for the sake of diagnostic.
+     * It is the responsibility of the caller to properly handle and report the given [exception].
+     * All the job’s children will receive a [CancellationException] with
+     * the [exception] as a cause for the sake of diagnosis.
      */
     public fun completeExceptionally(exception: Throwable): Boolean
 }

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.intrinsics.*
  * to automatically propagate all its elements and cancellation.
  *
  * The best ways to obtain a standalone instance of the scope are [CoroutineScope()] and [MainScope()] factory functions,
- * taking care to cancel these coroutine scopes when they are no longer needed (see section on custom usage below for
+ * taking care to cancel these coroutine scopes when they are no longer needed (see the section on custom usage below for
  * explanation and example).
  *
  * Additional context elements can be appended to the scope using the [plus][CoroutineScope.plus] operator.
@@ -158,14 +158,14 @@ public val CoroutineScope.isActive: Boolean
 
 /**
  * A global [CoroutineScope] not bound to any job.
- * Global scope is used to launch top-level coroutines which are operating on the whole application lifetime
- * and are not cancelled prematurely.
+ * Global scope is used to launch top-level coroutines that operate
+ * throughout the application's lifetime and are not canceled prematurely.
  *
  * Active coroutines launched in `GlobalScope` do not keep the process alive. They are like daemon threads.
  *
  * This is a **delicate** API. It is easy to accidentally create resource or memory leaks when
  * `GlobalScope` is used. A coroutine launched in `GlobalScope` is not subject to the principle of structured
- * concurrency, so if it hangs or gets delayed due to a problem (e.g. due to a slow network), it will stay working
+ * concurrency, so if it hangs or gets delayed due to a problem (e.g., due to a slow network), it will stay working
  * and consuming resources. For example, consider the following code:
  *
  * ```
@@ -177,13 +177,14 @@ public val CoroutineScope.isActive: Boolean
  * }
  * ```
  *
- * A call to `loadConfiguration` creates a coroutine in the `GlobalScope` that works in background without any
- * provision to cancel it or to wait for its completion. If a network is slow, it keeps waiting in background,
+ * A call to `loadConfiguration` creates a coroutine in the `GlobalScope` that works in the background without any
+ * provision to cancel it or to wait for its completion. If a network is slow, it keeps waiting in the background,
  * consuming resources. Repeated calls to `loadConfiguration` will consume more and more resources.
  *
  * ### Possible replacements
  *
- * In many cases uses of `GlobalScope` should be removed, marking the containing operation with `suspend`, for example:
+ * In many circumstances, uses of 'GlobalScope' should be removed,
+ * with the containing operation marked as 'suspend', for example:
  *
  * ```
  * suspend fun loadConfiguration() {
@@ -206,10 +207,10 @@ public val CoroutineScope.isActive: Boolean
  * ```
  *
  * In top-level code, when launching a concurrent operation from a non-suspending context, an appropriately
- * confined instance of [CoroutineScope] shall be used instead of a `GlobalScope`. See docs on [CoroutineScope] for
+ * confined instance of [CoroutineScope] shall be used instead of `GlobalScope`. See docs on [CoroutineScope] for
  * details.
  *
- * ### GlobalScope vs custom scope
+ * ### GlobalScope vs. Custom CoroutineScope
  *
  * Do not replace `GlobalScope.launch { ... }` with `CoroutineScope().launch { ... }` constructor function call.
  * The latter has the same pitfalls as `GlobalScope`. See [CoroutineScope] documentation on the intended usage of

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -123,7 +123,7 @@ public fun MainScope(): CoroutineScope = ContextScope(SupervisorJob() + Dispatch
 /**
  * Returns `true` when the current [Job] is still active (has not completed and was not cancelled yet).
  *
- * Coroutine cancallation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
+ * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * and normally, it's checked if a coroutine is cancelled when it *suspends*, for example,
  * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
  *
@@ -318,7 +318,7 @@ public fun CoroutineScope.cancel(message: String, cause: Throwable? = null): Uni
 /**
  * Throws the [CancellationException] that was the scope's cancellation cause if the scope is no longer [active][CoroutineScope.isActive].
  *
- * Coroutine cancallation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
+ * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * and normally, it's checked if a coroutine is cancelled when it *suspends*, for example,
  * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
  *

--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -11,23 +11,27 @@ import kotlin.jvm.*
 // --------------- core job interfaces ---------------
 
 /**
- * A background job. Conceptually, a job is a cancellable thing with a life-cycle that
- * culminates in its completion.
+ * A background job.
+ * Conceptually, a job is a cancellable thing with a lifecycle that
+ * concludes in its completion.
  *
- * Jobs can be arranged into parent-child hierarchies where cancellation
- * of a parent leads to immediate cancellation of all its [children] recursively.
+ * Jobs can be arranged into parent-child hierarchies where the cancellation
+ * of a parent leads to the immediate cancellation of all its [children] recursively.
  * Failure of a child with an exception other than [CancellationException] immediately cancels its parent and,
- * consequently, all its other children. This behavior can be customized using [SupervisorJob].
+ * consequently, all its other children.
+ * This behavior can be customized using [SupervisorJob].
  *
- * The most basic instances of `Job` interface are created like this:
+ * The most basic instances of the `Job` interface are created like this:
  *
- * - **Coroutine job** is created with [launch][CoroutineScope.launch] coroutine builder.
- *   It runs a specified block of code and completes on completion of this block.
+ * - A **coroutine job** is created with the [launch][CoroutineScope.launch] coroutine builder.
+ *   It runs a specified block of code and completes upon completion of this block.
  * - **[CompletableJob]** is created with a `Job()` factory function.
  *   It is completed by calling [CompletableJob.complete].
  *
- * Conceptually, an execution of a job does not produce a result value. Jobs are launched solely for their
- * side effects. See [Deferred] interface for a job that produces a result.
+ * Conceptually, an execution of a job does not produce a result value.
+ * Jobs are launched solely for their
+ * side effects.
+ * See the [Deferred] interface for a job that produces a result.
  *
  * ### Job states
  *
@@ -42,22 +46,30 @@ import kotlin.jvm.*
  * | _Cancelled_ (final state)        | `false`    | `true`        | `true`        |
  * | _Completed_ (final state)        | `false`    | `true`        | `false`       |
  *
- * Usually, a job is created in the _active_ state (it is created and started). However, coroutine builders
+ *
+ * Note that these states are mentioned in italics below to make them easier to distinguish.
+ *
+ * Usually, a job is created in the _active_ state (it is created and started).
+ * However, coroutine builders
  * that provide an optional `start` parameter create a coroutine in the _new_ state when this parameter is set to
- * [CoroutineStart.LAZY]. Such a job can be made _active_ by invoking [start] or [join].
+ * [CoroutineStart.LAZY].
+ * Such a job can be made _active_ by invoking [start] or [join].
  *
- * A job is _active_ while the coroutine is working or until [CompletableJob] is completed,
- * or until it fails or cancelled.
+ * A job is in the _active_ state while the coroutine is working or until the [CompletableJob] completes,
+ * fails, or is cancelled.
  *
- * Failure of an _active_ job with an exception makes it _cancelling_.
- * A job can be cancelled at any time with [cancel] function that forces it to transition to
- * the _cancelling_ state immediately. The job becomes _cancelled_  when it finishes executing its work and
+ * Failure of an _active_ job with an exception transitions the state to the _cancelling_ state.
+ * A job can be cancelled at any time with the [cancel] function that forces it to transition to
+ * the _cancelling_ state immediately.
+ * The job becomes _cancelled_ when it finishes executing its work and
  * all its children complete.
  *
  * Completion of an _active_ coroutine's body or a call to [CompletableJob.complete] transitions the job to
- * the _completing_ state. It waits in the _completing_ state for all its children to complete before
+ * the _completing_ state.
+ * It waits in the _completing_ state for all its children to complete before
  * transitioning to the _completed_ state.
- * Note that _completing_ state is purely internal to the job. For an outside observer a _completing_ job is still
+ * Note that _completing_ state is purely internal to the job.
+ * For an outside observer, a _completing_ job is still
  * active, while internally it is waiting for its children.
  *
  * ```
@@ -82,18 +94,21 @@ import kotlin.jvm.*
  *
  * A coroutine job is said to _complete exceptionally_ when its body throws an exception;
  * a [CompletableJob] is completed exceptionally by calling [CompletableJob.completeExceptionally].
- * An exceptionally completed job is cancelled and the corresponding exception becomes the _cancellation cause_ of the job.
+ * An exceptionally completed job is cancelled,
+ * and the corresponding exception becomes the _cancellation cause_ of the job.
  *
- * Normal cancellation of a job is distinguished from its failure by the type of this exception that caused its cancellation.
- * A coroutine that threw [CancellationException] is considered to be _cancelled normally_.
- * If a cancellation cause is a different exception type, then the job is considered to have _failed_.
- * When a job has _failed_, then its parent gets cancelled with the exception of the same type,
+ * Normal cancellation of a job is distinguished from its failure by the exception
+ * that caused its cancellation.
+ * A coroutine that throws a [CancellationException] is considered to be _cancelled_ normally.
+ * If a different exception causes the cancellation, then the job has _failed_.
+ * When a job has _failed_, its parent gets cancelled with the same type of exception,
  * thus ensuring transparency in delegating parts of the job to its children.
  *
- * Note, that [cancel] function on a job only accepts [CancellationException] as a cancellation cause, thus
+ * Note, that the [cancel] function on a job only accepts a [CancellationException] as a cancellation cause, thus
  * calling [cancel] always results in a normal cancellation of a job, which does not lead to cancellation
- * of its parent. This way, a parent can [cancel] its own children (cancelling all their children recursively, too)
- * without cancelling itself.
+ * of its parent.
+ * This way, a parent can [cancel] his children (cancelling all their children recursively, too)
+ * without cancelling himself.
  *
  * ### Concurrency and synchronization
  *

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.*
  * - A failure of a child job that was created using [launch][CoroutineScope.launch] can be handled via [CoroutineExceptionHandler] in the context.
  * - A failure of a child job that was created using [async][CoroutineScope.async] can be handled via [Deferred.await] on the resulting deferred value.
  *
- * If a [parent] job is specified, then this supervisor job becomes a child job of [parent] and is cancelled when the
+ * If a [parent] job is specified, then this supervisor job becomes a child job of the [parent] and is cancelled when the
  * parent fails or is cancelled. All this supervisor's children are cancelled in this case, too.
  */
 @Suppress("FunctionName")

--- a/kotlinx-coroutines-core/common/src/Yield.kt
+++ b/kotlinx-coroutines-core/common/src/Yield.kt
@@ -6,8 +6,8 @@ import kotlin.coroutines.intrinsics.*
 /**
  * Suspends this coroutine and immediately schedules it for further execution.
  *
- * A coroutine run uninterrupted on a thread until the coroutine *suspend*,
- * giving other coroutines a chance to use that thread for their own computations.
+ * A coroutine runs uninterrupted on a thread until the coroutine suspends,
+ * giving other coroutines a chance to use that thread for their computations.
  * Normally, coroutines suspend whenever they wait for something to happen:
  * for example, trying to receive a value from a channel that's currently empty will suspend.
  * Sometimes, a coroutine does not need to wait for anything,

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -95,7 +95,7 @@ import kotlin.coroutines.*
  * ```
  *
  * From the implementation point of view, it means that all flow implementations should
- * only emit from the same coroutine.
+ * only emit from the same coroutine context.
  * This constraint is efficiently enforced by the default [flow] builder.
  * The [flow] builder should be used if the flow implementation does not start any coroutines.
  * Its implementation prevents most of the development mistakes:

--- a/kotlinx-coroutines-core/jvm/src/ThreadContextElement.kt
+++ b/kotlinx-coroutines-core/jvm/src/ThreadContextElement.kt
@@ -4,11 +4,12 @@ import kotlinx.coroutines.internal.*
 import kotlin.coroutines.*
 
 /**
- * Defines elements in [CoroutineContext] that are installed into thread context
+ * Defines elements in a [CoroutineContext] that are installed into the thread context
  * every time the coroutine with this element in the context is resumed on a thread.
  *
- * Implementations of this interface define a type [S] of the thread-local state that they need to store on
- * resume of a coroutine and restore later on suspend. The infrastructure provides the corresponding storage.
+ * Implementations of this interface define a type [S] of the thread-local state that they need to store
+ * upon resuming a coroutine and restore later upon suspension.
+ * The infrastructure provides the corresponding storage.
  *
  * Example usage looks like this:
  *
@@ -188,10 +189,10 @@ public interface CopyableThreadContextElement<S> : ThreadContextElement<S> {
 
 /**
  * Wraps [ThreadLocal] into [ThreadContextElement]. The resulting [ThreadContextElement]
- * maintains the given [value] of the given [ThreadLocal] for coroutine regardless of the actual thread its is resumed on.
- * By default [ThreadLocal.get] is used as a value for the thread-local variable, but it can be overridden with [value] parameter.
- * Beware that context element **does not track** modifications of the thread-local and accessing thread-local from coroutine
- * without the corresponding context element returns **undefined** value. See the examples for a detailed description.
+ * maintains the given [value] of the given [ThreadLocal] for a coroutine regardless of the actual thread it is resumed on.
+ * By default [ThreadLocal.get] is used as a value for the thread-local variable, but it can be overridden with the [value] parameter.
+ * Beware that the context element **does not track** modifications of the thread-local and accessing thread-local from a coroutine
+ * without the corresponding context element returns an **undefined** value. See the examples for a detailed description.
  *
  *
  * Example usage:

--- a/kotlinx-coroutines-core/jvm/test/guide/example-cancel-04.kt
+++ b/kotlinx-coroutines-core/jvm/test/guide/example-cancel-04.kt
@@ -9,7 +9,7 @@ fun main() = runBlocking {
         var nextPrintTime = startTime
         var i = 0
         while (isActive) { // cancellable computation loop
-            // print a message twice a second
+            // prints a message twice a second
             if (currentTimeMillis() >= nextPrintTime) {
                 println("job: I'm sleeping ${i++} ...")
                 nextPrintTime += 500L

--- a/kotlinx-coroutines-test/common/src/TestScope.kt
+++ b/kotlinx-coroutines-test/common/src/TestScope.kt
@@ -139,9 +139,9 @@ public val TestScope.testTimeSource: TimeSource.WithComparableMarks get() = test
  * It ensures that all the test module machinery is properly initialized.
  * - If [context] doesn't provide a [TestCoroutineScheduler] for orchestrating the virtual time used for delay-skipping,
  *   a new one is created, unless either
- *   - a [TestDispatcher] is provided, in which case [TestDispatcher.scheduler] is used;
- *   - at the moment of the creation of the scope, [Dispatchers.Main] is delegated to a [TestDispatcher], in which case
- *     its [TestCoroutineScheduler] is used.
+ *     - a [TestDispatcher] is provided, in which case [TestDispatcher.scheduler] is used;
+ *     - at the moment of the creation of the scope, [Dispatchers.Main] is delegated to a [TestDispatcher], in which case
+ *       its [TestCoroutineScheduler] is used.
  * - If [context] doesn't have a [TestDispatcher], a [StandardTestDispatcher] is created.
  * - A [CoroutineExceptionHandler] is created that makes [TestCoroutineScope.cleanupTestCoroutines] throw if there were
  *   any uncaught exceptions, or forwards the exceptions further in a platform-specific manner if the cleanup was

--- a/license/NOTICE.txt
+++ b/license/NOTICE.txt
@@ -5,4 +5,4 @@
 =========================================================================
 
 kotlinx.coroutines library.
-Copyright 2016-2024 JetBrains s.r.o and contributors
+Copyright 2016-2025 JetBrains s.r.o and contributors


### PR DESCRIPTION
In this part, it says that it checks whether it's the same coroutine, but in the [actual implementation](https://github.com/Kotlin/kotlinx.coroutines/blob/465e29d325841244f3a1aac2e13073bc965f9736/kotlinx-coroutines-core/common/src/flow/internal/SafeCollector.common.kt#L23), it checks whether it's the same CoroutineContext rather than the same coroutine.

Specifically, in the case of the withContext example, although it internally creates a DispatchedCoroutine object, this is only for context switching, and it still maintains the same coroutine.
 ```
 val myFlow = flow {
      // GlobalScope.launch { // is prohibited
      // launch(Dispatchers.IO) { // is prohibited
      // withContext(CoroutineName("myFlow")) { // is prohibited
      emit(1) // OK
      coroutineScope {
          emit(2) // OK -- still the same coroutine
      }
  }
 ```

Therefore, it might be less confusing to describe this as checking for the same coroutine context rather than the same coroutine.
