### PR TITLE
Simplify full-queue check to use single margin

### DIFF
--- a/kotlinx-coroutines-core/common/src/internal/LockFreeTaskQueue.kt
+++ b/kotlinx-coroutines-core/common/src/internal/LockFreeTaskQueue.kt
@@ -102,9 +102,8 @@ internal class LockFreeTaskQueueCore<E : Any>(
             if (state and (FROZEN_MASK or CLOSED_MASK) != 0L) return state.addFailReason() // cannot add
             state.withState { head, tail ->
                 val mask = this.mask // manually move instance field to local for performance
-                // If queue is Single-Consumer then there could be one element beyond head that we cannot overwrite,
-                // so we check for full queue with an extra margin of one element
-                if ((tail + 2) and mask == head and mask) return ADD_FROZEN // overfull, so do freeze & copy
+                // Reserve one margin element to determine when the queue is full
+                if ((tail + 1) and mask == head and mask) return ADD_FROZEN // overfull, so do freeze & copy
                 // If queue is Multi-Consumer then the consumer could still have not cleared element
                 // despite the above check for one free slot.
                 if (!singleConsumer && array[tail and mask].value != null) {


### PR DESCRIPTION
Update outdated full-queue check logic of `LockFreeTaskQueueCore`. No more need to have 2 margin elements; one is sufficient.

Tested in `LockFreeTaskQueueStressTest` and `LockFreeTaskQueueTest`

See also #4205 