### PR TITLE
Update Readme to say Kotlin 2.1.0 to match the reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![JetBrains official project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Download](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.10.2)](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.10.2)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.0.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.1.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://kotlinlang.org/api/kotlinx.coroutines/)
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/coroutines/)
 
 Library support for Kotlin coroutines with [multiplatform](#multiplatform) support.
-This is a companion version for the Kotlin `2.0.0` release.
+This is a companion version for the Kotlin `2.1.0` release.
 
 ```kotlin
 suspend fun main() = coroutineScope {
@@ -21,7 +21,7 @@ suspend fun main() = coroutineScope {
 }
 ```
 
-> Play with coroutines online [here](https://pl.kotl.in/9zva88r7S)
+> Play with coroutines online [here](https://pl.kotl.in/lPYtYEtD5)
 
 ## Modules
 
@@ -94,7 +94,7 @@ And make sure that you use the latest Kotlin version:
 
 ```xml
 <properties>
-    <kotlin.version>2.0.0</kotlin.version>
+    <kotlin.version>2.1.0</kotlin.version>
 </properties>
 ```
 
@@ -113,10 +113,10 @@ And make sure that you use the latest Kotlin version:
 ```kotlin
 plugins {
     // For build.gradle.kts (Kotlin DSL)
-    kotlin("jvm") version "2.0.0"
+    kotlin("jvm") version "2.1.0"
     
     // For build.gradle (Groovy DSL)
-    id "org.jetbrains.kotlin.jvm" version "2.0.0"
+    id "org.jetbrains.kotlin.jvm" version "2.1.0"
 }
 ```
 


### PR DESCRIPTION
It's been Kotlin 2.1.0 for three patch releases already, but the readme wrongly says 2.0.0.