### PR TITLE
Fix flakiness in `ChannelSelectStressTest`.

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/channels/ChannelSelectStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/channels/ChannelSelectStressTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.*
 import org.junit.After
 import org.junit.Test
+import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.atomic.AtomicLongArray
 import kotlin.test.*
 
@@ -17,6 +18,7 @@ class ChannelSelectStressTest : TestBase() {
     private val received = atomic(0)
     private val receivedArray = AtomicLongArray(elementsToSend / Long.SIZE_BITS)
     private val channel = Channel<Int>()
+    private val senderFinished = CyclicBarrier(pairedCoroutines)
 
     @After
     fun tearDown() {
@@ -51,6 +53,7 @@ class ChannelSelectStressTest : TestBase() {
                 if (element >= elementsToSend) break
                 select<Unit> { channel.onSend(element) {} }
             }
+            senderFinished.await()
             channel.close(CancellationException())
         }
     }


### PR DESCRIPTION
It's possible for another sender to close the channel between incrementing `sent` and suspending for `select`. If that happens, the `select` just throws `CancellationException`, cancelling the coroutine and causing an element to be missing at the end of the test.