### PR TITLE
Update Kotlin to 2.2.0 - update the playground link to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ suspend fun main() = coroutineScope {
 }
 ```
 
-> Play with coroutines online [here](https://pl.kotl.in/9zva88r7S)
+> Play with coroutines online [here](https://pl.kotl.in/Wf3HxgZvx)
 
 ## Modules
 


### PR DESCRIPTION
Addition to https://github.com/Kotlin/kotlinx.coroutines/pull/4485

NB: good to remember to always do it, as once opening a playground link with an outdated kotlin version poisons the subsequent playground usage