### PR TITLE
Fix wasm compilation in user project branch

### DIFF
--- a/kotlinx-coroutines-test/api/kotlinx-coroutines-test.klib.api
+++ b/kotlinx-coroutines-test/api/kotlinx-coroutines-test.klib.api
@@ -75,23 +75,6 @@ final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = .
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>) // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
 
 // Targets: [js, wasmJs]
-final class kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting { // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting|null[0]
-    constructor <init>() // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.<init>|<init>(){}[0]
-
-    // Targets: [js]
-    final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>){}[0]
-
-    // Targets: [js]
-    final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>, kotlin/Function1<kotlin/Throwable, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>;kotlin.Function1<kotlin.Throwable,kotlin.Unit>){}[0]
-
-    // Targets: [wasmJs]
-    final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
-
-    // Targets: [wasmJs]
-    final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>, kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>;kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
-}
-
-// Targets: [js, wasmJs]
 final fun (kotlinx.coroutines.test/TestScope).kotlinx.coroutines.test/runTest(kotlin.time/Duration = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest@kotlinx.coroutines.test.TestScope(kotlin.time.Duration;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
 
 // Targets: [js, wasmJs]
@@ -105,3 +88,19 @@ final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = .
 
 // Targets: [js, wasmJs]
 final fun kotlinx.coroutines.test/runTest(kotlin.coroutines/CoroutineContext = ..., kotlin/Long, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines.test/TestScope, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test/runTest|runTest(kotlin.coroutines.CoroutineContext;kotlin.Long;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.test.TestScope,kotlin.Unit>){}[0]
+
+// Targets: [js]
+final class kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting { // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting|null[0]
+    constructor <init>() // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.<init>|<init>(){}[0]
+
+    final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>){}[0]
+    final fun then(kotlin/Function1<kotlin/Unit, kotlin/Unit>, kotlin/Function1<kotlin/Throwable, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.Unit,kotlin.Unit>;kotlin.Function1<kotlin.Throwable,kotlin.Unit>){}[0]
+}
+
+// Targets: [wasmJs]
+final class kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting : kotlin.js/JsAny { // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting|null[0]
+    constructor <init>() // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.<init>|<init>(){}[0]
+
+    final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
+    final fun then(kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>, kotlin/Function1<kotlin.js/JsAny, kotlin/Unit>): kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting // kotlinx.coroutines.test.internal/JsPromiseInterfaceForTesting.then|then(kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>;kotlin.Function1<kotlin.js.JsAny,kotlin.Unit>){}[0]
+}

--- a/kotlinx-coroutines-test/wasmJs/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/wasmJs/src/TestBuilders.kt
@@ -6,7 +6,6 @@ import kotlin.js.*
 
 public actual typealias TestResult = JsPromiseInterfaceForTesting
 
-@Suppress("INFERRED_TYPE_VARIABLE_INTO_POSSIBLE_EMPTY_INTERSECTION")
 internal actual fun createTestResult(testProcedure: suspend CoroutineScope.() -> Unit): TestResult =
     GlobalScope.promise {
         testProcedure()

--- a/kotlinx-coroutines-test/wasmJs/src/internal/JsPromiseInterfaceForTesting.kt
+++ b/kotlinx-coroutines-test/wasmJs/src/internal/JsPromiseInterfaceForTesting.kt
@@ -7,7 +7,7 @@ a parametric class. So, we make a non-parametric class just for this. */
  * @suppress
  */
 @JsName("Promise")
-public external class JsPromiseInterfaceForTesting {
+public external class JsPromiseInterfaceForTesting : JsAny {
     /**
      * @suppress
      */


### PR DESCRIPTION
The suppressed warning was indicating something wrong with the code. After [KT-63348](https://youtrack.jetbrains.com/issue/KT-63348) we get a compilation error

```
file:///C:/Users/Kirill/IdeaProjects/user-projects/kotlinx.coroutines/build/wasm/packages/kotlinx-coroutines-testWasm-test/kotlin/kotlinx-coroutines-testWasm-test.uninstantiated.mjs:269
        const wasmModule = new WebAssembly.Module(wasmBuffer);
                           ^
CompileError: WebAssembly.Module(): Compiling function #6810:"kotlinx.coroutines.test.createTestResult" failed: call[0] expected type (ref null 6), found call of type externref @+775164
    at instantiate (file:///C:/Users/Kirill/IdeaProjects/user-projects/kotlinx.coroutines/build/wasm/packages/kotlinx-coroutines-testWasm-test/kotlin/kotlinx-coroutines-testWasm-test.uninstantiated.mjs:269:28)
    at async file:///C:/Users/Kirill/IdeaProjects/user-projects/kotlinx.coroutines/build/wasm/packages/kotlinx-coroutines-testWasm-test/kotlin/kotlinx-coroutines-testWasm-test.mjs:6:18
```

This commit fixes the compilation and allows us to remove the warning suppression.

PR to master: https://github.com/Kotlin/kotlinx.coroutines/pull/4439