### PR TITLE
Fix misleading documentation comment for Dispatchers.IO

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -25,7 +25,7 @@ public actual object Dispatchers {
      * The [CoroutineDispatcher] that is designed for offloading blocking IO tasks to a shared pool of threads.
      *
      * Additional threads in this pool are created and are shutdown on demand.
-     * The number of threads used by tasks in this dispatcher is limited by the value of
+     * The parallelism of tasks in this dispatcher is limited by the value of
      * "`kotlinx.coroutines.io.parallelism`" ([IO_PARALLELISM_PROPERTY_NAME]) system property.
      * It defaults to the limit of 64 threads or the number of cores (whichever is larger).
      *


### PR DESCRIPTION
## Problem

The documentation for `Dispatchers.IO` appears to be misleading.

Specifically, it suggests that the `kotlinx.coroutines.io.parallelism` system property limits the number of threads, when in fact:

- The `kotlinx.coroutines.io.parallelism` property controls the **parallelism limit**, not the **maximum thread count**.
- The actual thread pool backing `Dispatchers.IO` can grow up to `MAX_POOL_SIZE`, which defaults to `CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE` (`2^21 - 2 = 2,097,150` threads).

## Proposal

Update the comment to clarify that `kotlinx.coroutines.io.parallelism` controls **parallelism** (i.e., the number of concurrently scheduled tasks), not the actual number of threads used by the underlying thread pool.
