### PR TITLE
Ignore exceptions thrown from Thread.UncaughtExceptionHandler

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/CoroutineExceptionHandlerImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/CoroutineExceptionHandlerImpl.kt
@@ -28,7 +28,17 @@ internal actual fun ensurePlatformExceptionHandlerLoaded(callback: CoroutineExce
 internal actual fun propagateExceptionFinalResort(exception: Throwable) {
     // use the thread's handler
     val currentThread = Thread.currentThread()
-    currentThread.uncaughtExceptionHandler.uncaughtException(currentThread, exception)
+    val exceptionHandler = currentThread.uncaughtExceptionHandler
+    try {
+        exceptionHandler.uncaughtException(currentThread, exception)
+    } catch (_: Throwable) {
+        /* Do nothing.
+         * From https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.UncaughtExceptionHandler.html :
+         * > Any exception thrown by this method will be ignored by the Java Virtual Machine.
+         *
+         * This means the authors of the thread exception handlers have the right to throw exceptions indiscriminately.
+         * We have no further channels for propagating the fatal exception, so we give up. */
+    }
 }
 
 // This implementation doesn't store a stacktrace, which is good because a stacktrace doesn't make sense for this.


### PR DESCRIPTION
Fixes #4516

Background
----------

Whenever an *uncaught* exception happens in a coroutine, it gets reported to the `CoroutineExceptionHandler`. See <https://kotlinlang.org/docs/exception-handling.html#coroutineexceptionhandler>. However, if it's not installed, a platform-specific handler is used.
On the JVM, this means invoking the thread's
`UncaughtExceptionHandler`, which logs the exception to the console by default, but can be configured to do other things (for example, on Android, it will crash the application).

Problem
-------

User-specified `UncaughtExceptionHandler` instances are allowed to throw exceptions.
Java's documentation says so
(https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.UncaughtExceptionHandler.html):
> Any exception thrown by this method will be ignored by the Java Virtual Machine.

This means a user is allowed to write a throwing
`UncaughtExceptionHandler`, and the caller has to deal with it.

In our implementation, however, we are simply invoking the exception handler as a plain function, and if that function throws an exception, we allow this exception to propagate to the coroutine machinery, causing it to fail.

Solution
--------

To comply with the contract defined for `UncaughtExceptionHandler`, we also ignore the exceptions thrown from there.