### PR TITLE
docs: add example for `runTest` to reiterate that runTest waits for children to finish

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -85,7 +85,6 @@ public expect class TestResult
  * }
  * ```
  *
- *
  * If the results of children coroutines computations are not needed in the runTest scope,
  * there is no need to wait for children coroutines to finish, they are awaited for automatically
  * by runTest parent coroutine.
@@ -231,6 +230,7 @@ public fun runTest(
  *     // 2
  *     job.join() // the main test coroutine suspends here, so the child is executed
  *     // 4
+ *     // use the results here
  * }
  *
  * @Test
@@ -242,7 +242,29 @@ public fun runTest(
  *     // 2
  *     advanceUntilIdle() // runs the tasks until their queue is empty
  *     // 4
+ *     // use the results here
  * }
+ * ```
+ *
+ * If the results of children coroutines computations are not needed in the runTest scope,
+ * there is no need to wait for children coroutines to finish, they are awaited for automatically
+ * by runTest parent coroutine.
+ * ```
+ * @Test
+ * fun exampleWaitingForAsyncTasks3() = runTest {
+ *     val x = 0
+ *     val y = 1
+ *     // 1
+ *     launch {
+ *         // 3
+ *         assertEquals(0, x)
+ *     }
+ *     launch {
+ *         // 4
+ *         assertEquals(1, y)
+ *     }
+ *     // 2
+ * }  // 5
  * ```
  *
  * ### Task scheduling

--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -50,8 +50,8 @@ public expect class TestResult
  * }
  * ```
  *
- * The platform difference entails that, in order to use this function correctly in common code, one must always
- * immediately return the produced [TestResult] from the test method, without doing anything else afterwards. See
+ * The platform difference entails that, to use this function correctly in common code, one must always
+ * immediately return the produced [TestResult] from the test method, without doing anything else afterward. See
  * [TestResult] for details on this.
  *
  * The test is run on a single thread, unless other [CoroutineDispatcher] are used for child coroutines.
@@ -211,8 +211,8 @@ public fun runTest(
  * }
  * ```
  *
- * The platform difference entails that, in order to use this function correctly in common code, one must always
- * immediately return the produced [TestResult] from the test method, without doing anything else afterwards. See
+ * The platform difference entails that, to use this function correctly in common code, one must always
+ * immediately return the produced [TestResult] from the test method, without doing anything else afterward. See
  * [TestResult] for details on this.
  *
  * The test is run in a single thread, unless other [CoroutineDispatcher] are used for child coroutines.

--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -69,6 +69,7 @@ public expect class TestResult
  *     // 2
  *     job.join() // the main test coroutine suspends here, so the child is executed
  *     // 4
+ *     // use the results here
  * }
  *
  * @Test
@@ -80,7 +81,30 @@ public expect class TestResult
  *     // 2
  *     testScheduler.advanceUntilIdle() // runs the tasks until their queue is empty
  *     // 4
+ *     // use the results here
  * }
+ * ```
+ *
+ *
+ * If the results of children coroutines computations are not needed in the runTest scope,
+ * there is no need to wait for children coroutines to finish, they are awaited for automatically
+ * by runTest parent coroutine.
+ * ```
+ * @Test
+ * fun exampleWaitingForAsyncTasks3() = runTest {
+ *     val x = 0
+ *     val y = 1
+ *     // 1
+ *     launch {
+ *         // 3
+ *         assertEquals(0, x)
+ *     }
+ *     launch {
+ *         // 4
+ *         assertEquals(1, y)
+ *     }
+ *     // 2
+ * }  // 5
  * ```
  *
  * ### Task scheduling


### PR DESCRIPTION
Two previous examples (L63-84) could be misinterpreted as if there's a need to explicitly `join` or generally wait for children coroutines to finish, since they don't do anything after joining the launched coroutine.

The misleading examples (L63-84):
```
 * @Test
 * fun exampleWaitingForAsyncTasks1() = runTest {
 *     // 1
 *     val job = launch {
 *         // 3
 *     }
 *     // 2
 *     job.join() // the main test coroutine suspends here, so the child is executed
 *     // 4
 * }
 *
 * @Test
 * fun exampleWaitingForAsyncTasks2() = runTest {
 *     // 1
 *     launch {
 *         // 3
 *     }
 *     // 2
 *     testScheduler.advanceUntilIdle() // runs the tasks until their queue is empty
 *     // 4
 * }
 * ```