### PR TITLE
Convert return in expression body to labeled return in preparation for KT-22786

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
@@ -519,9 +519,9 @@ internal open class SharedFlowImpl<T>(
     }
 
     private fun cancelEmitter(emitter: Emitter) = synchronized(this) {
-        if (emitter.index < head) return // already skipped past this index
+        if (emitter.index < head) return@synchronized // already skipped past this index
         val buffer = buffer!!
-        if (buffer.getBufferAt(emitter.index) !== emitter) return // already resumed
+        if (buffer.getBufferAt(emitter.index) !== emitter) return@synchronized // already resumed
         buffer.setBufferAt(emitter.index, NO_VALUE)
         cleanupTailLocked()
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22786/Returns-are-not-allowed-for-expression-body-functions-and-are-allowed-when-an-inline-lambda-is-added