### PR TITLE
Reliably run finalizers even if `runBlocking` got interrupted.

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -91,12 +91,11 @@ private class BlockingCoroutine<T>(
             eventLoop?.incrementUseCount()
             try {
                 while (true) {
-                    @Suppress("DEPRECATION")
-                    if (Thread.interrupted()) cancelCoroutine(InterruptedException())
                     val parkNanos = eventLoop?.processNextEvent() ?: Long.MAX_VALUE
                     // note: process next even may loose unpark flag, so check if completed before parking
                     if (isCompleted) break
                     parkNanos(this, parkNanos)
+                    if (Thread.interrupted()) cancelCoroutine(InterruptedException())
                 }
             } finally { // paranoia
                 eventLoop?.decrementUseCount()

--- a/kotlinx-coroutines-core/jvm/src/Builders.kt
+++ b/kotlinx-coroutines-core/jvm/src/Builders.kt
@@ -92,7 +92,7 @@ private class BlockingCoroutine<T>(
             try {
                 while (true) {
                     @Suppress("DEPRECATION")
-                    if (Thread.interrupted()) throw InterruptedException().also { cancelCoroutine(it) }
+                    if (Thread.interrupted()) cancelCoroutine(InterruptedException())
                     val parkNanos = eventLoop?.processNextEvent() ?: Long.MAX_VALUE
                     // note: process next even may loose unpark flag, so check if completed before parking
                     if (isCompleted) break

--- a/kotlinx-coroutines-core/jvm/test/RunBlockingJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/RunBlockingJvmTest.kt
@@ -1,7 +1,10 @@
 package kotlinx.coroutines
 
 import kotlinx.coroutines.testing.*
-import org.junit.*
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+import kotlin.test.*
+import kotlin.time.Duration
 
 class RunBlockingJvmTest : TestBase() {
     @Test
@@ -12,5 +15,62 @@ class RunBlockingJvmTest : TestBase() {
         }
         rb.hashCode() // unused
     }
-}
 
+    /** Tests that the [runBlocking] coroutine runs to completion even it was interrupted. */
+    @Test
+    fun testFinishingWhenInterrupted() {
+        startInSeparateThreadAndInterrupt { mayInterrupt ->
+            expect(1)
+            try {
+                runBlocking {
+                    try {
+                        mayInterrupt()
+                        expect(2)
+                        delay(Duration.INFINITE)
+                    } finally {
+                        withContext(NonCancellable) {
+                            expect(3)
+                            repeat(10) { yield() }
+                            expect(4)
+                        }
+                    }
+                }
+            } catch (_: InterruptedException) {
+                expect(5)
+            }
+        }
+        finish(6)
+    }
+
+    /** Tests that [runBlocking] will exit if it gets interrupted. */
+    @Test
+    fun testCancellingWhenInterrupted() {
+        startInSeparateThreadAndInterrupt { mayInterrupt ->
+            expect(1)
+            try {
+                runBlocking {
+                    try {
+                        mayInterrupt()
+                        expect(2)
+                        delay(Duration.INFINITE)
+                    } catch (_: CancellationException) {
+                        expect(3)
+                    }
+                }
+            } catch (_: InterruptedException) {
+                expect(4)
+            }
+        }
+        finish(5)
+    }
+
+    private fun startInSeparateThreadAndInterrupt(action: (mayInterrupt: () -> Unit) -> Unit) {
+        val latch = CountDownLatch(1)
+        val thread = thread {
+            action { latch.countDown() }
+        }
+        latch.await()
+        thread.interrupt()
+        thread.join()
+    }
+}


### PR DESCRIPTION
Fixes #4384