### PR TITLE
Nit: Remove vestigial safe call in jvm Exceptions.kt

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Exceptions.kt
+++ b/kotlinx-coroutines-core/jvm/src/Exceptions.kt
@@ -68,9 +68,6 @@ internal actual class JobCancellationException public actual constructor(
         other === this ||
             other is JobCancellationException && other.message == message && other.job == job && other.cause == cause
 
-    override fun hashCode(): Int {
-        // since job is transient it is indeed nullable after deserialization
-        @Suppress("UNNECESSARY_SAFE_CALL")
-        return (message!!.hashCode() * 31 + (job?.hashCode() ?: 0)) * 31 + (cause?.hashCode() ?: 0)
-    }
+    override fun hashCode(): Int =
+        (message!!.hashCode() * 31 + job.hashCode()) * 31 + (cause?.hashCode() ?: 0)
 }


### PR DESCRIPTION
Looking at the git diff, seems like this change was first made to address `job` being null after deserialization, but then a commit afterwards made `job` a truly non-nullable computed property based on `_job`, thus this safe call is unnecessary and misleading. This was likely overlooked in the latter commit since everything compiled and ran just fine