### PR TITLE
Add `doBlocking()` utility method for running coroutines.

### DIFF
--- a/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
+++ b/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
@@ -34,6 +34,6 @@ public expect fun <T> runBlocking(context: CoroutineContext = EmptyCoroutineCont
  * fun foobar() = runBlocking { ... }
  * ```
  */
-public fun <T> doBlocking(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> Unit) {
+public fun doBlocking(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> Unit) {
   runBlocking(context, block)
 }

--- a/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
+++ b/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt
@@ -22,3 +22,18 @@ import kotlin.coroutines.*
  * block, potentially leading to thread starvation issues.
  */
 public expect fun <T> runBlocking(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> T): T
+
+/**
+ * Runs the given coroutine on the current thread, blocking until completion.
+ *
+ * This is like [runBlocking], but returns [Unit] which is a useful utility to run coroutines for their side effect
+ * when [Unit] is expected.
+ *
+ * Example:
+ * ```kt
+ * fun foobar() = runBlocking { ... }
+ * ```
+ */
+public fun <T> doBlocking(context: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> Unit) {
+  runBlocking(context, block)
+}


### PR DESCRIPTION
This is a useful utility method used in places where you want to run a coroutine for its side effect.

E.g.,

```kt
fun main() = doBlocking {
  // ...
}
```

```kt
@Test
fun myTest() = doBlocking {
  // ...
}
```

With `runBlocking()`, if the last line of the coroutine block being run doesn't evaluate to `Unit`, e.g.:

```kt
fun main() {
  runBlocking {
    // ...
    Unit
  }
}
```

the compiler will complain about being unable to infer the type variable T of the block. Inserting a "return value" of `Unit` at the end is necessary to tell the compiler the block's return type.

Similarly, if you do

```kt
@Test
fun myTest() = runBlocking {
  // ...
   Unit
}
```

without the explicit `Unit` "return value" at the end, if the last line evaluates to a non-unit type, you'll get a type mismatch error, or the compiler will infer `myTest()`'s return type to be non-Unit.