### PR TITLE
Use gender-neutral pronouns in Job documentation

### DIFF
--- a/kotlinx-coroutines-core/common/src/Job.kt
+++ b/kotlinx-coroutines-core/common/src/Job.kt
@@ -107,8 +107,8 @@ import kotlin.jvm.*
  * Note, that the [cancel] function on a job only accepts a [CancellationException] as a cancellation cause, thus
  * calling [cancel] always results in a normal cancellation of a job, which does not lead to cancellation
  * of its parent.
- * This way, a parent can [cancel] his children (cancelling all their children recursively, too)
- * without cancelling himself.
+ * This way, a parent can [cancel] its children (cancelling all their children recursively, too)
+ * without cancelling itself.
  *
  * ### Concurrency and synchronization
  *


### PR DESCRIPTION
#### What changed:

Updated comments in Job.kt to use gender-neutral pronouns when referring to parent jobs and their children.

#### Why:

Using "its" when referring to code entities like jobs is more technically accurate and aligns with modern documentation practices for inclusive language.
