### PR TITLE
Advertise source jars for JVM-only libraries

### DIFF
--- a/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
@@ -22,15 +22,11 @@ publishing {
         apply(plugin = "java-library")
 
         // MPP projects pack their sources automatically, java libraries need to explicitly pack them
-        val sources = tasks.register("sourcesJar", Jar::class) {
-            archiveClassifier = "sources"
-            from(sourceSets.named("main").get().allSource)
-        }
+        project.extensions.getByType(JavaPluginExtension::class.java).withSourcesJar()
 
         publications {
             register("mavenJava", MavenPublication::class) {
                 from(components["java"])
-                artifact(sources)
             }
         }
     }


### PR DESCRIPTION
Original implementation:
https://github.com/vanniktech/gradle-maven-publish-plugin/blob/f22bd35c84c3df28700db4ca3de11d5b78a29fde/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt#L472 Thanks, @vanniktech!

The issue with the replaced implementation is that it only packs the jar, without registering the publication variant. Checking the sources of `java { withSourcesJar() }`, we see the corresponding logic, but given that we can instead invoke it directly, no need to reimplement it.

Fixes #4112