### PR TITLE
Document structured concurrency

### DIFF
--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -43,14 +43,11 @@ import kotlin.jvm.*
  *   using the [newCoroutineContext] function.
  *   In most cases, this means that elements from [context] simply override
  *   the elements in the [CoroutineScope.coroutineContext].
- *   If no [ContinuationInterceptor] is present in the resulting context,
- *   then [Dispatchers.Default] is added there.
- * - Then, the [Job] in the [CoroutineScope.coroutineContext] is used as the *parent* of the new coroutine,
- *   unless overridden.
- *   Overriding the [Job] is forbidden; see a separate subsection below for details.
- *   The new coroutine's [Job] is added to the resulting context.
+ * - Then, the [Job] in the [CoroutineScope.coroutineContext] is used as the *parent* of the new coroutine.
+ *   Passing a [Job] in [context] overrides the parent and is forbidden; see a separate subsection below for details.
+ *   The new coroutine's [Job] is added to the context.
  *
- * The resulting coroutine context is the [coroutineContext] of the [CoroutineScope]
+ * The resulting coroutine context becomes the [coroutineContext] of the [CoroutineScope]
  * passed to the [block] as its receiver.
  *
  * The new coroutine is considered [active][isActive] until the [block] and all its child coroutines finish.
@@ -63,14 +60,15 @@ import kotlin.jvm.*
  * Here is a restatement of some main points as they relate to [launch]:
  *
  * - The lifecycle of the parent [CoroutineScope] cannot end until this coroutine
- *   (as well as all its children) completes.
+ *   and all its children complete.
  * - If the parent [CoroutineScope] is cancelled, this coroutine is cancelled as well.
  * - If this coroutine fails with a non-[CancellationException] exception
  *   and the parent [CoroutineScope] has a non-supervisor [Job] in its context,
  *   the parent [Job] is cancelled with this exception.
- * - If this coroutine fails with an exception and the parent [CoroutineScope] has a supervisor [Job] or no job at all
+ * - If this coroutine fails with a non-[CancellationException] exception
+ *   and the parent [CoroutineScope] has a [SupervisorJob] or no job at all
  *   (as is the case with [GlobalScope] or malformed scopes),
- *   the exception is considered uncaught and is propagated as the [CoroutineExceptionHandler] documentation describes.
+ *   the exception cannot be propagated and is handled as the [CoroutineExceptionHandler] documentation describes.
  * - The lifecycle of the [CoroutineScope] passed as the receiver to the [block]
  *   will not end until the [block] completes (or gets cancelled before ever having a chance to run).
  * - If the [block] throws a [CancellationException], the coroutine is considered cancelled,
@@ -80,12 +78,12 @@ import kotlin.jvm.*
  *
  * Passing a [Job] in the [context] argument breaks structured concurrency and is not a supported pattern.
  * It does not throw an exception only for backward compatibility reasons, as a lot of code was written this way.
- * Always structure your coroutines such that the lifecycle of the child coroutine is
+ * Always structure your coroutines so that the lifecycle of the child coroutine is
  * contained in the lifecycle of the [CoroutineScope] it is launched in.
  *
- * To help with migrating to structured concurrency, the specific behaviour of passing a [Job] in the [context] argument
+ * To help with migrating to structured concurrency, the specific behavior of passing a [Job] in the [context] argument
  * is described here.
- * **Do not rely on this behaviour in new code.**
+ * **Do not rely on this behavior in new code.**
  *
  * If [context] contains a [Job] element, it will be the *parent* of the new coroutine,
  * and the lifecycle of the new coroutine will not be tied to the [CoroutineScope] at all.
@@ -97,13 +95,15 @@ import kotlin.jvm.*
  *   Instead, the exception will be propagated to the [Job] passed in the [context] argument.
  *   If that [Job] is a [SupervisorJob], the exception will be unhandled,
  *   and will be propagated as the [CoroutineExceptionHandler] documentation describes.
- *   If that [Job] is not a [SupervisorJob], it will be cancelled with the exception thrown by [launch].
- * - If the [CoroutineScope] is lexically scoped (for example, created by [coroutineScope] or [withContext]),
+ *   If that [Job] is not a [SupervisorJob], it will be cancelled with the exception the coroutine failed with.
+ * - The [CoroutineScope] may complete without waiting for the new coroutine to finish.
+ *   In particular, if the [CoroutineScope] is lexically scoped
+ *   (for example, created by [coroutineScope] or [withContext]),
  *   the function defining the scope will not wait for the new coroutine to finish.
  *
  * ## Communicating with the coroutine
  *
- * [Job.cancel] can be used to cancel the coroutine, and [Job.join] can be used to block until its completion
+ * [Job.cancel] can be used to cancel the coroutine, and [Job.join] suspends until its completion
  * without blocking the current thread.
  * Note that [Job.join] succeeds even if the coroutine was cancelled or failed with an exception.
  * [Job.cancelAndJoin] is a convenience function that combines cancellation and joining.
@@ -121,11 +121,10 @@ import kotlin.jvm.*
  *
  * [launch] is similar to [async] whose block returns a [Unit] value.
  *
- * The only difference is the handling of uncaught coroutine exceptions:
- * if an [async] coroutine fails with an exception, then even if the exception cannot be propagated to the parent,
- * a [CoroutineExceptionHandler] will not be invoked.
+ * The only difference is the handling of failures that cannot be propagated to the parent:
+ * for an [async] coroutine, a [CoroutineExceptionHandler] will not be invoked in that scenario.
  * Instead, the user of [async] must call [Deferred.await] to get the result of the coroutine,
- * which will be the uncaught exception.
+ * which will be the exception the coroutine failed with.
  *
  * ## Pitfalls
  *
@@ -157,7 +156,7 @@ import kotlin.jvm.*
  *
  * The reason for this is that any [CancellationException] thrown in the coroutine is treated as a signal to cancel
  * the coroutine, but not the parent.
- * In this scenario, this is unlikely to be the desired behaviour:
+ * In this scenario, this is unlikely to be the desired behavior:
  * this was a failure and not a cancellation and should be propagated to the parent.
  *
  * This is a legacy behavior that cannot be changed in a backward-compatible way.
