### PR TITLE
Fix the explanation of flow emit constraints

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -95,7 +95,7 @@ import kotlin.coroutines.*
  * ```
  *
  * From the implementation point of view, it means that all flow implementations should
- * only emit from the same coroutine.
+ * only emit from the same coroutine context.
  * This constraint is efficiently enforced by the default [flow] builder.
  * The [flow] builder should be used if the flow implementation does not start any coroutines.
  * Its implementation prevents most of the development mistakes:


### PR DESCRIPTION
In this part, it says that it checks whether it's the same coroutine, but in the [actual implementation](https://github.com/Kotlin/kotlinx.coroutines/blob/465e29d325841244f3a1aac2e13073bc965f9736/kotlinx-coroutines-core/common/src/flow/internal/SafeCollector.common.kt#L23), it checks whether it's the same CoroutineContext rather than the same coroutine.

Specifically, in the case of the withContext example, although it internally creates a DispatchedCoroutine object, this is only for context switching, and it still maintains the same coroutine.
 ```
 val myFlow = flow {
      // GlobalScope.launch { // is prohibited
      // launch(Dispatchers.IO) { // is prohibited
      // withContext(CoroutineName("myFlow")) { // is prohibited
      emit(1) // OK
      coroutineScope {
          emit(2) // OK -- still the same coroutine
      }
  }
 ```

Therefore, it might be less confusing to describe this as checking for the same coroutine context rather than the same coroutine.
