### PR TITLE
Upgrade to Kotlin 2.1.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,18 @@ allprojects {
     }
 }
 
+configure(subprojects.filter { !sourceless.contains(it.name) }) {
+    if (isMultiplatform) {
+        apply(plugin = "kotlin-multiplatform")
+        apply(plugin = "kotlin-multiplatform-conventions")
+    } else if (platformOf(this) == "jvm") {
+        apply(plugin = "kotlin-jvm-conventions")
+    } else {
+        val platform = platformOf(this)
+        throw IllegalStateException("No configuration rules for $platform")
+    }
+}
+
 // needs to be before evaluationDependsOn due to weird Gradle ordering
 configure(subprojects) {
     fun Project.shouldSniff(): Boolean =
@@ -106,18 +118,6 @@ configure(subprojects) {
         } else {
             apply(plugin = "animalsniffer-jvm-conventions")
         }
-    }
-}
-
-configure(subprojects.filter { !sourceless.contains(it.name) }) {
-    if (isMultiplatform) {
-        apply(plugin = "kotlin-multiplatform")
-        apply(plugin = "kotlin-multiplatform-conventions")
-    } else if (platformOf(this) == "jvm") {
-        apply(plugin = "kotlin-jvm-conventions")
-    } else {
-        val platform = platformOf(this)
-        throw IllegalStateException("No configuration rules for $platform")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Kotlin
 version=1.10.2-SNAPSHOT
 group=org.jetbrains.kotlinx
-kotlin_version=2.1.0
+kotlin_version=2.1.20
 # DO NOT rename this property without adapting kotlinx.train build chain:
 atomicfu_version=0.26.1
 benchmarks_version=0.4.13


### PR DESCRIPTION
The block applying `kotlin("multiplatform")` had to be moved above the block applying animalsniffer, because since 2.1.20, the Multiplatform plugin applies `java-base`, and the animalsniffer plugin is not prepared for this order of plugin applications, always assuming that the Multiplatform plugin goes before the Java plugin:
https://github.com/xvik/gradle-animalsniffer-plugin/blob/cbcb2d524dacba651cac183216cbefcdcf629a3a/src/main/groovy/ru/vyarus/gradle/plugin/animalsniffer/AnimalSnifferPlugin.groovy#L81

Thanks to @ALikhachev for investigating the issue!