@@ -215,7 +214,7 @@ public fun CoroutineScope.launch(
 
 /**
  * Launches a new *child coroutine* of [CoroutineScope] without blocking the current thread
- * and returns a reference to the coroutine as a [Deferred] that can be used to access the final value.
+ * and returns a reference to the coroutine as a [Deferred] that can be used to access the result of the coroutine.
  *
  * [block] is the computation of the new coroutine that will run concurrently.
  * The coroutine is considered active until the block and all the child coroutines created in it finish.
@@ -246,14 +245,14 @@ public fun CoroutineScope.launch(
  * Here is a restatement of some main points as they relate to [async]:
  *
  * - The lifecycle of the parent [CoroutineScope] cannot end until this coroutine
- *   (as well as all its children) completes.
+ *   and all its children complete.
  * - If the parent [CoroutineScope] is cancelled, this coroutine is cancelled as well.
  * - If this coroutine fails with a non-[CancellationException] exception
  *   and the parent [CoroutineScope] has a non-supervisor [Job] in its context,
  *   the parent [Job] is cancelled with this exception.
  * - If this coroutine fails with an exception and the parent [CoroutineScope] has a supervisor [Job] or no job at all
  *   (as is the case with [GlobalScope] or malformed scopes),
- *   the exception is considered uncaught and is only available through the returned [Deferred].
+ *   the exception cannot be propagated and is only available through the returned [Deferred].
  * - The lifecycle of the [CoroutineScope] passed as the receiver to the [block]
  *   will not end until the [block] completes (or gets cancelled before ever having a chance to run).
  * - If the [block] throws a [CancellationException], the coroutine is considered cancelled,
@@ -267,7 +266,7 @@ public fun CoroutineScope.launch(
  * including [CancellationException] if the coroutine was cancelled.
  * See the "CancellationException silently stopping computations" pitfall in the [launch] documentation.
  *
- * [Deferred.cancel] can be used to cancel the coroutine, and [Deferred.join] can be used to block until its completion
+ * [Deferred.cancel] can be used to cancel the coroutine, and [Deferred.join] suspends until its completion
  * without blocking the current thread or accessing its result.
  * Note that [Deferred.join] succeeds even if the coroutine was cancelled or failed with an exception.
  * [Deferred.cancelAndJoin] is a convenience function that combines cancellation and joining.
@@ -325,8 +324,7 @@ private class LazyDeferredCoroutine<T>(
  *
  * [context] specifies the additional context elements for the coroutine to combine with
  * the elements already present in the [currentCoroutineContext].
- * It is incorrect to pass a [Job] element there, as this breaks structured concurrency,
- * unless it is [NonCancellable].
+ * It is incorrect to pass a [Job] element there, unless it is [NonCancellable], as this breaks structured concurrency.
  *
  * If the resulting [CoroutineScope.coroutineContext] is cancelled before the [block] starts running,
  * [block] will immediately finish with a [CancellationException],
@@ -334,7 +332,8 @@ private class LazyDeferredCoroutine<T>(
  *
  * ## Structured Concurrency
  *
- * The behavior of [withContext] is similar to [coroutineScope], as it, too, creates a new *scoped child coroutine*.
+ * The behavior of [withContext] is similar to [coroutineScope], as it, too,
+ * creates a new *lexically scoped child coroutine*.
  * Refer to the documentation of that function for details.
  *
  * The difference is that [withContext] does not simply call the [block] in a new coroutine
@@ -344,14 +343,14 @@ private class LazyDeferredCoroutine<T>(
  * - First, [currentCoroutineContext] is combined with the [context] argument.
  *   In most cases, this means that elements from [context] simply override
  *   the elements in the [currentCoroutineContext],
- *   but if they are `CopyableThreadContextElement`s, they are copied and combined as needed.
+ *   but if they are `CopyableThreadContextElement`s, they are copied and merged as needed.
  * - Then, the [Job] in the [currentCoroutineContext], if any, is used as the *parent* of the new scope,
  *   unless overridden.
  *   Overriding the [Job] is forbidden with the notable exception of [NonCancellable];
  *   see a separate subsection below for details.
  *   The new scope's [Job] is added to the resulting context.
  *
- * The [Job] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
+ * The [Job] of the new scope is not a normal child of the caller coroutine but a **lexically scoped** one,
  * meaning that the failure of the [Job] will not affect the parent [Job].
  * Instead, the exception leading to the failure will be rethrown to the caller of this function.
  *
@@ -390,12 +389,12 @@ private class LazyDeferredCoroutine<T>(
  *
  * Passing a [Job] in the [context] argument breaks structured concurrency and is not a supported pattern.
  * It does not throw an exception only for backward compatibility reasons, as a lot of code was written this way.
- * Always structure your coroutines such that the lifecycle of the child coroutine is
+ * Always structure your coroutines so that the lifecycle of the child coroutine is
  * contained in the lifecycle of the [CoroutineScope] it is launched in.
  *
- * To help with migrating to structured concurrency, the specific behaviour of passing a [Job] in the [context] argument
+ * To help with migrating to structured concurrency, the specific behavior of passing a [Job] in the [context] argument
  * is described here.
- * **Do not rely on this behaviour in new code.**
+ * **Do not rely on this behavior in new code.**
  *
  * If [context] contains a [Job] element, it will be the *parent* of the new coroutine,
  * and the lifecycle of the new coroutine will not be tied to the [currentCoroutineContext] at all.
@@ -407,7 +406,7 @@ private class LazyDeferredCoroutine<T>(
  *   will not cancel the parent [Job].
  * - If the [currentCoroutineContext] is cancelled, the new coroutine will not be affected.
  * - In particular, if [withContext] avoided a dispatch (see "Dispatching behavior" below)
- *   and its block finished without an exception, [withContext] itself will not throw a [CancellationException].
+ *   and finished without an exception, [withContext] itself will not throw a [CancellationException].
  *   This means that the block execution will continue even if the parent coroutine was cancelled.
  *
  * If the purpose of passing a [Job] to [withContext] is to ensure that [block] gets cancelled when that job
@@ -455,7 +454,7 @@ private class LazyDeferredCoroutine<T>(
  * in which [withContext] was invoked is cancelled by the time its dispatcher starts to execute the code,
  * it discards the result of [withContext] and throws a [CancellationException].
  *
- * Note that if the dispatch from [withContext] back to the original context does not need to happen
+ * On the other hand, if the dispatch from [withContext] back to the original context does not need to happen
  * (because of having the same dispatcher and not having to wait for the children)
  * *and* the [context] passed to [withContext] contains [NonCancellable],
  * then cancellation of the caller will not prevent a value from being successfully returned.
@@ -465,7 +464,7 @@ private class LazyDeferredCoroutine<T>(
  * ### Returning closeable resources
  *
  * Values returned from [withContext] will typically be lost if the caller is cancelled.
- * The exception is the `withContext(NonCancellable)` pattern.
+ * An important exception is the `withContext(NonCancellable)` pattern.
  *
  * See the corresponding section in the [coroutineScope] documentation for details,
  * as well as the [NonCancellable] documentation.

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -320,32 +320,99 @@ private class LazyDeferredCoroutine<T>(
 // --------------- withContext ---------------
 
 /**
- * Calls the specified suspending block with a given coroutine context, suspends until it completes, and returns
+ * Calls the specified suspending [block] with an updated coroutine context, suspends until it completes, and returns
  * the result.
  *
- * The resulting context for the [block] is derived by merging the current [coroutineContext] with the
- * specified [context] using `coroutineContext + context` (see [CoroutineContext.plus]).
- * This suspending function is cancellable. It immediately checks for cancellation of
- * the resulting context and throws [CancellationException] if it is not [active][CoroutineContext.isActive].
+ * [context] specifies the additional context elements for the coroutine to combine with
+ * the elements already present in the [CoroutineScope.coroutineContext].
+ * It is incorrect to pass a [Job] element there, as this breaks structured concurrency,
+ * unless it is [NonCancellable].
  *
- * Calls to [withContext] whose [context] argument provides a [CoroutineDispatcher] that is
- * different from the current one, by necessity, perform additional dispatches: the [block]
- * can not be executed immediately and needs to be dispatched for execution on
- * the passed [CoroutineDispatcher], and then when the [block] completes, the execution
- * has to shift back to the original dispatcher.
+ * If the resulting [CoroutineScope.coroutineContext] is cancelled before the [block] starts running,
+ * [block] will immediately finish with a [CancellationException],
+ * possibly without even being scheduled for execution.
  *
- * Note that the result of `withContext` invocation is dispatched into the original context in a cancellable way
- * with a **prompt cancellation guarantee**, which means that if the original [coroutineContext]
- * in which `withContext` was invoked is cancelled by the time its dispatcher starts to execute the code,
- * it discards the result of `withContext` and throws [CancellationException].
+ * ## Structured Concurrency
  *
- * The cancellation behaviour described above is enabled if and only if the dispatcher is being changed.
- * For example, when using `withContext(NonCancellable) { ... }` there is no change in dispatcher and
- * this call will not be cancelled neither on entry to the block inside `withContext` nor on exit from it.
+ * The behavior of [withContext] is similar to [coroutineScope], as it, too, creates a new *scoped child coroutine*.
+ * Refer to the documentation of that function for details.
  *
- * It is incorrect to pass any instances of [Job] other than [NonCancellable] to [withContext].
- * The only reason this does not raise an exception is preserving backward compatibility.
- * If the purpose of passing a [Job] to this function is to ensure that [block] gets cancelled when that job
+ * The difference is that [withContext] does not simply call the [block] in a new coroutine
+ * but updates the [currentCoroutineContext] used for running it.
+ *
+ * The context of the new scope is created like this:
+ * - First, [currentCoroutineContext] is combined with the [context] argument.
+ *   In most cases, this means that elements from [context] simply override
+ *   the elements in the [currentCoroutineContext],
+ *   but if they are `CopyableThreadContextElement`s, they are copied and combined as needed.
+ * - Then, the [Job] in the [currentCoroutineContext], if any, is used as the *parent* of the new scope,
+ *   unless overridden.
+ *   Overriding the [Job] is forbidden with the notable exception of [NonCancellable];
+ *   see a separate subsection below for details.
+ *   The new scope's [Job] is added to the resulting context.
+ *
+ * The context of the new scope is obtained by combining the [currentCoroutineContext] with a new [Job]
+ * whose parent is the [Job] of the caller [currentCoroutineContext] (if any).
+ * The [Job] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
+ * meaning that the failure of the [Job] will not affect the parent [Job].
+ * Instead, the exception leading to the failure will be rethrown to the caller of this function.
+ *
+ * ### Overriding the parent job
+ *
+ * #### [NonCancellable]
+ *
+ * Passing [NonCancellable] in the [context] argument is a special case that allows
+ * the [block] to run even if the parent coroutine is cancelled.
+ *
+ * This is useful in particular for performing cleanup operations
+ * if the cleanup procedure is itself a `suspend` function.
+ *
+ * Example:
+ *
+ * ```
+ * class Connection {
+ *     suspend fun terminate()
+ * }
+ *
+ * val connection = Connection()
+ * try {
+ *     // some cancellable operations...
+ * } finally {
+ *     withContext(NonCancellable) {
+ *         // this block will run even if the parent coroutine is cancelled
+ *         connection.terminate()
+ *     }
+ * }
+ * ```
+ *
+ * Beware that combining [NonCancellable] with context elements that change the dispatcher
+ * will make this cleanup code incorrect. See the [NonCancellable] documentation for details.
+ *
+ * #### Other [Job] elements
+ *
+ * Passing a [Job] in the [context] argument breaks structured concurrency and is not a supported pattern.
+ * It does not throw an exception only for backward compatibility reasons, as a lot of code was written this way.
+ * Always structure your coroutines such that the lifecycle of the child coroutine is
+ * contained in the lifecycle of the [CoroutineScope] it is launched in.
+ *
+ * To help with migrating to structured concurrency, the specific behaviour of passing a [Job] in the [context] argument
+ * is described here.
+ * **Do not rely on this behaviour in new code.**
+ *
+ * If [context] contains a [Job] element, it will be the *parent* of the new coroutine,
+ * and the lifecycle of the new coroutine will not be tied to the [CoroutineScope] at all.
+ *
+ * In specific terms:
+ *
+ * - If the [Job] passed to the [context] is cancelled, the new coroutine will be cancelled.
+ * - However, because [withContext] creates a scoped child coroutine, the failure of [block]
+ *   will not cancel the parent [Job].
+ * - If the [currentCoroutineContext] is cancelled, the new coroutine will not be affected.
+ * - In particular, if [withContext] avoided a dispatch (see "Dispatching behavior" below)
+ *   and its block finished without an exception, [withContext] itself will not throw a [CancellationException].
+ *   This means that the block execution will continue even if the parent coroutine was cancelled.
+ *
+ * If the purpose of passing a [Job] to [withContext] is to ensure that [block] gets cancelled when that job
  * gets cancelled, this pattern can be used instead:
  *
  * ```
@@ -370,6 +437,40 @@ private class LazyDeferredCoroutine<T>(
  *
  * This way, the [block] gets cancelled when either the caller or `scopeWithTheRequiredJob` gets cancelled,
  * ensuring that unnecessary computations do not keep executing.
+ *
+ * ## Dispatching behavior
+ *
+ * If [context] provides a [ContinuationInterceptor] other than the one used by the caller,
+ * the [block] can not simply be called inline with the updated context and has to go through a dispatch,
+ * that is, get scheduled on the new [ContinuationInterceptor].
+ * It is up to the [ContinuationInterceptor] to actually run the [block],
+ * and it may take arbitrarily long for that to happen.
+ * After the [block] has completed, the computation has to be dispatched back to the original
+ * [ContinuationInterceptor].
+ *
+ * If the resulting context in which [block] should run has the same [ContinuationInterceptor]
+ * as the caller, no dispatch is performed.
+ * In that case, no dispatch happens on exiting the [block] either, unless child coroutines have to be awaited.
+ *
+ * Note that the result of [withContext] invocation is dispatched into the original context in a cancellable way
+ * with a **prompt cancellation guarantee**, which means that if the original [coroutineContext]
+ * in which [withContext] was invoked is cancelled by the time its dispatcher starts to execute the code,
+ * it discards the result of [withContext] and throws a [CancellationException].
+ *
+ * Note that if the dispatch from [withContext] back to the original context does not need to happen
+ * (because of having the same dispatcher and not having to wait for the children)
+ * *and* the [context] passed to [withContext] contains [NonCancellable],
+ * then cancellation of the caller will not prevent a value from being successfully returned.
+ *
+ * ## Pitfalls
+ *
+ * ### Returning closeable resources
+ *
+ * Values returned from [withContext] will typically be lost if the caller is cancelled.
+ * The exception is the `withContext(NonCancellable)` pattern.
+ *
+ * See the corresponding section in the [coroutineScope] documentation for details,
+ * as well as the [NonCancellable] documentation.
  */
 public suspend fun <T> withContext(
     context: CoroutineContext,

--- a/kotlinx-coroutines-core/common/src/Builders.common.kt
+++ b/kotlinx-coroutines-core/common/src/Builders.common.kt
@@ -62,7 +62,7 @@ import kotlin.jvm.*
  * The details of structured concurrency are described in the [CoroutineScope] interface documentation.
  * Here is a restatement of some main points as they relate to [launch]:
  *
- * - The lifecycle of the parent [CoroutineScope] can not end until this coroutine
+ * - The lifecycle of the parent [CoroutineScope] cannot end until this coroutine
  *   (as well as all its children) completes.
  * - If the parent [CoroutineScope] is cancelled, this coroutine is cancelled as well.
  * - If this coroutine fails with a non-[CancellationException] exception
@@ -122,7 +122,7 @@ import kotlin.jvm.*
  * [launch] is similar to [async] whose block returns a [Unit] value.
  *
  * The only difference is the handling of uncaught coroutine exceptions:
- * if an [async] coroutine fails with an exception, then even if the exception can not be propagated to the parent,
+ * if an [async] coroutine fails with an exception, then even if the exception cannot be propagated to the parent,
  * a [CoroutineExceptionHandler] will not be invoked.
  * Instead, the user of [async] must call [Deferred.await] to get the result of the coroutine,
  * which will be the uncaught exception.
@@ -170,8 +170,8 @@ import kotlin.jvm.*
  *     } catch (e: CancellationException) {
  *         if (isActive) {
  *             // we were not cancelled, this is a failure
- *             println("`result` was cancelled")
- *             throw IllegalStateException("$result was cancelled", e)
+ *             println("`deferred` was cancelled")
+ *             throw IllegalStateException("deferred was cancelled", e)
  *         } else {
  *             println("I was cancelled")
  *             // throw again to finish the coroutine
@@ -245,7 +245,7 @@ public fun CoroutineScope.launch(
  * The details of structured concurrency are described in the [CoroutineScope] interface documentation.
  * Here is a restatement of some main points as they relate to [async]:
  *
- * - The lifecycle of the parent [CoroutineScope] can not end until this coroutine
+ * - The lifecycle of the parent [CoroutineScope] cannot end until this coroutine
  *   (as well as all its children) completes.
  * - If the parent [CoroutineScope] is cancelled, this coroutine is cancelled as well.
  * - If this coroutine fails with a non-[CancellationException] exception
@@ -324,7 +324,7 @@ private class LazyDeferredCoroutine<T>(
  * the result.
  *
  * [context] specifies the additional context elements for the coroutine to combine with
- * the elements already present in the [CoroutineScope.coroutineContext].
+ * the elements already present in the [currentCoroutineContext].
  * It is incorrect to pass a [Job] element there, as this breaks structured concurrency,
  * unless it is [NonCancellable].
  *
@@ -351,8 +351,6 @@ private class LazyDeferredCoroutine<T>(
  *   see a separate subsection below for details.
  *   The new scope's [Job] is added to the resulting context.
  *
- * The context of the new scope is obtained by combining the [currentCoroutineContext] with a new [Job]
- * whose parent is the [Job] of the caller [currentCoroutineContext] (if any).
  * The [Job] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
  * meaning that the failure of the [Job] will not affect the parent [Job].
  * Instead, the exception leading to the failure will be rethrown to the caller of this function.
@@ -400,7 +398,7 @@ private class LazyDeferredCoroutine<T>(
  * **Do not rely on this behaviour in new code.**
  *
  * If [context] contains a [Job] element, it will be the *parent* of the new coroutine,
- * and the lifecycle of the new coroutine will not be tied to the [CoroutineScope] at all.
+ * and the lifecycle of the new coroutine will not be tied to the [currentCoroutineContext] at all.
  *
  * In specific terms:
  *
@@ -441,7 +439,7 @@ private class LazyDeferredCoroutine<T>(
  * ## Dispatching behavior
  *
  * If [context] provides a [ContinuationInterceptor] other than the one used by the caller,
- * the [block] can not simply be called inline with the updated context and has to go through a dispatch,
+ * the [block] cannot simply be called inline with the updated context and has to go through a dispatch,
  * that is, get scheduled on the new [ContinuationInterceptor].
  * It is up to the [ContinuationInterceptor] to actually run the [block],
  * and it may take arbitrarily long for that to happen.
@@ -452,8 +450,8 @@ private class LazyDeferredCoroutine<T>(
  * as the caller, no dispatch is performed.
  * In that case, no dispatch happens on exiting the [block] either, unless child coroutines have to be awaited.
  *
- * Note that the result of [withContext] invocation is dispatched into the original context in a cancellable way
- * with a **prompt cancellation guarantee**, which means that if the original [coroutineContext]
+ * Note that the result of a [withContext] invocation is dispatched into the original context in a cancellable way
+ * with a **prompt cancellation guarantee**, which means that if the original [currentCoroutineContext]
  * in which [withContext] was invoked is cancelled by the time its dispatcher starts to execute the code,
  * it discards the result of [withContext] and throws a [CancellationException].
  *

--- a/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineContext.common.kt
@@ -3,9 +3,18 @@ package kotlinx.coroutines
 import kotlin.coroutines.*
 
 /**
- * Creates a context for a new coroutine. It installs [Dispatchers.Default] when no other dispatcher or
- * [ContinuationInterceptor] is specified and adds optional support for debugging facilities (when turned on)
- * and copyable-thread-local facilities on JVM.
+ * Creates a context for a new coroutine.
+ *
+ * This function is used by coroutine builders to create a new coroutine context.
+ * - It installs [Dispatchers.Default] when no other dispatcher or [ContinuationInterceptor] is specified.
+ * - On the JVM, if the debug mode is enabled, it assigns a unique identifier to every coroutine for tracking it.
+ * - On the JVM, copyable thread-local elements from [CoroutineScope.coroutineContext] and [context]
+ *   are copied and combined as needed.
+ * - The elements of [context] and [CoroutineScope.coroutineContext] other than copyable thread-context ones
+ *   are combined as is, with the elements from [context] overriding the elements from [CoroutineScope.coroutineContext]
+ *   in case of equal [keys][CoroutineContext.Key].
+ *
+ * See the documentation of this function's JVM implementation for platform-specific details.
  */
 public expect fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext
 

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -327,7 +327,7 @@ import kotlin.coroutines.intrinsics.*
  * job.join() // finishes normally
  * ```
  *
- * If a coroutine fails with an exception,
+ * If a coroutine fails with a non-[CancellationException] exception,
  * is not a coroutine created with lexically scoped coroutine builders like [coroutineScope] or [withContext],
  * *and* its parent is a normal [Job] (not a [SupervisorJob]),
  * the parent fails with that exception, too (and the same logic applies recursively to the parent of the parent, etc.):
@@ -374,10 +374,13 @@ import kotlin.coroutines.intrinsics.*
  * the first one to fail will be propagated, and the rest will be attached to it as
  * [suppressed exceptions][Throwable.suppressedExceptions].
  *
- * If a coroutine fails with an exception and cannot cancel its parent
+ * If a coroutine fails with a non-[CancellationException] exception and cannot cancel its parent
  * (because its parent is a [SupervisorJob] or there is none at all),
  * the failure is reported through other channels.
  * See [CoroutineExceptionHandler] for details.
+ *
+ * Failing with a [CancellationException] only cancels the coroutine itself and its children.
+ * It does not affect the parent or any other coroutines and is not considered a failure.
  *
  * ### How-to: stop failures of child coroutines from cancelling other coroutines
  *

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -791,6 +791,9 @@ public object GlobalScope : CoroutineScope {
  *   Note that this happens on any child coroutine's failure even if [block] finishes successfully.
  * - [coroutineScope] will only finish when all the coroutines launched in it finish.
  *   If all of them complete without failing, the [coroutineScope] returns the result of the [block] to the caller.
+ *
+ * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
+ * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
  */
 public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R {
     contract {

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -836,7 +836,8 @@ public object GlobalScope : CoroutineScope {
  * ```
  *
  * If cancellation during the acquisition of the resource is also undesired, the following pattern can be used
- * ([coroutineScope] is not needed here, as [withContext] defines its own [CoroutineScope], but :
+ * ([coroutineScope] would be meaningless here, as [withContext] defines its own [CoroutineScope],
+ * but another lexical scope like [supervisorScope] or [withContext] can be useful as part of this pattern):
  *
  * ```
  * withContext(NonCancellable) {

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -12,12 +12,12 @@ import kotlin.coroutines.intrinsics.*
 /**
  * A scope in which coroutines run.
  *
- * The scope allows managing the lifecycles of several coroutines simultaneously
+ * A coroutine scope allows managing the lifecycles of several coroutines simultaneously
  * and setting the execution properties with which coroutines (its "children") are launched.
  *
- * Execution properties are defined as [CoroutineContext.Element] values that may affect the behavior of
+ * Execution properties are [CoroutineContext.Element] values that may affect the behavior of
  * `kotlinx.coroutines`—for example, which thread pool a coroutine should run on.
- * See a more detailed explanation of the context elements in a separate section below.
+ * See a more detailed explanation of coroutine context elements in a separate section below.
  *
  * A set of rules called "structured concurrency" ensures that the lifecycles of children
  * are nested inside the lifecycles of their parent scopes.
@@ -40,12 +40,8 @@ import kotlin.coroutines.intrinsics.*
  *
  * - The scheduling policy, represented by a [CoroutineDispatcher] element.
  *   Some commonly used dispatchers are provided in the [Dispatchers] object.
- * - [CoroutineExceptionHandler] that defines how failures of child coroutines should be reported whenever
- *   structured concurrency does not provide a way to propagate the failure to the parent.
- *   Typically, this happens because the root scope of the ancestry tree is not lexically scoped,
- *   that is, not created using coroutine builders like [coroutineScope] or [withContext] that return the result
- *   directly to the caller.
- *   See the [CoroutineExceptionHandler] documentation for the full set of rules.
+ * - [CoroutineExceptionHandler] that defines how to handle coroutine failures that cannot
+ *   be propagated to any other coroutine.
  * - A [CoroutineName] element that can be used to name coroutines for debugging purposes.
  * - On the JVM, a `ThreadContextElement` ensures that a specific thread-local value gets set on the thread
  *   that executes the coroutine.
@@ -123,7 +119,6 @@ import kotlin.coroutines.intrinsics.*
  *     MyEntity().use { entity ->
  *         entity.doSomethingWhileEntityExists()
  *         Thread.sleep(200)
- *         entity.close()
  *     }
  * }
  * ```
@@ -221,7 +216,7 @@ import kotlin.coroutines.intrinsics.*
  *         }
  *         launch(Dispatchers.Main) {
  *             // create a separate coroutine on the UI thread
- *             if (file1.await() == file2.await()) {
+ *             if (file1.await().contentEquals(file2.await())) {
  *                 uiShow("Files are equal")
  *             } else {
  *                 uiShow("Files are not equal")
@@ -384,11 +379,6 @@ import kotlin.coroutines.intrinsics.*
  * the first observed failure will be propagated, and the rest will be attached to it as
  * [suppressed exceptions][Throwable.suppressedExceptions].
  *
- * If a non-lexically-scoped coroutine fails with a non-[CancellationException] exception and cannot cancel its parent
- * (because its parent is a [SupervisorJob] or there is none at all),
- * the failure is reported through other means.
- * See [CoroutineExceptionHandler] for details.
- *
  * Failing with a [CancellationException] only cancels the coroutine itself and its children.
  * It does not affect the parent or sibling coroutines and is not considered a failure.
  *
@@ -440,7 +430,7 @@ import kotlin.coroutines.intrinsics.*
  * }
  * ```
  *
- * [CoroutineStart.ATOMIC] ensures that the new coroutine is not cancelled until it is started.
+ * [CoroutineStart.ATOMIC] ensures that the new coroutine is not cancelled until it at least started to execute.
  * [NonCancellable] in [withContext] ensures that the code inside the block is executed even if the coroutine
  * created by [launch] is cancelled.
  */
@@ -450,10 +440,10 @@ public interface CoroutineScope {
      *
      * The context represents various execution properties of the coroutines launched in this scope,
      * such as the [dispatcher][CoroutineDispatcher] or
-     * the [procedure for handling uncaught exceptions][CoroutineExceptionHandler].
+     * the [procedure for handling exceptions without a propagation path][CoroutineExceptionHandler].
      * Except [GlobalScope], a [job][Job] instance for enforcing structured concurrency
      * must also be present in the context of every [CoroutineScope].
-     * See the documentation for [CoroutineScope] for details.
+     * See the documentation of [CoroutineScope] for details.
      *
      * Accessing this property in general code is not recommended for any purposes
      * except accessing the [Job] instance for advanced usages.
@@ -483,7 +473,7 @@ public operator fun CoroutineScope.plus(context: CoroutineContext): CoroutineSco
 /**
  * Creates a [CoroutineScope] for scheduling UI updates.
  *
- * Example of use:
+ * Usage example:
  * ```
  * class MyAndroidActivity: Activity() {
  *     // be careful not to write `get() =` here by accident!
@@ -509,7 +499,6 @@ public operator fun CoroutineScope.plus(context: CoroutineContext): CoroutineSco
  * the other coroutines will not be affected.
  * A [CoroutineExceptionHandler] is not installed.
  *
- * The resulting scope has [SupervisorJob] and [Dispatchers.Main] context elements.
  * If you want to append additional elements to the main scope, use the [CoroutineScope.plus] operator:
  * `val scope = MainScope() + CoroutineName("MyActivity")`.
  *
@@ -533,20 +522,19 @@ public fun MainScope(): CoroutineScope = ContextScope(SupervisorJob() + Dispatch
  *
  * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative),
  * and usually, it's checked if a coroutine is cancelled when it *suspends*, for example,
- * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
+ * when trying to [await][Deferred.await] a [Deferred][kotlinx.coroutines.Deferred] that has not yet completed.
  *
  * Sometimes, a coroutine does not need to perform suspending operations but still wants to be cooperative
  * and respect cancellation.
  *
  * The [isActive] property is intended to be used for scenarios like this:
  * ```
- * val watchdogDispatcher = Dispatchers.IO.limitParallelism(1)
  * fun backgroundWork() {
  *     println("Doing bookkeeping in the background in a blocking manner")
  *     Thread.sleep(100L) // Sleep 100ms
  * }
  * // Part of some non-trivial CoroutineScope-confined lifecycle
- * launch(watchdogDispatcher) {
+ * launch(Dispatchers.IO) {
  *     while (isActive) {
  *         // Repetitively do some background work that is non-suspending
  *         backgroundWork()
@@ -580,10 +568,6 @@ public val CoroutineScope.isActive: Boolean
  * The global scope is used to launch top-level coroutines whose lifecycles are not limited by structured concurrency.
  * Since [GlobalScope] does not have a [Job], it is impossible to cancel all coroutines launched in it.
  * Likewise, there is no way to wait for all coroutines launched in it to finish.
- *
- * Active coroutines launched in `GlobalScope` do not keep the process alive.
- * They are similar to [daemon threads][https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDaemon-boolean-]
- * in this regard.
  *
  * This is a **delicate** API. [GlobalScope] is easy to use to create new coroutines,
  * avoiding all bureaucracy of structured concurrency, but it also means losing all its benefits.
@@ -646,9 +630,9 @@ public val CoroutineScope.isActive: Boolean
  * ### Crashes
  *
  * [GlobalScope] does not have a [CoroutineExceptionHandler] installed.
- * This means that exceptions thrown in coroutines created using [launch] will be uncaught,
- * leading to platform-specific behavior, such as crashing the application (on Android and Kotlin/Native)
- * or populating the logs with potentially unnecessary information (on non-Android JVM, JS, and Wasm).
+ * This means that exceptions thrown in coroutines created using [launch] will lead to platform-specific
+ * last-resort error propagation behavior, such as crashing the application (on Android, Kotlin/Native, and JS)
+ * or populating the logs with potentially unnecessary information (on non-Android JVM).
  * Please see [CoroutineExceptionHandler] for details.
  *
  * ```
@@ -700,7 +684,7 @@ public val CoroutineScope.isActive: Boolean
  * }
  * ```
  *
- * A common pattern is to use [withContext] in a top-level `suspend fun main()` function:
+ * A useful pattern is to use [withContext] in a top-level `suspend fun main()` function:
  *
  * ```
  * suspend fun main() {
@@ -760,19 +744,21 @@ public object GlobalScope : CoroutineScope {
  *
  * The lifecycle of the new [Job] begins with starting the [block] and completes when both the [block] and
  * all the coroutines launched in the scope complete.
+ * Only then can the [coroutineScope] call return a value.
  *
  * The context of the new scope is obtained by combining the [currentCoroutineContext] with a new [Job]
  * whose parent is the [Job] of the caller [currentCoroutineContext] (if any).
- * The [Job] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
+ * This parent-child relationship ensures that whenever the caller gets cancelled, so does the new scope.
+ *
+ * The [Job] of the new scope is not a normal child of the caller coroutine but a **lexically scoped** one,
  * meaning that the failure of the [Job] will not affect the parent [Job].
  * Instead, the exception leading to the failure will be rethrown to the caller of this function.
  *
- * If any child coroutine in this scope fails with an exception,
+ * If [block] or any child coroutine in this scope fails with an exception,
  * the scope fails, cancelling all the other children and its own [block].
  * See [supervisorScope] for a similar function that allows child coroutines to fail independently.
  *
- * Together, this makes [coroutineScope] suitable for representing a task
- * that can be split into several subtasks,
+ * [coroutineScope] is suitable for representing a task that can be split into several subtasks,
  * which can be executed concurrently but have their results combined at some point,
  * all in the span of running a single function:
  *
@@ -794,21 +780,10 @@ public object GlobalScope : CoroutineScope {
  * }
  * ```
  *
- * Rephrasing this in more practical terms, the specific list of structured concurrency interactions is as follows:
- * - Cancelling the caller's [currentCoroutineContext] leads to cancellation of the new [CoroutineScope]
- *   (corresponding to the code running in the [block]), which in turn cancels all the coroutines launched in it.
- * - If the new [CoroutineScope] fails with an exception
- *   (which happens if either its [block] or any child coroutine fails with an exception),
- *   the exception is rethrown to the caller,
- *   without directly affecting the caller's [Job].
- *   Note that this happens on any child coroutine's failure even if [block] finishes successfully.
- * - [coroutineScope] will only finish when all the coroutines launched in it finish.
- *   If all of them complete without failing, the [coroutineScope] returns the result of the [block] to the caller.
- *
  * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
  * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
  *
- * ## Pitfall: returning closeable resources from a scoped coroutine
+ * ## Pitfall: returning closeable resources from a lexically scoped coroutine
  *
  * The returned value must be safe to drop without any extra cleanup. For example, this code is incorrect:
  *
@@ -845,9 +820,7 @@ public object GlobalScope : CoroutineScope {
  * }
  * ```
  *
- * If cancellation during the acquisition of the resource is also undesired, the following pattern can be used
- * ([coroutineScope] would be meaningless here, as [withContext] defines its own [CoroutineScope],
- * but another lexical scope like [supervisorScope] or [withContext] can be useful as part of this pattern):
+ * If cancellation during the acquisition of the resource is also undesired, the following pattern can be used:
  *
  * ```
  * withContext(NonCancellable) {
@@ -858,10 +831,12 @@ public object GlobalScope : CoroutineScope {
  * }
  * ```
  *
+ * See [NonCancellable] for details.
+ *
  * Be aware, however, that like any [NonCancellable] usage, this creates the risk of accessing values past the point
  * where they are valid.
  * For example, if the caller coroutine scope is tied to the lifecycle of a UI element, with cancellation meaning
- * that the UI element was already disposed of, accessing it during the acquisition of a resource or
+ * that the UI element was already disposed of, accessing the UI during the acquisition of a resource or
  * before the first suspension point in [use] is not allowed and may lead to crashes.
  */
 public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R {
@@ -1036,7 +1011,7 @@ public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R 
  * ```
  *
  * This behavior is suitable for cases where one task is decomposed into several subtasks,
- * and one failure means the whole operation can no longer succeed and will have to be cancelled.
+ * so one failure means the whole operation can no longer succeed and will have to be cancelled.
  * However, in the far more common scenarios where `CoroutineScope()` represents the lifecycle of some entity
  * that supports multiple independent concurrent operations,
  * this is not the desired behavior.
@@ -1051,8 +1026,8 @@ public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R 
  * Examples of this include `CoroutineScope(currentCoroutineContext())`, `CoroutineScope(coroutineContext)`,
  * `CoroutineScope(scope.coroutineContext)`, or any variations thereof that add new elements or remove existing ones.
  *
- * In all of these cases, the [Job] in the context of the new scope will be used as the parent job of all the
- * coroutines in the newly created scope, meaning this scope will essentially be a view of some other scope,
+ * In all of these cases, the [Job] passed in the argument will become the [Job] of the newly created [CoroutineScope],
+ * meaning this scope will essentially be a view of some other scope,
  * similar to what the [CoroutineScope.plus] operation produces.
  *
  * ```
@@ -1094,7 +1069,7 @@ public suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R 
  * ```
  *
  * If launching a coroutine in the context of the caller is the desired behavior,
- * make it explicit by passing the context:
+ * make it explicit by passing the outer scope as a parameter:
  *
  * ```
  * fun foo(scope: CoroutineScope) {
@@ -1147,7 +1122,7 @@ public fun CoroutineScope(context: CoroutineContext): CoroutineScope =
  *     }
  * ```
  *
- * Failing to cancel the scope when it is no longer needed will lead to resource leaks
+ * Failing to cancel the scope when it is no longer in active use will lead to resource leaks
  * and can also potentially crash the program if some object used by the child coroutines becomes destroyed.
  *
  * ### Cancelling lexical [CoroutineScope]
@@ -1245,21 +1220,20 @@ public fun CoroutineScope.cancel(message: String, cause: Throwable? = null): Uni
  *
  * Coroutine cancellation [is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative),
  * and normally, it's checked if a coroutine is cancelled when it *suspends*, for example,
- * when trying to read from a [channel][kotlinx.coroutines.channels.Channel] that is empty.
+ * when trying to [await][Deferred.await] a [Deferred][kotlinx.coroutines.Deferred] that has not yet completed.
  *
  * Sometimes, a coroutine does not need to perform suspending operations but still wants to be cooperative
  * and respect cancellation.
  *
  * [ensureActive] function is intended to be used for these scenarios and immediately bubble up the cancellation exception:
  * ```
- * val watchdogDispatcher = Dispatchers.IO.limitParallelism(1)
  * fun backgroundWork() {
  *     println("Doing bookkeeping in the background in a non-suspending manner")
  *     Thread.sleep(100L) // Sleep 100ms
  * }
  * fun postBackgroundCleanup() = println("Doing something else")
  * // Part of some non-trivial CoroutineScope-confined lifecycle
- * launch(watchdogDispatcher) {
+ * launch(Dispatchers.IO) {
  *     while (true) {
  *         // Repeatedly do some background work that is non-suspending
  *         backgroundWork()
@@ -1281,6 +1255,18 @@ public fun CoroutineScope.cancel(message: String, cause: Throwable? = null): Uni
  * }
  * ```
  *
+ * Alternatively, [yield] can be used to both ensure that [currentCoroutineContext] is active
+ * and give other coroutines a chance to run on this thread:
+ *
+ * ```
+ * suspend fun doSomething() {
+ *     // yield the thread to other coroutines
+ *     yield()
+ *     // ...
+ * }
+ * ```
+ *
+ * @see yield for a version that gives other coroutines a chance to run on this thread.
  * @see CoroutineScope.isActive for a version that returns a boolean value instead of throwing an exception.
  */
 public fun CoroutineScope.ensureActive(): Unit = coroutineContext.ensureActive()

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -92,7 +92,7 @@ import kotlin.coroutines.intrinsics.*
  * When the lifecycle of the scope is not limited lexically
  * (for example, when coroutines should outlive the function that creates them)
  * but is tied to the lifecycle of some entity, the [CoroutineScope] constructor function can be used
- * to define a personal scope for that entity that should be stored as a field there.
+ * to define a personal scope for the entity. This scope should be stored as a field in the entity.
  *
  * **The key part of using a custom `CoroutineScope` is cancelling it at the end of the lifecycle.**
  * The [CoroutineScope.cancel] extension function shall be used when the entity launching coroutines

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -16,12 +16,12 @@ import kotlin.coroutines.intrinsics.*
  * and setting the execution properties with which coroutines (its "children") are launched.
  *
  * Execution properties are defined as [CoroutineContext.Element] values that may affect the behavior of
- * `kotlinx.coroutines`--for example, which thread pool a coroutine should run on.
+ * `kotlinx.coroutines`—for example, which thread pool a coroutine should run on.
  * See a more detailed explanation of the context elements in a separate section below.
  *
  * A set of rules called "structured concurrency" ensures that the lifecycles of children
  * are nested inside the lifecycles of their parent scopes.
- * For example, a scope is cancelled, all coroutines in it are cancelled too, and the scope itself
+ * For example, if a scope is cancelled, all coroutines in it are cancelled too, and the scope itself
  * cannot be completed until all its children are completed.
  * See a more detailed explanation of structured concurrency in a separate section below.
  *
@@ -45,6 +45,7 @@ import kotlin.coroutines.intrinsics.*
  *   Typically, this happens because the root scope of the ancestry tree is not lexically scoped,
  *   that is, not created using coroutine builders like [coroutineScope] or [withContext] that return the result
  *   directly to the caller.
+ *   See the [CoroutineExceptionHandler] documentation for the full set of rules.
  * - A [CoroutineName] element that can be used to name coroutines for debugging purposes.
  * - On the JVM, a `ThreadContextElement` ensures that a specific thread-local value gets set on the thread
  *   that executes the coroutine.
@@ -202,10 +203,10 @@ import kotlin.coroutines.intrinsics.*
  * ```
  * suspend fun downloadFile(url: String): ByteArray {
  *     return withContext(Dispatchers.IO) {
- *         // this code will execute on the UI thread
+ *         // this code will execute on a thread for blocking work
  *         val file = byteArrayOf()
  *         // download the file
- *         return file
+ *         file
  *     }
  * }
  *
@@ -344,7 +345,7 @@ import kotlin.coroutines.intrinsics.*
  *             launch {
  *                 // This cancels the `coroutineScope` coroutine, since
  *                 // 1. The coroutine fails with a non-`CancellationException` exception,
- *                 // 2. `launch` is not a lexically scope coroutine builder,
+ *                 // 2. `launch` is not a lexically scoped coroutine builder,
  *                 // 3. `coroutineScope` has a non-supervisor `Job`
  *                 throw IllegalStateException()
  *             }
@@ -389,7 +390,7 @@ import kotlin.coroutines.intrinsics.*
  * See [CoroutineExceptionHandler] for details.
  *
  * Failing with a [CancellationException] only cancels the coroutine itself and its children.
- * It does not affect the parent or any sibling coroutines and is not considered a failure.
+ * It does not affect the parent or sibling coroutines and is not considered a failure.
  *
  * ### How-to: stop failures of child coroutines from cancelling other coroutines
  *
@@ -413,13 +414,13 @@ import kotlin.coroutines.intrinsics.*
  *
  * ```
  * supervisorScope {
- *     val failingCoroutine = scope.launch(Dispatchers.IO + CoroutineExceptionHandler { _, e ->
+ *     val failingCoroutine = launch(CoroutineExceptionHandler { _, e ->
  *         println("Coroutine failed with exception $e")
  *     }) {
  *         throw IllegalStateException("This exception will not cancel the scope")
  *     }
  *     failingCoroutine.join()
- *     launch(Dispatchers.IO) {
+ *     launch {
  *         println("This coroutine is active! See: ${isActive}")
  *     }
  * }
@@ -480,7 +481,7 @@ public operator fun CoroutineScope.plus(context: CoroutineContext): CoroutineSco
     ContextScope(coroutineContext + context)
 
 /**
- * Creates the a [CoroutineScope] for scheduling UI updates.
+ * Creates a [CoroutineScope] for scheduling UI updates.
  *
  * Example of use:
  * ```
@@ -732,7 +733,7 @@ public val CoroutineScope.isActive: Boolean
  * ```
  * // A global coroutine to log statistics every second, must be always active
  * @OptIn(DelicateCoroutinesApi::class)
- * val globalScopeReporter = GlobalScope.launch(CoroutineExceptionHandler) { _, e ->
+ * val globalScopeReporter = GlobalScope.launch(CoroutineExceptionHandler { _, e ->
  *     logFatalError("Error in the global statistics-logging coroutine: $e")
  * }) {
  *     while (true) {
@@ -778,7 +779,7 @@ public object GlobalScope : CoroutineScope {
  * ```
  * // If the current coroutine is cancelled, `firstFile`, `secondFile`,
  * // and `await()` get cancelled.
- * fun downloadAndCompareTwoFiles() = coroutineScope {
+ * suspend fun downloadAndCompareTwoFiles() = coroutineScope {
  *     val firstFile = async {
  *         // If this fails, `secondFile` and `await()` get cancelled,
  *         // and `downloadAndCompareTwoFiles` rethrows the exception,
@@ -809,7 +810,7 @@ public object GlobalScope : CoroutineScope {
  *
  * ## Pitfall: returning closeable resources from a scoped coroutine
  *
- * [R] must be a value that can safely be dropped. For example, this code is incorrect:
+ * The returned value must be safe to drop without any extra cleanup. For example, this code is incorrect:
  *
  * ```
  * // DO NOT DO THIS

--- a/kotlinx-coroutines-core/common/src/CoroutineScope.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineScope.kt
@@ -12,20 +12,16 @@ import kotlin.coroutines.intrinsics.*
 /**
  * A scope in which coroutines run.
  *
- * A scope defines a group of coroutines with shared execution properties
- * and mutually dependent lifecycles.
+ * The scope allows managing the lifecycles of several coroutines simultaneously
+ * and setting the execution properties with which coroutines (its "children") are launched.
  *
- * The execution properties of coroutines are defined by the [coroutineContext] property of this interface
- * and are inherited by all coroutines launched in this scope.
- * A [CoroutineContext] is a collection of [CoroutineContext.Element] values that may affect the behavior of
- * `kotlinx.coroutines`.
- * For example, the [CoroutineDispatcher] element of the context defines which threads the coroutines will run on,
- * with [Dispatchers.Main] meaning the coroutines will run on the main thread of the application.
+ * Execution properties are defined as [CoroutineContext.Element] values that may affect the behavior of
+ * `kotlinx.coroutines`--for example, which thread pool a coroutine should run on.
  * See a more detailed explanation of the context elements in a separate section below.
  *
- * The lifecycles of coroutines are governed by a set of rules called "structured concurrency",
- * meaning that the lifetimes of child coroutines are strictly inside the lifetime of the scope.
- * If a scope is cancelled, all coroutines in it are cancelled too, and the scope itself
+ * A set of rules called "structured concurrency" ensures that the lifecycles of children
+ * are nested inside the lifecycles of their parent scopes.
+ * For example, a scope is cancelled, all coroutines in it are cancelled too, and the scope itself
  * cannot be completed until all its children are completed.
  * See a more detailed explanation of structured concurrency in a separate section below.
  *
@@ -299,14 +295,14 @@ import kotlin.coroutines.intrinsics.*
  * ```
  *
  * Such a [CoroutineScope] receiver is provided for [launch], [async], and other coroutine builders,
- * as well as for scoping functions like [coroutineScope], [supervisorScope], and [withContext].
+ * as well as for lexically scoping functions like [coroutineScope], [supervisorScope], and [withContext].
  * Each of these [CoroutineScope] instances is tied to the lifecycle of the code block it runs in.
  *
  * Like the example above shows, a coroutine does not complete until all its children are completed.
  * This means that [Job.join] on a [launch] or [async] result or [Deferred.await] on an [async] result
- * will not return until all the children of that coroutine are completed,
- * and scoping functions like [coroutineScope] and [withContext] will not return until all the coroutines
- * launched in them are completed.
+ * will not return until all the children of that coroutine are completed.
+ * Likewise, lexically scoping functions like [coroutineScope] and [withContext] will not return
+ * until all the coroutines launched in them are completed.
  *
  * #### Interactions between coroutines
  *
@@ -331,16 +327,27 @@ import kotlin.coroutines.intrinsics.*
  * job.join() // finishes normally
  * ```
  *
- * If a coroutine fails with a non-[CancellationException] exception,
- * is not a coroutine created with lexically scoped coroutine builders like [coroutineScope] or [withContext],
- * *and* its parent is a normal [Job] (not a [SupervisorJob]),
- * the parent fails with that exception, too (and the same logic applies recursively to the parent of the parent, etc.):
+ * A failure of a child coroutine causes the parent to fail with the same exception if all of the following conditions
+ * are met:
+ * 1. The exception is not a [CancellationException].
+ * 2. The failed child coroutine was not created with lexically scoped coroutine builders
+ *    like [coroutineScope] or [withContext].
+ * 3. The parent coroutine's [Job] is not a [SupervisorJob].
+ *
+ * The same logic applies recursively to the parent of the parent, etc.
+ * Example:
  *
  * ```
  * check(
  *     runCatching {
  *         coroutineScope {
- *             launch { throw IllegalStateException() }
+ *             launch {
+ *                 // This cancels the `coroutineScope` coroutine, since
+ *                 // 1. The coroutine fails with a non-`CancellationException` exception,
+ *                 // 2. `launch` is not a lexically scope coroutine builder,
+ *                 // 3. `coroutineScope` has a non-supervisor `Job`
+ *                 throw IllegalStateException()
+ *             }
  *             launch {
  *                 // this coroutine will be cancelled
  *                 // when the parent gets cancelled
@@ -350,10 +357,8 @@ import kotlin.coroutines.intrinsics.*
  *     }.exceptionOrNull()
  *     is IllegalStateException
  * )
- * // the calling coroutine will *not* be cancelled,
- * // even though the caller is a parent of the failed `coroutineScope`,
- * // because `coroutineScope` is a lexically scoped coroutine builder,
- * // which propagate their exceptions by rethrowing them.
+ * // The currently running coroutine will *not* be cancelled
+ * // because the failed coroutine (`coroutineScope`) is lexically scoped.
  * check(currentCoroutineContext().isActive)
  * ```
  *
@@ -380,7 +385,7 @@ import kotlin.coroutines.intrinsics.*
  *
  * If a non-lexically-scoped coroutine fails with a non-[CancellationException] exception and cannot cancel its parent
  * (because its parent is a [SupervisorJob] or there is none at all),
- * the failure is reported through other channels.
+ * the failure is reported through other means.
  * See [CoroutineExceptionHandler] for details.
  *
  * Failing with a [CancellationException] only cancels the coroutine itself and its children.

--- a/kotlinx-coroutines-core/common/src/NonCancellable.kt
+++ b/kotlinx-coroutines-core/common/src/NonCancellable.kt
@@ -61,7 +61,7 @@ import kotlin.coroutines.*
  * The reason for this is that [withContext] obeys the **prompt cancellation** principle,
  * which means that dispatching back from it to the original context will fail with a [CancellationException]
  * even if the block passed to [withContext] finished successfully,
- * overriding the original exception thrown by the `try` block, if any.
+ * overriding the original exception thrown by the `try` block.
  *
  * To avoid this, you should use [NonCancellable] as the only element in the context of the `withContext` call,
  * and then inside the block, you can switch to any dispatcher you need:
@@ -101,9 +101,9 @@ import kotlin.coroutines.*
  *
  * Similarly to the case of specifying a dispatcher alongside [NonCancellable] in a [withContext] argument,
  * having to wait for child coroutines can lead to a dispatch at the end of the [withContext] call,
- * which will lead to it throwing a [CancellationException] due to the prompt cancellation guarantee.
+ * causing a [CancellationException] due to the prompt cancellation guarantee.
  *
- * The solution to this is also similar:
+ * The solution to this is similar to the one above:
  *
  * ```
  * withContext(Dispatchers.Main) {

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -33,19 +33,65 @@ public fun SupervisorJob(parent: Job? = null) : CompletableJob = SupervisorJobIm
 public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
 
 /**
- * Creates a [CoroutineScope] with [SupervisorJob] and calls the specified suspend [block] with this scope.
- * The provided scope inherits its [coroutineContext][CoroutineScope.coroutineContext] from the outer scope, using the
- * [Job] from that context as the parent for the new [SupervisorJob].
- * This function returns as soon as the given block and all its child coroutines are completed.
+ * Runs the given [block] in-place in a new [CoroutineScope] with a [SupervisorJob]
+ * based on the caller coroutine context, returning its result.
  *
- * Unlike [coroutineScope], a failure of a child does not cause this scope to fail and does not affect its other children,
- * so a custom policy for handling failures of its children can be implemented. See [SupervisorJob] for additional details.
+ * The lifecycle of the new [SupervisorJob] begins with starting the [block] and completes when both the [block] and
+ * all the coroutines launched in the scope complete.
  *
- * If an exception happened in [block], then the supervisor job is failed and all its children are cancelled.
- * If the current coroutine was cancelled, then both the supervisor job itself and all its children are cancelled.
+ * The context of the new scope is obtained by combining the [currentCoroutineContext] with a new [SupervisorJob]
+ * whose parent is the [Job] of the caller [currentCoroutineContext] (if any).
+ * The [SupervisorJob] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
+ * meaning that the failure of the [SupervisorJob] will not affect the parent [Job].
+ * Instead, the exception leading to the failure will be rethrown to the caller of this function.
  *
- * The method may throw a [CancellationException] if the current job was cancelled externally,
- * or rethrow an exception thrown by the given [block].
+ * If a child coroutine launched in the new scope fails, it will not affect the other children of the scope.
+ * However, if the [block] finishes with an exception, it will cancel the scope and all its children.
+ * See [coroutineScope] for a similar function that treats every child coroutine as crucial for obtaining the result
+ * and cancels the whole computation if one of them fails.
+ *
+ * Together, this makes [supervisorScope] a good choice for launching multiple coroutines where some failures
+ * are acceptable and should not affect the others.
+ *
+ * ```
+ * // cancelling the caller's coroutine will cancel the new scope and all its children
+ * suspend fun tryDownloadFiles(urls: List<String>): List<Deferred<ByteArray>> =
+ *     supervisorScope {
+ *         urls.map { url ->
+ *             async {
+ *                 // if one of the downloads fails, the others will continue
+ *                 donwloadFileContent(url)
+ *             }
+ *         }
+ *     } // every download will fail or complete by the time this function returns
+ * ```
+ *
+ * Rephrasing this in more practical terms, the specific list of structured concurrency interactions is as follows:
+ * - Cancelling the caller's [currentCoroutineContext] leads to cancellation of the new [CoroutineScope]
+ *   (corresponding to the code running in the [block]), which in turn cancels all the coroutines launched in it.
+ * - If the [block] fails with an exception, the exception is rethrown to the caller,
+ *   without directly affecting the caller's [Job].
+ * - [supervisorScope] will only finish when all the coroutines launched in it finish.
+ *   After that, the [supervisorScope] returns (or rethrows) the result of the [block] to the caller.
+ *
+ * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
+ * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
+ *
+ * **Pitfall**: [supervisorScope] does not install a [CoroutineExceptionHandler] in the new scope.
+ * This means that if a child coroutine started with [launch] fails, its exception will be unhandled,
+ * possibly crashing the program. Use the following pattern to avoid this:
+ *
+ * ```
+ * withContext(CoroutineExceptionHandler { _, exception ->
+ *     // handle the exceptions as needed
+ * }) {
+ *     supervisorScope {
+ *         // launch child coroutines here
+ *     }
+ * }
+ * ```
+ *
+ * Alternatively, the [CoroutineExceptionHandler] can be supplied to the newly launched coroutines themselves.
  */
 public suspend fun <R> supervisorScope(block: suspend CoroutineScope.() -> R): R {
     contract {

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -77,7 +77,11 @@ public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
  * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
  * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
  *
- * **Pitfall**: [supervisorScope] does not install a [CoroutineExceptionHandler] in the new scope.
+ * ## Pitfalls
+ *
+ * ### Uncaught exceptions in child coroutines
+ *
+ * [supervisorScope] does not install a [CoroutineExceptionHandler] in the new scope.
  * This means that if a child coroutine started with [launch] fails, its exception will be unhandled,
  * possibly crashing the program. Use the following pattern to avoid this:
  *
@@ -92,6 +96,11 @@ public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
  * ```
  *
  * Alternatively, the [CoroutineExceptionHandler] can be supplied to the newly launched coroutines themselves.
+ *
+ * ### Returning closeable resources
+ *
+ * Values returned from [supervisorScope] will be lost if the caller is cancelled.
+ * See the corresponding section in the [coroutineScope] documentation for details.
  */
 public suspend fun <R> supervisorScope(block: suspend CoroutineScope.() -> R): R {
     contract {

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -33,15 +33,17 @@ public fun SupervisorJob(parent: Job? = null) : CompletableJob = SupervisorJobIm
 public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
 
 /**
- * Runs the given [block] in-place in a new [CoroutineScope] with a [SupervisorJob]
- * based on the caller coroutine context, returning its result.
+ * Runs the given [block] in-place in a new [CoroutineScope] that contains a [SupervisorJob]
+ * and is based on the caller coroutine context. The result of [block] is returned.
  *
  * The lifecycle of the new [SupervisorJob] begins with starting the [block] and completes when both the [block] and
  * all the coroutines launched in the scope complete.
  *
  * The context of the new scope is obtained by combining the [currentCoroutineContext] with a new [SupervisorJob]
  * whose parent is the [Job] of the caller [currentCoroutineContext] (if any).
- * The [SupervisorJob] of the new scope is not a normal child of the caller coroutine but a lexically scoped one,
+ * This parent-child relationship ensures that whenever the caller gets cancelled, so does the new scope.
+ *
+ * The [SupervisorJob] of the new scope is not a normal child of the caller coroutine but a **lexically scoped** one,
  * meaning that the failure of the [SupervisorJob] will not affect the parent [Job].
  * Instead, the exception leading to the failure will be rethrown to the caller of this function.
  *
@@ -50,7 +52,7 @@ public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
  * See [coroutineScope] for a similar function that treats every child coroutine as crucial for obtaining the result
  * and cancels the whole computation if one of them fails.
  *
- * Together, this makes [supervisorScope] a good choice for launching multiple coroutines where some failures
+ * [supervisorScope] is a good choice for launching multiple coroutines where some failures
  * are acceptable and should not affect the others.
  *
  * ```
@@ -65,14 +67,6 @@ public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
  *         }
  *     } // every download will fail or complete by the time this function returns
  * ```
- *
- * Rephrasing this in more practical terms, the specific list of structured concurrency interactions is as follows:
- * - Cancelling the caller's [currentCoroutineContext] leads to cancellation of the new [CoroutineScope]
- *   (corresponding to the code running in the [block]), which in turn cancels all the coroutines launched in it.
- * - If the [block] fails with an exception, the exception is rethrown to the caller,
- *   without directly affecting the caller's [Job].
- * - [supervisorScope] will only finish when all the coroutines launched in it finish.
- *   After that, the [supervisorScope] returns (or rethrows) the result of the [block] to the caller.
  *
  * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
  * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.

--- a/kotlinx-coroutines-core/common/src/Supervisor.kt
+++ b/kotlinx-coroutines-core/common/src/Supervisor.kt
@@ -13,7 +13,7 @@ import kotlin.jvm.*
 /**
  * Creates a _supervisor_ job object in an active state.
  * Children of a supervisor job can fail independently of each other.
- * 
+ *
  * A failure or cancellation of a child does not cause the supervisor job to fail and does not affect its other children,
  * so a supervisor can implement a custom policy for handling failures of its children:
  *
@@ -60,7 +60,7 @@ public fun SupervisorJob0(parent: Job? = null) : Job = SupervisorJob(parent)
  *         urls.map { url ->
  *             async {
  *                 // if one of the downloads fails, the others will continue
- *                 donwloadFileContent(url)
+ *                 downloadFileContent(url)
  *             }
  *         }
  *     } // every download will fail or complete by the time this function returns

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -14,8 +14,8 @@ import kotlin.time.*
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Shortcut for calling [withTimeout] with a [Duration] timeout of [timeMillis] milliseconds.
- * Please see that overload for details.
+ * Shorthand form for calling [withTimeout] with a [Duration] timeout of [timeMillis] milliseconds.
+ * Please see the overload accepting a [Duration] for details.
  *
  * > Note: the behavior of this function can be different from [withTimeout] if [timeMillis] is greater than
  * `Long.MAX_VALUE / 2` milliseconds.
@@ -31,21 +31,21 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
 }
 
 /**
- * Calls the specified suspending [block] with the specified [timeout], suspends until it completes,
+ * Calls the given suspending [block] with the specified [timeout], suspends until it completes,
  * and returns the result.
  *
  * If the [block] execution times out, it is cancelled with a [TimeoutCancellationException].
- * If the [timeout] is non-positive, this happens immediately and the [block] is not executed.
+ * If the [timeout] is non-positive, this happens immediately, and the [block] is not executed.
  *
- * The cancellation on timeout is asynchronous with respect to the code running in the block
- * and may happen at any time, even after the [block] finishes executing but before the caller gets resumed with
- * the result.
+ * Cancellation on timeout runs concurrently the code running in the block and may happen at any time,
+ * even after the [block] finishes executing but before the caller gets resumed with the result.
  *
- * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].
+ * > Implementation note: how the time is tracked exactly is an implementation detail of the [CoroutineDispatcher]
+ * in the [currentCoroutineContext].
  *
  * ## Structured Concurrency
  *
- * [withTimeout] behaves like [coroutineScope], as it, too, creates a new *scoped child coroutine*.
+ * [withTimeout] behaves like [coroutineScope], as it, too, creates a new *lexically scoped child coroutine*.
  * Refer to the documentation of [coroutineScope] for details.
  *
  * ## Pitfalls
@@ -54,9 +54,9 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  *
  * [withTimeout] will not automatically stop all code inside it from being executed once the timeout gets triggered.
  * It only cancels the running [block], but it's up to the [block] to notice that it was cancelled, for example,
- * using [ensureActive], checking [isActive], or using [suspendCancellableCoroutine].
+ * by suspending or checking [isActive].
  *
- * For example, this JVM code will run to completion, taking 10 seconds to do so:
+ * This JVM code will run to completion, taking 10 seconds to do so:
  *
  * ```
  * withTimeout(1.seconds) {
@@ -104,7 +104,7 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  * }
  * ```
  *
- * If [withTimeout] has to return a nullable value and [withTimeoutOrNull] cannot be used,
+ * If [withTimeout] has to return a nullable value, and so [withTimeoutOrNull] cannot be used,
  * this pattern can help instead:
  *
  * ```
@@ -123,7 +123,7 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  * ```
  *
  * Another option is to specify the timeout action in a [select] invocation
- * with [onTimeout][SelectBuilder.onTimeout] clause.
+ * with an [onTimeout][SelectBuilder.onTimeout] clause.
  *
  * ### Returning closeable resources
  *
@@ -142,8 +142,8 @@ public suspend fun <T> withTimeout(timeout: Duration, block: suspend CoroutineSc
 }
 
 /**
- * Shortcut for calling [withTimeoutOrNull] with a [Duration] timeout of [timeMillis] milliseconds.
- * Please see that overload for details.
+ * Shorthand form for calling [withTimeoutOrNull] with a [Duration] timeout of [timeMillis] milliseconds.
+ * Please see the overload accepting a [Duration] for details.
  *
  * > Note: the behavior of this function can be different from [withTimeoutOrNull] if [timeMillis] is greater than
  * `Long.MAX_VALUE / 2` milliseconds.
@@ -156,7 +156,7 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
         return suspendCoroutineUninterceptedOrReturn { uCont ->
             val timeoutCoroutine = TimeoutCoroutine(timeMillis, uCont)
             coroutine = timeoutCoroutine
-            setupTimeout<T?, T?>(timeoutCoroutine, block)
+            setupTimeout(timeoutCoroutine, block)
         }
     } catch (e: TimeoutCancellationException) {
         // Return null if it's our exception, otherwise propagate it upstream (e.g. in case of nested withTimeouts)
@@ -168,21 +168,21 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
 }
 
 /**
- * Calls the specified suspending [block] with the specified [timeout], suspends until it completes,
+ * Calls the given suspending [block] with the specified [timeout], suspends until it completes,
  * and returns the result.
  *
  * If the [block] execution times out, it is cancelled with a [TimeoutCancellationException].
- * If the [timeout] is non-positive, this happens immediately and the [block] is not executed.
+ * If the [timeout] is non-positive, this happens immediately, and the [block] is not executed.
  *
- * The cancellation on timeout is asynchronous with respect to the code running in the block
- * and may happen at any time, even after the [block] finishes executing but before the caller gets resumed with
- * the result.
+ * Cancellation on timeout runs concurrently the code running in the block and may happen at any time,
+ * even after the [block] finishes executing but before the caller gets resumed with the result.
  *
- * > Implementation note: how the time is tracked exactly is an implementation detail of the context's [CoroutineDispatcher].
+ * > Implementation note: how the time is tracked exactly is an implementation detail of the [CoroutineDispatcher]
+ * in the [currentCoroutineContext].
  *
  * ## Structured Concurrency
  *
- * [withTimeoutOrNull] behaves like [coroutineScope], as it, too, creates a new *scoped child coroutine*.
+ * [withTimeoutOrNull] behaves like [coroutineScope], as it, too, creates a new *lexically scoped child coroutine*.
  * Refer to the documentation of [coroutineScope] for details.
  *
  * ## Pitfalls
@@ -192,9 +192,9 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
  * [withTimeoutOrNull] will not automatically stop all code inside it from being executed
  * once the timeout gets triggered.
  * It only cancels the running [block], but it's up to the [block] to notice that it was cancelled, for example,
- * using [ensureActive], checking [isActive], or using [suspendCancellableCoroutine].
+ * by suspending or checking [isActive].
  *
- * For example, this JVM code will run to completion, taking 10 seconds to do so:
+ * This JVM code will run to completion, taking 10 seconds to do so:
  *
  * ```
  * withTimeoutOrNull(1.seconds) {

--- a/kotlinx-coroutines-core/common/src/Timeout.kt
+++ b/kotlinx-coroutines-core/common/src/Timeout.kt
@@ -67,7 +67,7 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  * On the JVM, use the `runInterruptible` function to propagate cancellations
  * to blocking JVM code as thread interruptions.
  *
- * See the [Cancellation is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative).
+ * See the [Make coroutines react to cancellation](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * section of the coroutines guide for details.
  *
  * ### [TimeoutCancellationException] is not considered an error
@@ -104,14 +104,14 @@ public suspend fun <T> withTimeout(timeMillis: Long, block: suspend CoroutineSco
  * }
  * ```
  *
- * If [withTimeout] has to return a nullable value and [withTimeoutOrNull] can not be used,
+ * If [withTimeout] has to return a nullable value and [withTimeoutOrNull] cannot be used,
  * this pattern can help instead:
  *
  * ```
  * coroutineScope {
  *     launch {
  *         try {
- *             withTimeoutOrNull(10.milliseconds) {
+ *             withTimeout(10.milliseconds) {
  *                 // Some operation that is going to time out
  *                 awaitCancellation()
  *             }
@@ -197,7 +197,7 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
  * For example, this JVM code will run to completion, taking 10 seconds to do so:
  *
  * ```
- * withTimeout(1.seconds) {
+ * withTimeoutOrNull(1.seconds) {
  *     Thread.sleep(10_000)
  * }
  * ```
@@ -205,7 +205,7 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
  * On the JVM, use the `runInterruptible` function to propagate cancellations
  * to blocking JVM code as thread interruptions.
  *
- * See the [Cancellation is cooperative](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative).
+ * See the [Make coroutines react to cancellation](https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative)
  * section of the coroutines guide for details.
  *
  * ### Returning closeable resources
@@ -214,7 +214,7 @@ public suspend fun <T> withTimeoutOrNull(timeMillis: Long, block: suspend Corout
  *
  * See the corresponding section in the [coroutineScope] documentation for details.
  *
- * @see withTimeoutOrNull
+ * @see withTimeout
  * @see SelectBuilder.onTimeout
  */
 public suspend fun <T> withTimeoutOrNull(timeout: Duration, block: suspend CoroutineScope.() -> T): T? =

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -118,32 +118,50 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * channel.cancel()
  * ```
  *
- * If this coroutine finishes with an exception, it will close the channel with that exception as the cause,
+ * If this coroutine finishes with an exception, it will attempt to close the channel with that exception as the cause,
  * so after receiving all the existing elements,
  * all further attempts to receive from it will throw the exception with which the coroutine finished.
+ * In addition, the exception will cancel the parent coroutine through structured concurrency.
  *
  * ```
  * val produceJob = Job()
+ * val scope = CoroutineScope(produceJob)
  * // create and populate a channel with a buffer
- * val channel = produce<Int>(produceJob, capacity = Channel.UNLIMITED) {
+ * val channel = scope.produce<Int>(capacity = Channel.UNLIMITED) {
  *     repeat(5) { send(it) }
  *     throw TestException()
  * }
- * produceJob.join() // wait for `produce` to fail
+ * produceJob.join() // wait for the parent of the `produce` to get cancelled
  * check(produceJob.isCancelled == true)
  * // prints 0, 1, 2, 3, 4, then throws `TestException`
  * for (value in channel) { println(value) }
  * ```
  *
- * The exception will not be considered uncaught even if the parent coroutine does not react to it
- * (for example, because it has a [SupervisorJob]).
- * This means that, in the following code, the exception will not be reported anywhere and needs to be handled
- * manually by receiving from the resulting channel:
+ * If the channel is already closed *and* the exception cannot be propagated through structured concurrency
+ * (for example, because the parent has a [SupervisorJob]), the last-resort error-handling logic described in the
+ * [CoroutineExceptionHandler] will get invoked:
  *
  * ```
- * supervisorScope {
- *     produce<Int> {
- *         throw IllegalStateException()
+ * withContext(CoroutineExceptionHandler { ctx, e ->
+ *     // Will be invoked with `Failed to cancel`
+ *     println("Failure in the produce coroutine: $e")
+ * }) {
+ *     supervisorScope {
+ *         // Because the parent job is a supervisor,
+ *         // the exception will not be propagated to the parent.
+ *         val channel = produce(capacity = Channel.UNLIMITED) {
+ *             send(1)
+ *             try {
+ *                 awaitCancellation()
+ *             } catch (e: CancellationException) {
+ *                 throw IllegalStateException("Failed to cancel", e)
+ *             }
+ *         }
+ *         channel.receive()
+ *         // Cancelling a channel also closes it,
+ *         // so now, the exception with which `produce` fails
+ *         // cannot be propagated.
+ *         channel.cancel()
  *     }
  * }
  * ```
@@ -212,9 +230,11 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * - If this coroutine fails with a non-[CancellationException] exception
  *   and the parent [CoroutineScope] has a non-supervisor [Job] in its context,
  *   the parent [Job] is cancelled with this exception.
- * - If this coroutine fails with an exception and the parent [CoroutineScope] has a supervisor [Job] or no job at all
+ * - If this coroutine fails with a non-[CancellationException] exception,
+ *   the parent [CoroutineScope] has a supervisor [Job] or no job at all
  *   (as is the case with [GlobalScope] or malformed scopes),
- *   the exception is considered uncaught and is only available through the returned [ReceiveChannel].
+ *   and the channel is already [closed][SendChannel.close],
+ *   the exception cannot be propagated and is handled as the [CoroutineExceptionHandler] documentation describes.
  * - The lifecycle of the [CoroutineScope] passed as the receiver to the [block]
  *   will not end until the [block] completes (or gets cancelled before ever having a chance to run).
  * - If the [block] throws a [CancellationException], the coroutine is considered cancelled,

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -109,7 +109,7 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  *     try {
  *         send(3) // will throw CancellationException
  *     } catch (e: CancellationException) {
- *         println("The channel was cancelled!)
+ *         println("The channel was cancelled!")
  *         throw e // always rethrow CancellationException
  *     }
  * }
@@ -171,13 +171,6 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  *
  * The behavior around coroutine cancellation and error handling is experimental and may change in a future release.
  *
- * ### Coroutine context
- *
- * The coroutine context is inherited from this [CoroutineScope]. Additional context elements can be specified with the [context] argument.
- * If the context does not have any dispatcher or other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * The parent job is inherited from the [CoroutineScope] as well, but it can also be overridden
- * with a corresponding [context] element.
- *
  * See [newCoroutineContext] for a description of debugging facilities available for newly created coroutines.
  *
  * ### Undelivered elements
@@ -211,9 +204,9 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  * ### Interactions between coroutines
  *
  * The details of structured concurrency are described in the [CoroutineScope] interface documentation.
- * Here is a restatement of some main points as they relate to [async]:
+ * Here is a restatement of some main points as they relate to [produce]:
  *
- * - The lifecycle of the parent [CoroutineScope] can not end until this coroutine
+ * - The lifecycle of the parent [CoroutineScope] cannot end until this coroutine
  *   (as well as all its children) completes.
  * - If the parent [CoroutineScope] is cancelled, this coroutine is cancelled as well.
  * - If this coroutine fails with a non-[CancellationException] exception
@@ -221,7 +214,7 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
  *   the parent [Job] is cancelled with this exception.
  * - If this coroutine fails with an exception and the parent [CoroutineScope] has a supervisor [Job] or no job at all
  *   (as is the case with [GlobalScope] or malformed scopes),
- *   the exception is considered uncaught and is only available through the returned [Channel].
+ *   the exception is considered uncaught and is only available through the returned [ReceiveChannel].
  * - The lifecycle of the [CoroutineScope] passed as the receiver to the [block]
  *   will not end until the [block] completes (or gets cancelled before ever having a chance to run).
  * - If the [block] throws a [CancellationException], the coroutine is considered cancelled,

--- a/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
+++ b/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
@@ -12,10 +12,80 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
 /**
- * Runs a new coroutine and **blocks** the current thread until its completion.
+ * Runs the given [block] in-place in a new coroutine based on [context],
+ * **blocking the current thread** until its completion, and then returning its result.
  *
  * It is designed to bridge regular blocking code to libraries that are written in suspending style, to be used in
- * `main` functions and in tests.
+ * `main` functions, in tests, and in non-`suspend` callbacks when `suspend` functions need to be called.
+ *
+ * On the JVM, if this blocked thread is interrupted (see `java.lang.Thread.interrupt`),
+ * then the coroutine job is cancelled and this `runBlocking` invocation throws an `InterruptedException`.
+ * On Kotlin/Native, there is no way to interrupt a thread.
+ *
+ * ## Structured concurrency
+ *
+ * The lifecycle of the new coroutine's [Job] begins with starting the [block] and completes when both the [block] and
+ * all the coroutines launched in the scope complete.
+ *
+ * A new coroutine is created with the following properties:
+ * - A new [Job] for a lexically scoped coroutine is created.
+ *   Its parent is the [Job] from the [context], if any was passed.
+ * - If a [ContinuationInterceptor] is passed in [context],
+ *   it is used as a dispatcher of the new coroutine created by [runBlocking].
+ *   Otherwise, the new coroutine is dispatched to an event loop opened on this thread.
+ * - The other pieces of the context are put into the new coroutine context as is.
+ * - [newCoroutineContext] is called to optionally install debugging facilities.
+ *
+ * The resulting context is available in the [CoroutineScope] passed as the [block]'s receiver.
+ *
+ * Because the new coroutine is lexically scoped, even if a [Job] was passed in the [context],
+ * it will not be cancelled if [runBlocking] or some child coroutine fails with an exception.
+ * Instead, the exception will be rethrown to the caller of this function.
+ *
+ * If any child coroutine in this scope fails with an exception,
+ * the scope fails, cancelling all the other children and its own [block].
+ * If children should fail independently, consider using [supervisorScope]:
+ * ```
+ * runBlocking(CoroutineExceptionHandler { _, e ->
+ *     // handle the exception
+ * }) {
+ *     supervisorScope {
+ *         // Children fail independently here
+ *     }
+ * }
+ * ```
+ *
+ * Rephrasing this in more practical terms, the specific list of structured concurrency interactions is as follows:
+ * - The caller's [currentCoroutineContext] *is not taken into account*, its cancellation does not affect [runBlocking].
+ * - If the new [CoroutineScope] fails with an exception
+ *   (which happens if either its [block] or any child coroutine fails with an exception),
+ *   the exception is rethrown to the caller,
+ *   without affecting the [Job] passed in the [context] (if any).
+ *   Note that this happens on any child coroutine's failure even if [block] finishes successfully.
+ * - Cancelling the [Job] passed in the [context] (if any) cancels the new coroutine and its children.
+ * - [runBlocking] will only finish when all the coroutines launched in it finish.
+ *   If all of them complete without failing, the [runBlocking] returns the result of the [block] to the caller.
+ *
+ * ## Event loop
+ *
+ * The default [CoroutineDispatcher] for this builder is an internal implementation of event loop that processes
+ * continuations in this blocked thread until the completion of this coroutine.
+ *
+ * This event loop is set in a thread-local variable and is accessible to nested [runBlocking] calls and
+ * coroutine tasks forming an event loop
+ * (such as the tasks of [Dispatchers.Unconfined] and [MainCoroutineDispatcher.immediate]).
+ *
+ * Nested [runBlocking] calls may execute other coroutines' tasks instead of running their own tasks.
+ *
+ * When [CoroutineDispatcher] is explicitly specified in the [context], then the new coroutine runs in the context of
+ * the specified dispatcher while the current thread is blocked (and possibly running tasks from other
+ * [runBlocking] calls on the same thread or [Dispatchers.Unconfined]).
+ *
+ * See [CoroutineDispatcher] for the other implementations that are provided by `kotlinx.coroutines`.
+ *
+ * ## Pitfalls
+ *
+ * ### Calling from a suspend function
  *
  * Calling [runBlocking] from a suspend function is redundant.
  * For example, the following code is incorrect:
@@ -25,47 +95,72 @@ import kotlin.jvm.JvmName
  *     val data = runBlocking { // <- redundant and blocks the thread, do not do that
  *         fetchConfigurationData() // suspending function
  *     }
+ *     // ...
  * ```
  *
  * Here, instead of releasing the thread on which `loadConfiguration` runs if `fetchConfigurationData` suspends, it will
  * block, potentially leading to thread starvation issues.
+ * Additionally, the [currentCoroutineContext] will be ignored, and the new computation will run in the context of
+ * the new `runBlocking` coroutine.
  *
- * The default [CoroutineDispatcher] for this builder is an internal implementation of event loop that processes continuations
- * in this blocked thread until the completion of this coroutine.
- * See [CoroutineDispatcher] for the other implementations that are provided by `kotlinx.coroutines`.
- *
- * When [CoroutineDispatcher] is explicitly specified in the [context], then the new coroutine runs in the context of
- * the specified dispatcher while the current thread is blocked. If the specified dispatcher is an event loop of another `runBlocking`,
- * then this invocation uses the outer event loop.
- *
- * If the [context] contains a [Job],
- * that job becomes the parent of the [CoroutineScope] passed as the receiver to the [block].
- * This can be used to establish a structured concurrency relationship across the boundary of a non-`suspend` function:
+ * Instead, write it like this:
  *
  * ```
- * val currentCoroutine = ThreadLocal<Job?>()
+ * suspend fun loadConfiguration() {
+ *     val data = fetchConfigurationData() // suspending function
+ *     // ...
+ * ```
  *
- * interface BlockingInterface {
- *     fun performSomeBlockingTask()
+ * ### Sharing tasks between [runBlocking] calls
+ *
+ * The event loop used by [runBlocking] is shared with the other [runBlocking] calls.
+ * This can lead to surprising and undesired behavior.
+ *
+ * ```
+ * runBlocking {
+ *     val job = launch {
+ *         delay(50.milliseconds)
+ *         println("Hello from the outer child coroutine")
+ *     }
+ *     runBlocking {
+ *         println("Entered the inner runBlocking")
+ *         delay(100.milliseconds)
+ *         println("Leaving the inner runBlocking")
+ *     }
  * }
+ * ```
  *
- * object AsyncImplOfBlockingInterface: BlockingInterface {
- *     override fun performSomeBlockingTask() {
- *         runBlocking(currentCoroutine.get() ?: EmptyCoroutineContext) {
- *             // do some async task
+ * This outputs the following:
+ *
+ * ```
+ * Entered the inner runBlocking
+ * Hello from the outer child coroutine
+ * Leaving the inner runBlocking
+ * ```
+ *
+ * For example, the following code may fail with a stack overflow error:
+ *
+ * ```
+ * runBlocking {
+ *     repeat(1000) {
+ *         launch {
+ *             try {
+ *                 runBlocking {
+ *                     // do nothing
+ *                 }
+ *             } catch (e: Throwable) {
+ *                 println(e)
+ *             }
  *         }
  *     }
  * }
  * ```
  *
- * If this blocked thread is interrupted (see `Thread.interrupt`), then the coroutine job is cancelled and
- * this `runBlocking` invocation throws `InterruptedException`.
+ * The reason is that each new `runBlocking` attempts to run the task of the outer `runBlocking` coroutine inline,
+ * but those, in turn, start new `runBlocking` calls.
  *
- * See [newCoroutineContext][CoroutineScope.newCoroutineContext] for a description of debugging facilities that are available
- * for a newly created coroutine.
- *
- * @param context the context of the coroutine. The default value is an event loop on the current thread.
- * @param block the coroutine code.
+ * The specific behavior of work stealing may change in the future, but is unlikely to be fully fixed,
+ * given how widespread [runBlocking] is.
  */
 @OptIn(ExperimentalContracts::class)
 @JvmName("runBlockingK")

--- a/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
+++ b/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
@@ -25,26 +25,26 @@ import kotlin.jvm.JvmName
  * ## Structured concurrency
  *
  * The lifecycle of the new coroutine's [Job] begins with starting the [block] and completes when both the [block] and
- * all the coroutines launched in the scope complete.
+ * all the coroutines created in the scope complete.
  *
- * A new coroutine is created with the following properties:
+ * The new coroutine executing [block] is created:
  * - A new [Job] for a lexically scoped coroutine is created.
  *   Its parent is the [Job] from the [context], if any was passed.
- * - If a [ContinuationInterceptor] is passed in [context],
- *   it is used as a dispatcher of the new coroutine created by [runBlocking].
- *   Otherwise, the new coroutine is dispatched to an event loop opened on this thread.
- * - The other pieces of the context are put into the new coroutine context as is.
+ * - By default, an event loop opened on this thread is used as the [ContinuationInterceptor].
+ *   This can be overridden by passing a [ContinuationInterceptor] in [context].
+ * - The other elements of [context] are put into the new coroutine context as is.
  * - [newCoroutineContext] is called to optionally install debugging facilities.
  *
- * The resulting context is available in the [CoroutineScope] passed as the [block]'s receiver.
+ * The resulting context is available in the [CoroutineScope] that is passed as the [block]'s receiver.
  *
  * Because the new coroutine is lexically scoped, even if a [Job] was passed in the [context],
  * it will not be cancelled if [runBlocking] or some child coroutine fails with an exception.
  * Instead, the exception will be rethrown to the caller of this function.
+ * However, cancelling the [Job] passed in the [context] does also cancel the new coroutine.
  *
  * If any child coroutine in this scope fails with an exception,
  * the scope fails, cancelling all the other children and its own [block].
- * If children should fail independently, consider using [supervisorScope]:
+ * If it is desired that children fail independently, consider using [supervisorScope]:
  * ```
  * runBlocking(CoroutineExceptionHandler { _, e ->
  *     // handle the exception—necessary when using `supervisorScope`
@@ -55,30 +55,20 @@ import kotlin.jvm.JvmName
  * }
  * ```
  *
- * Rephrasing this in more practical terms, the specific list of structured concurrency interactions is as follows:
- * - The caller's [currentCoroutineContext] *is not taken into account*, its cancellation does not affect [runBlocking].
- * - If the new [CoroutineScope] fails with an exception
- *   (which happens if either its [block] or any child coroutine fails with an exception),
- *   the exception is rethrown to the caller,
- *   without affecting the [Job] passed in the [context] (if any).
- *   Note that this happens on any child coroutine's failure even if [block] finishes successfully.
- * - Cancelling the [Job] passed in the [context] (if any) cancels the new coroutine and its children.
- * - [runBlocking] will only finish when all the coroutines launched in it finish.
- *   If all of them complete without failing, the [runBlocking] returns the result of the [block] to the caller.
- *
  * ## Event loop
  *
- * The default [CoroutineDispatcher] for this builder is an internal implementation of event loop that processes
- * continuations in this blocked thread until the completion of this coroutine.
+ * The default [ContinuationInterceptor] for this builder is an internal implementation of event loop that processes
+ * continuations in the current thread until the completion of the [runBlocking] coroutine.
  *
- * This event loop is set in a thread-local variable and is accessible to nested [runBlocking] calls and
+ * This event loop is set in a thread-local variable and is accessible by nested [runBlocking] calls and
  * coroutine tasks forming an event loop
  * (such as the tasks of [Dispatchers.Unconfined] and [MainCoroutineDispatcher.immediate]).
  *
- * Nested [runBlocking] calls may execute other coroutines' tasks instead of running their own tasks.
+ * Nested [runBlocking] calls may execute other coroutines' tasks from the same event loop
+ * instead of running their own tasks.
  *
- * When [CoroutineDispatcher] is explicitly specified in the [context], then the new coroutine runs in the context of
- * the specified dispatcher while the current thread is blocked (and possibly running tasks from other
+ * If a [ContinuationInterceptor] is present in the [context], the new coroutine runs in the context of
+ * the specified interceptor while the current thread is blocked (and possibly running tasks from other
  * [runBlocking] calls on the same thread or [Dispatchers.Unconfined]).
  *
  * See [CoroutineDispatcher] for the other implementations that are provided by `kotlinx.coroutines`.
@@ -92,7 +82,7 @@ import kotlin.jvm.JvmName
  * ```
  * suspend fun loadConfiguration() {
  *     // DO NOT DO THIS:
- *     val data = runBlocking { // <- redundant and blocks the thread, do not do that
+ *     val data = runBlocking { // <- redundant and blocks the thread, avoid this!
  *         fetchConfigurationData() // suspending function
  *     }
  *     // ...

--- a/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
+++ b/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
@@ -47,7 +47,7 @@ import kotlin.jvm.JvmName
  * If children should fail independently, consider using [supervisorScope]:
  * ```
  * runBlocking(CoroutineExceptionHandler { _, e ->
- *     // handle the exception
+ *     // handle the exception—necessary when using `supervisorScope`
  * }) {
  *     supervisorScope {
  *         // Children fail independently here

--- a/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
+++ b/kotlinx-coroutines-core/jvm/src/CoroutineContext.kt
@@ -5,17 +5,21 @@ import kotlin.coroutines.*
 import kotlin.coroutines.jvm.internal.CoroutineStackFrame
 
 /**
- * Creates a context for a new coroutine. It installs [Dispatchers.Default] when no other dispatcher or
- * [ContinuationInterceptor] is specified and adds optional support for debugging facilities (when turned on)
- * and copyable-thread-local facilities on JVM.
- * See [DEBUG_PROPERTY_NAME] for description of debugging facilities on JVM.
+ * Creates a context for a new coroutine.
  *
- * When [CopyableThreadContextElement] values are used, the logic for processing them is as follows:
- * - If [this] or [context] has a copyable thread-local value whose key is absent in [context] or [this],
- *   it is [copied][CopyableThreadContextElement.copyForChild] to the new context.
- * - If [this] has a copyable thread-local value whose key is present in [context],
- *   it is [merged][CopyableThreadContextElement.mergeForChild] with the one from [context].
- * - The other values are added to the new context as is, with [context] values taking precedence.
+ * See the documentation of this function's common-code implementation for a general overview.
+ * Here, the JVM-specific details are described.
+ *
+ * - If the [debug mode][DEBUG_PROPERTY_NAME] is enabled,
+ *   [newCoroutineContext] assigns a unique identifier to every coroutine for tracking it.
+ *   The ID is visible in [toString] of the coroutine context or its job and in the thread name,
+ *   as well as in the dumps produced by the `kotlinx-coroutines-debug` module.
+ * - [CopyableThreadContextElement] values are combined.
+ *   If both the parent and [context] have the same [CopyableThreadContextElement]
+ *   (when their [key][CoroutineContext.Key] is equal),
+ *   the values are [merged][CopyableThreadContextElement.mergeForChild].
+ *   If only the parent or only the [context] has the [CopyableThreadContextElement],
+ *   the value is [copied][CopyableThreadContextElement.copyForChild].
  */
 @ExperimentalCoroutinesApi
 public actual fun CoroutineScope.newCoroutineContext(context: CoroutineContext): CoroutineContext {

--- a/kotlinx-coroutines-core/jvm/src/future/Future.kt
+++ b/kotlinx-coroutines-core/jvm/src/future/Future.kt
@@ -39,8 +39,8 @@ import kotlin.coroutines.*
  *
  * If [CompletableFuture.complete] or [CompletableFuture.completeExceptionally] are called on the result of the
  * [future], the coroutine gets cancelled *without a cause specified*.
- * This means that even if the future is completed with an exception externally, [CoroutineScope] will not be notified
- * about the error.
+ * This means that even if the future is completed with an exception externally,
+ * the parent [CoroutineScope] will not be notified about the error.
  *
  * @param context the context to be added to the [CoroutineScope.coroutineContext] when creating the new coroutine.
  * @param start the coroutine start strategy. The default value is [CoroutineStart.DEFAULT].

--- a/kotlinx-coroutines-core/jvm/src/future/Future.kt
+++ b/kotlinx-coroutines-core/jvm/src/future/Future.kt
@@ -7,25 +7,46 @@ import java.util.function.*
 import kotlin.coroutines.*
 
 /**
- * Starts a new coroutine and returns its result as an implementation of [CompletableFuture].
+ * Launches a new *child coroutine* of [CoroutineScope] without blocking the current thread
+ * and returns a [CompletableFuture] representing the result of the coroutine's execution.
+ *
  * The running coroutine is cancelled when the resulting future is cancelled or otherwise completed.
  *
- * The coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
- * If the context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * The parent job is inherited from a [CoroutineScope] as well, but it can also be overridden
- * with corresponding [context] element.
+ * [block] is the computation of the new coroutine that will run concurrently.
+ * The [CompletableFuture] will only be completed once both the [block] and all the child coroutines created in it
+ * finish.
  *
- * By default, the coroutine is immediately scheduled for execution.
- * Other options can be specified via `start` parameter. See [CoroutineStart] for details.
- * A value of [CoroutineStart.LAZY] is not supported
- * (since `CompletableFuture` framework does not provide the corresponding capability) and
- * produces [IllegalArgumentException].
+ * [context] specifies the additional context elements for the coroutine to combine with
+ * the elements already present in the [CoroutineScope.coroutineContext].
+ * It is incorrect to pass a [Job] element there, as this breaks structured concurrency.
  *
- * See [newCoroutineContext][CoroutineScope.newCoroutineContext] for a description of debugging facilities that are available for newly created coroutine.
+ * By default, the coroutine is scheduled for execution on its [ContinuationInterceptor].
+ * There is no guarantee that it will start immediately: this is decided by the [ContinuationInterceptor].
+ * It is possible that the new coroutine will be cancelled before starting, in which case its code will not be executed.
+ * The [start] parameter can be used to adjust this behavior. See [CoroutineStart] for details.
+ * The [CoroutineStart.LAZY] value for [start] is not supported, since [CompletableFuture] does not provide an API
+ * for only starting the computation when its result is queried.
  *
- * @param context additional to [CoroutineScope.coroutineContext] context of the coroutine.
- * @param start coroutine start option. The default value is [CoroutineStart.DEFAULT].
- * @param block the coroutine code.
+ * ## Structured Concurrency
+ *
+ * [future] is equivalent to [async] in terms of structured concurrency.
+ *
+ * ## Communicating with the coroutine
+ *
+ * [CompletableFuture.get] can be used to block the current thread until the result of the [future] is available.
+ * If the [future] coroutine fails with an exception, [CompletableFuture.get] will throw an [ExecutionException]
+ * with the original error set as the cause.
+ *
+ * If [CompletableFuture.complete] or [CompletableFuture.completeExceptionally] are called on the result of the
+ * [future], the coroutine gets cancelled *without a cause specified*.
+ * This means that even if the future is completed with an exception externally, [CoroutineScope] will not be notified
+ * about the error.
+ *
+ * @param context the context to be added to the [CoroutineScope.coroutineContext] when creating the new coroutine.
+ * @param start the coroutine start strategy. The default value is [CoroutineStart.DEFAULT].
+ * @param block the coroutine code to be invoked in the child coroutine.
+ * @throws IllegalArgumentException if [CoroutineStart.LAZY] is passed to [start].
+ * @see async for a function that returns `Deferred`, which can be awaited without blocking the thread.
  */
 public fun <T> CoroutineScope.future(
     context: CoroutineContext = EmptyCoroutineContext,


### PR DESCRIPTION
This PR updates the documentation so that it clearly defines the structured concurrency interactions. The updated docs include:
* [x] `CoroutineScope.kt`.
* [x] `supervisorScope`
* [x] `Builders.common.kt`: `launch`, `async`, and the other coroutine builders should document their structured concurrency behaviors.
* [x] The `withTimeout` family of functions.
* [x] `produce`.

Some other functions could benefit from this, but are outside the scope of the PR:
* [ ] Coroutine builders from the reactive integrations.
* [ ] JS+Wasm `promise`.
* [ ] The `future` function.

We should include what's already there in the next release, without trying to complete the change. At the cost of introducing the inconsistency, we'll be able to publish a release sooner, and the feedback on the parts that were changed could inform the future edits.