### PR TITLE
Use providers.gradle property instead of rootProject.properties in the build scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ allprojects {
     if (deployVersion != null) version = deployVersion
 
     if (isSnapshotTrainEnabled(rootProject)) {
-        val skipSnapshotChecks = rootProject.properties["skip_snapshot_checks"] != null
+        val skipSnapshotChecks = providers.gradleProperty("skip_snapshot_checks").isPresent
         if (!skipSnapshotChecks && version != version("atomicfu")) {
             throw IllegalStateException("Current deploy version is $version, but atomicfu version is not overridden (${version("atomicfu")}) for $this")
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 val cacheRedirectorEnabled = System.getenv("CACHE_REDIRECTOR")?.toBoolean() == true
 val buildSnapshotTrain = properties["build_snapshot_train"]?.toString()?.toBoolean() == true
-val kotlinDevUrl = project.rootProject.properties["kotlin_repo_url"] as? String
+val kotlinDevUrl = project.providers.gradleProperty("kotlin_repo_url").orNull
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -33,7 +33,7 @@ private val LOGGER: Logger = Logger.getLogger("Kotlin settings logger")
  * @return a Kotlin API version parametrized from command line nor gradle.properties, null otherwise
  */
 fun getOverriddenKotlinApiVersion(project: Project): KotlinVersion? {
-    val apiVersion = project.rootProject.properties["kotlin_api_version"] as? String
+    val apiVersion = project.providers.gradleProperty("kotlin_api_version").orNull
     return if (apiVersion != null) {
         LOGGER.info("""Configured Kotlin API version: '$apiVersion' for project $${project.name}""")
         KotlinVersion.fromVersion(apiVersion)
@@ -48,7 +48,7 @@ fun getOverriddenKotlinApiVersion(project: Project): KotlinVersion? {
  * @return a Kotlin Language version parametrized from command line nor gradle.properties, null otherwise
  */
 fun getOverriddenKotlinLanguageVersion(project: Project): KotlinVersion? {
-    val languageVersion = project.rootProject.properties["kotlin_language_version"] as? String
+    val languageVersion = project.providers.gradleProperty("kotlin_language_version").orNull
     return if (languageVersion != null) {
         LOGGER.info("""Configured Kotlin Language version: '$languageVersion' for project ${project.name}""")
         KotlinVersion.fromVersion(languageVersion)
@@ -66,7 +66,7 @@ fun getOverriddenKotlinLanguageVersion(project: Project): KotlinVersion? {
  * @return an url for a kotlin compiler repository parametrized from command line nor gradle.properties, empty string otherwise
  */
 fun getKotlinDevRepositoryUrl(project: Project): URI? {
-    val url: String? = project.rootProject.properties["kotlin_repo_url"] as? String
+    val url: String? = project.providers.gradleProperty("kotlin_repo_url").orNull
     if (url != null) {
         LOGGER.info("""Configured Kotlin Compiler repository url: '$url' for project ${project.name}""")
         return URI.create(url)
@@ -125,9 +125,8 @@ fun Project.configureCommunityBuildTweaks() {
  */
 fun getOverriddenKotlinVersion(project: Project): String? =
     if (isSnapshotTrainEnabled(project)) {
-        val snapshotVersion = project.rootProject.properties["kotlin_snapshot_version"]
+        project.providers.gradleProperty("kotlin_snapshot_version").orNull
             ?: error("'kotlin_snapshot_version' should be defined when building with a snapshot compiler")
-        snapshotVersion.toString()
     } else {
         null
     }
@@ -136,7 +135,7 @@ fun getOverriddenKotlinVersion(project: Project): String? =
  * Checks if the project is built with a snapshot version of Kotlin compiler.
  */
 fun isSnapshotTrainEnabled(project: Project): Boolean {
-    val buildSnapshotTrain = project.rootProject.properties["build_snapshot_train"] as? String
+    val buildSnapshotTrain = project.providers.gradleProperty("build_snapshot_train").orNull
     return !buildSnapshotTrain.isNullOrBlank()
 }
 
@@ -154,7 +153,7 @@ fun shouldUseLocalMaven(project: Project): Boolean {
  * Then, `true` means that warnings should be treated as errors, `false` means that they should not.
  */
 private fun warningsAreErrorsOverride(project: Project): Boolean? =
-    when (val prop = project.rootProject.properties["kotlin_Werror_override"] as? String) {
+    when (val prop = project.providers.gradleProperty("kotlin_Werror_override").orNull) {
         null -> null
         "enable" -> true
         "disable" -> false
@@ -187,10 +186,10 @@ fun KotlinCommonCompilerOptions.configureKotlinUserProject() {
  * See <https://github.com/Kotlin/kotlinx.coroutines/pull/4392#issuecomment-2775630200>
  */
 fun KotlinCommonCompilerOptions.addExtraCompilerFlags(project: Project) {
-    val extraOptions = project.rootProject.properties["kotlin_additional_cli_options"] as? String
+    val extraOptions = project.providers.gradleProperty("kotlin_additional_cli_options").orNull
     if (extraOptions != null) {
         LOGGER.info("""Adding extra compiler flags '$extraOptions' for a compilation in the project $${project.name}""")
-        extraOptions.split(" ")?.forEach {
+        extraOptions.split(" ").forEach {
             if (it.isNotEmpty()) freeCompilerArgs.add(it)
         }
     }

--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -139,10 +139,25 @@ fun isSnapshotTrainEnabled(project: Project): Boolean {
     return !buildSnapshotTrain.isNullOrBlank()
 }
 
+/**
+ * The list of projects snapshot versions of which we may want to use with `kotlinx.coroutines`.
+ *
+ * In `gradle.properties`, these properties are defined as `<name>_version`, e.g. `kotlin_version`.
+ */
+val firstPartyDependencies = listOf(
+    "kotlin",
+    "atomicfu",
+)
+
 fun shouldUseLocalMaven(project: Project): Boolean {
-    val hasSnapshotDependency = project.rootProject.properties.any { (key, value) ->
-        key.endsWith("_version") && value is String && value.endsWith("-SNAPSHOT").also {
-            if (it) println("NOTE: USING SNAPSHOT VERSION: $key=$value")
+    val hasSnapshotDependency = firstPartyDependencies.any { dependencyName ->
+        val key = "${dependencyName}_version"
+        val value = project.providers.gradleProperty(key).orNull
+        if (value != null && value.endsWith("-SNAPSHOT")) {
+            println("NOTE: USING SNAPSHOT VERSION: $key=$value")
+            true
+        } else {
+            false
         }
     }
     return hasSnapshotDependency || isSnapshotTrainEnabled(project)

--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -114,7 +114,7 @@ fun Project.configureCommunityBuildTweaks() {
             }.files.single()
 
             manifest.readLines().forEach {
-                println(it)
+                LOGGER.info(it)
             }
         }
     }
@@ -154,7 +154,7 @@ fun shouldUseLocalMaven(project: Project): Boolean {
         val key = "${dependencyName}_version"
         val value = project.providers.gradleProperty(key).orNull
         if (value != null && value.endsWith("-SNAPSHOT")) {
-            println("NOTE: USING SNAPSHOT VERSION: $key=$value")
+            LOGGER.info("NOTE: USING SNAPSHOT VERSION: $key=$value")
             true
         } else {
             false

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -10,14 +10,16 @@ fun Project.version(target: String): String {
     return property("${target}_version") as String
 }
 
-val Project.jdkToolchainVersion: Int get() = property("jdk_toolchain_version").toString().toInt()
+val Project.jdkToolchainVersion: Int get() =
+    providers.gradleProperty("jdk_toolchain_version").get().toInt()
 
 /**
  * TODO: check if this is still relevant.
  * It was introduced in <https://github.com/Kotlin/kotlinx.coroutines/pull/2389>, and the project for which this was
  * done is already long finished.
  */
-val Project.nativeTargetsAreEnabled: Boolean get() = rootProject.properties["disable_native_targets"] == null
+val Project.nativeTargetsAreEnabled: Boolean get() =
+    !providers.gradleProperty("disable_native_targets").isPresent
 
 val Project.sourceSets: SourceSetContainer
     get() = extensions.getByName("sourceSets") as SourceSetContainer

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,15 @@
-# Kotlin
 version=1.10.2-SNAPSHOT
 group=org.jetbrains.kotlinx
+
+# First-party dependencies.
+# ONLY rename these properties alongside adapting kotlinx.train build chain
+# and the `firstPartyDependencies` list in `buildSrc`.
 kotlin_version=2.1.20
-# DO NOT rename this property without adapting kotlinx.train build chain:
 atomicfu_version=0.26.1
-benchmarks_version=0.4.13
-benchmarks_jmh_version=1.37
 
 # Dependencies
+benchmarks_version=0.4.13
+benchmarks_jmh_version=1.37
 junit_version=4.12
 junit5_version=5.7.0
 knit_version=0.5.0

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         DO NOT change the name of these properties without adapting kotlinx.train build chain.
     */
     fun checkIsSnapshotTrainProperty(): Boolean {
-        val buildSnapshotTrain = rootProject.properties["build_snapshot_train"]?.toString()
+        val buildSnapshotTrain = providers.gradleProperty("build_snapshot_train").orNull
         return !buildSnapshotTrain.isNullOrEmpty()
     }
 
@@ -64,10 +64,10 @@ java {
 }
 
 val kotlinVersion = if (extra["build_snapshot_train"] == true) {
-    rootProject.properties["kotlin_snapshot_version"]?.toString()
+    providers.gradleProperty("kotlin_snapshot_version").orNull
         ?: throw IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with snapshot compiler")
 } else {
-    rootProject.properties["kotlin_version"].toString()
+    providers.gradleProperty("kotlin_version").get()
 }
 
 val asmVersion = property("asm_version")

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -19,13 +19,19 @@ buildscript {
         return !buildSnapshotTrain.isNullOrEmpty()
     }
 
+    val firstPartyDependencies = listOf(
+        "kotlin",
+        "atomicfu",
+    )
+
     fun checkIsSnapshotVersion(): Boolean {
         var usingSnapshotVersion = checkIsSnapshotTrainProperty()
-        rootProject.properties.forEach { (key, value) ->
-            if (key.endsWith("_version") && value is String && value.endsWith("-SNAPSHOT")) {
-                println("NOTE: USING SNAPSHOT VERSION: $key=$value")
-                usingSnapshotVersion = true
-            }
+        for (key in firstPartyDependencies) {
+            val value = providers.gradleProperty("${key}_version").orNull
+                ?.takeIf { it.endsWith("-SNAPSHOT") }
+                ?: continue
+            println("NOTE: USING SNAPSHOT VERSION: $key=$value")
+            usingSnapshotVersion = true
         }
         return usingSnapshotVersion
     }

--- a/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
+++ b/integration-testing/src/debugDynamicAgentTest/kotlin/DynamicAttachDebugTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import java.io.*
 import java.lang.IllegalStateException
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DynamicAttachDebugTest {
 
     @Test

--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -140,7 +140,7 @@ val jvmTest by tasks.getting(Test::class) {
     maxHeapSize = "1g"
     enableAssertions = true
     // 'stress' is required to be able to run all subpackage tests like ":jvmTests --tests "*channels*" -Pstress=true"
-    if (!Idea.active && rootProject.properties["stress"] == null) {
+    if (!Idea.active && !providers.gradleProperty("stress").isPresent) {
         exclude("**/*LincheckTest*")
         exclude("**/*StressTest.*")
     }


### PR DESCRIPTION
See <https://github.com/Kotlin/kotlinx.coroutines/pull/4392/files#r2016110128>
for an explanation of the benefits of this.

Additionally, the `integration-testing` no longer sees the `kotlinx.coroutines` having a `SNAPSHOT` version (which is always the case) as a valid reason to start looking at development repositories for packages.