### PR TITLE
Fix an explanation of flowOn Operator

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
@@ -209,12 +209,14 @@ public fun <T> Flow<T>.conflate(): Flow<T> = buffer(CONFLATED)
  *
  * For more explanation of context preservation please refer to [Flow] documentation.
  *
- * This operator retains a _sequential_ nature of flow if changing the context does not call for changing
- * the [dispatcher][CoroutineDispatcher]. Otherwise, if changing dispatcher is required, it collects
- * flow emissions in one coroutine that is run using a specified [context] and emits them from another coroutines
- * with the original collector's context using a channel with a [default][Channel.BUFFERED] buffer size
- * between two coroutines similarly to [buffer] operator, unless [buffer] operator is explicitly called
- * before or after `flowOn`, which requests buffering behavior and specifies channel size.
+ * This operator retains the _sequential_ nature of the flow as long as the context change  does not involve
+ * changing the [dispatcher][CoroutineDispatcher].
+ * However, if the dispatcher is changed, the flow's emissions are performed in a coroutine running with the
+ * specified [context], and the values are collected in another coroutine using the original collector's context.
+ * In this case, a channel with a [default][Channel.BUFFERED] buffer size is used internally between the two
+ * coroutines, similar to the behavior of the [buffer] operator.
+ * If a [buffer] operator is explicitly called before or after `flowOn`, it overrides the default buffering behavior
+ * and determines the channel size explicitly.
  *
  * Note, that flows operating across different dispatchers might lose some in-flight elements when cancelled.
  * In particular, this operator ensures that downstream flow does not resume on cancellation even if the element


### PR DESCRIPTION
In this part, it says :

Otherwise, if changing dispatcher is required, it collects flow emissions in one coroutine that is run using a specified [context] and emits them from another coroutines with the original collector's context

and this explanation is reversed.

If flowOn passes CoroutineDispatcher, then the flow's emissions are performed in a coroutine running with the specified CoroutineContext not collector's context. The collector's original context is used to collect values emitted from the flow. 

You can easily configure this by running below code.
```
val numberFlow: Flow<Int> = flow {
    for (number in 1..3) {
        println("[${Thread.currentThread().name}] Emitting: $number")
        emit(number)
        delay(1000)
    }
}

fun main() = runBlocking<Unit> {
    numberFlow
        .flowOn(Dispatchers.IO) 
        .collect { value ->
            println("[${Thread.currentThread().name}] Collected: $value")
        }
}
```

The result of code is:
```
[DefaultDispatcher-worker-1 @coroutine#2] Emitting: 1
[main @coroutine#1] Collected: 1
[DefaultDispatcher-worker-1 @coroutine#2] Emitting: 2
[main @coroutine#1] Collected: 2
[DefaultDispatcher-worker-1 @coroutine#2] Emitting: 3
[main @coroutine#1] Collected: 3

Process finished with exit code 0
```

The new coroutine(coroutine#2) is using DefaultDispatcher-worker-1 of Dispatchers.IO. And runBlocking Coroutine(coroutine#1) is collecting the value.