### PR TITLE
Ensure consistent `delay` behavior in `immediate` across platforms

### DIFF
--- a/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeDarwin/src/Dispatchers.kt
@@ -46,7 +46,7 @@ private class DarwinMainDispatcher(
         val timer = Timer()
         val timerBlock: TimerBlock = {
             timer.dispose()
-            continuation.resume(Unit)
+            with(continuation) { resumeUndispatched(Unit) }
         }
         timer.start(timeMillis, timerBlock)
         continuation.disposeOnCancellation(timer)

--- a/test-utils/common/src/MainDispatcherTestBase.kt
+++ b/test-utils/common/src/MainDispatcherTestBase.kt
@@ -155,6 +155,7 @@ abstract class MainDispatcherTestBase: TestBase() {
     /** Tests that [delay] runs the task inline instead of explicitly scheduling it
      * (which can be observed by the event loop's ordering). */
     @Test
+    @NoJs @NoWasmWasi @NoWasmJs // This test does not work for environments with a single always-on event loop
     fun testUndispatchedAfterDelay() = runTestOrSkip {
         launch(Dispatchers.Main.immediate) {
             val channel = Channel<Unit>()


### PR DESCRIPTION
Fixes #4430