### PR TITLE
docs: Coroutines guide: update URL

### DIFF
--- a/docs/topics/coroutines-guide.md
+++ b/docs/topics/coroutines-guide.md
@@ -20,7 +20,7 @@ In order to use coroutines as well as follow the examples in this guide, you nee
 ## Table of contents
 
 * [Coroutines basics](coroutines-basics.md)
-* [Hands-on: Intro to coroutines and channels](https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels)
+* [Tutorial: Intro to coroutines and channels](coroutines-and-channels.md)
 * [Cancellation and timeouts](cancellation-and-timeouts.md)
 * [Composing suspending functions](composing-suspending-functions.md)
 * [Coroutine context and dispatchers](coroutine-context-and-dispatchers.md)


### PR DESCRIPTION
The original URL
https://play.kotlinlang.org/hands-on/Introduction%20to%20Coroutines%20and%20Channels

redirects to
https://kotlinlang.org/docs/kotlin-hands-on.html,

and the `Introduction to Kotlin coroutines and channels﻿` subsection links you straight back to
https://kotlinlang.org/docs/coroutines-and-channels.html

So I just applied transitive closure :)

Also, this way it becomes consistent with the left-hand-side navigation pane [here](https://kotlinlang.org/docs/coroutines-guide.html#table-of-contents):
<img width="787" alt="image" src="https://github.com/user-attachments/assets/b844aa69-35ab-4303-b4c0-d33e91a883ae" />
