### PR TITLE
Update outdated comment in `CoroutineDispatcher.kt`

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -128,7 +128,7 @@ public abstract class CoroutineDispatcher :
      *
      * Note that this example was structured in such a way that it illustrates the parallelism guarantees.
      * In practice, it is usually better to use `Dispatchers.IO` or [Dispatchers.Default] instead of creating a
-     * `backgroundDispatcher`.
+     * `dispatcher`.
      *
      * ### `limitedParallelism(1)` pattern
      *


### PR DESCRIPTION
Renamed `backgroundDispatcher` to `dispatcher` to match the variable name in the sample code.

The variable name was renamed to `dispatcher` in this PR:
https://github.com/Kotlin/kotlinx.coroutines/pull/4098/files