### PR TITLE
Explicit types arguments instead of reified intersection

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/operators/CombineParametersTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/CombineParametersTest.kt
@@ -70,7 +70,7 @@ class CombineParametersTest : TestBase() {
 
     @Test
     fun testVararg() = runTest {
-        val flow = combine(
+        val flow = combine<Any?, String>(
             flowOf("1"),
             flowOf(2),
             flowOf("3"),
@@ -83,7 +83,7 @@ class CombineParametersTest : TestBase() {
 
     @Test
     fun testVarargTransform() = runTest {
-        val flow = combineTransform(
+        val flow = combineTransform<Any?, String>(
             flowOf("1"),
             flowOf(2),
             flowOf("3"),


### PR DESCRIPTION
Reified intersection type arguments are currently a warning (KT-52469) but will soon become an error (KT-71420).

This change is to unblock the user project build for the merge for KT-71420