### PR TITLE
Add ReceiveChannel.toList(destination)

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channels.common.kt
@@ -194,6 +194,43 @@ public suspend fun <E> ReceiveChannel<E>.toList(): List<E> = buildList {
     }
 }
 
+/**
+ * Consumes the elements of this channel into the given [destination] mutable list.
+ *
+ * This function will attempt to receive elements and put them into the list until the channel is
+ * [closed][SendChannel.close].
+ * Calling [toList] on channels that are not eventually closed is always incorrect:
+ * - It will suspend indefinitely if the channel is not closed, but no new elements arrive.
+ * - If new elements do arrive and the channel is not eventually closed, [toList] will use more and more memory
+ *   until exhausting it.
+ *
+ * If the channel is [closed][SendChannel.close] with a cause, [toList] will rethrow that cause.
+ * However, the [destination] list is left in a consistent state containing all the elements received from the channel
+ * up to that point.
+ *
+ * The operation is _terminal_.
+ * This function [consumes][ReceiveChannel.consume] all elements of the original [ReceiveChannel].
+ *
+ * Example:
+ * ```
+ * val values = listOf(1, 5, 2, 9, 3, 3, 1)
+ * // start a new coroutine that creates a channel,
+ * // sends elements to it, and closes it
+ * // once the coroutine's body finishes
+ * val channel = produce {
+ *    values.forEach { send(it) }
+ * }
+ * val destination = mutableListOf<Int>()
+ * channel.toList(destination)
+ * check(destination == values)
+ * ```
+ */
+public suspend inline fun <T> ReceiveChannel<T>.toList(destination: MutableList<T>) {
+    consumeEach {
+        destination.add(it)
+    }
+}
+
 @PublishedApi
 internal fun ReceiveChannel<*>.cancelConsumed(cause: Throwable?) {
     cancel(cause?.let {


### PR DESCRIPTION
Use case: collecting elements up until the point the channel is closed without losing the elements when `toList` when the exception is thrown.

This function is similar to `Flow<T>.toList(destination)`, which we already have, so the addition makes sense from the point of view of consistency as well.