### PR TITLE
Give upstream a chance to create new elements in collectLatest

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/internal/Merge.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/Merge.kt
@@ -17,7 +17,7 @@ internal class ChannelFlowTransformLatest<T, R>(
         ChannelFlowTransformLatest(transform, flow, context, capacity, onBufferOverflow)
 
     override suspend fun flowCollect(collector: FlowCollector<R>) {
-        assert { collector is SendingCollector } // So cancellation behaviour is not leaking into the downstream
+        assert { collector is SendingCollector } // So cancellation behavior is not leaking into the downstream
         coroutineScope {
             var previousFlow: Job? = null
             flow.collect { value ->
@@ -25,8 +25,8 @@ internal class ChannelFlowTransformLatest<T, R>(
                     cancel(ChildCancelledException())
                     join()
                 }
-                // Do not pay for dispatch here, it's never necessary
-                previousFlow = launch(start = CoroutineStart.UNDISPATCHED) {
+                // Dispatch to avoid blocking the upstream flow, which may produce more values immediately
+                previousFlow = launch {
                     collector.transform(value)
                 }
             }

--- a/kotlinx-coroutines-core/common/test/flow/terminal/CollectLatestTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/terminal/CollectLatestTest.kt
@@ -6,14 +6,6 @@ import kotlin.test.*
 
 class CollectLatestTest : TestBase() {
     @Test
-    fun testNoSuspension() = runTest {
-        flowOf(1, 2, 3).collectLatest {
-            expect(it)
-        }
-        finish(4)
-    }
-
-    @Test
     fun testSuspension() = runTest {
         flowOf(1, 2, 3).collectLatest {
             yield()
@@ -27,6 +19,7 @@ class CollectLatestTest : TestBase() {
         try {
             flow {
                 emit(1)
+                yield()
                 throw TestException()
             }.collectLatest { expect(1) }
             expectUnreached()
@@ -49,5 +42,24 @@ class CollectLatestTest : TestBase() {
             finish(2)
         }
 
+    }
+
+    /** Tests that if new values appear immediately, they cancel processing the old value. */
+    @Test
+    fun testNoSuspension() = runTest {
+        flowOf(3, 2, 1).collectLatest { value ->
+            expect(value)
+        }
+        finish(2)
+    }
+
+    /** Tests that upstream errors that happen immediately after emitting a value cancel processing the old value. */
+    @Test
+    fun testUpstreamErrorNoSuspension() = runTest({it is TestException}) {
+        flow {
+            emit(1)
+            throw TestException()
+        }.collectLatest { expectUnreached() }
+        expectUnreached()
     }
 }


### PR DESCRIPTION
Fixes #3109
Fixes #3679

We will need to combine this with a fix for https://github.com/Kotlin/kotlinx.coroutines/issues/4383 (which also affects the dispatching behavior of `*Latest`) and evaluate both on large existing codebases before publishing a release.