### PR TITLE
ChannelIterator: add an example

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1051,7 +1051,7 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
 /**
  * Iterator for a [ReceiveChannel].
  * Instances of this interface are *not thread-safe*.
- * Each iterator instance should be used by a single coroutine.
+ * Each iterator instance should be created and used by a single coroutine.
  *
  * An example usage:
  *

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1051,15 +1051,19 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
 /**
  * Iterator for a [ReceiveChannel].
  * Instances of this interface are *not thread-safe*.
- * A coroutine is only allowed to call methods on the iterator instances which it instantiated.
+ * A coroutine is only allowed to call methods on those iterator instances which it instantiated.
  *
  * Typically, an iterator is used indirectly in the `for` loop and is not instantiated explicitly.
  *
  * ```
  * for (element in channel) {
- *     // process element
+ *     // process the element
  * }
  * ```
+ *
+ * If your use-case requires handling the iterator directly,
+ * you must call [hasNext] before each [next].
+ * Refer to [hasNext] and [next] for more details.
  *
  * An example usage:
  *

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1051,7 +1051,15 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
 /**
  * Iterator for a [ReceiveChannel].
  * Instances of this interface are *not thread-safe*.
- * Each iterator instance should be created and used by a single coroutine.
+ * A coroutine is only allowed to call methods on the iterator instances which it instantiated.
+ *
+ * Typically, an iterator is used indirectly in the `for` loop and is not instantiated explicitly.
+ *
+ * ```
+ * for (element in channel) {
+ *     // process element
+ * }
+ * ```
  *
  * An example usage:
  *

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1050,7 +1050,36 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
 
 /**
  * Iterator for a [ReceiveChannel].
- * Instances of this interface are *not thread-safe* and shall not be used from concurrent coroutines.
+ * Instances of this interface are *not thread-safe*.
+ * Each iterator instance should be used by a single coroutine.
+ *
+ * An example usage:
+ *
+ * ```
+ * val channel = Channel<Int>()
+ * launch {
+ *      channel.send(1)
+ *      channel.send(2)
+ *      channel.send(3)
+ *      channel.close()  // NB: must close for iterators to finish
+ * }
+ * launch {
+ *      for (element in channel) {
+ *          println("Consumer A got $element")
+ *      }
+ * }
+ * launch {
+ *      for (element in channel) {
+ *          println("Consumer B got $element")
+ *      }
+ * }
+ * ```
+ * Possible output:
+ * ```text
+ * Consumer A got 1
+ * Consumer A got 2
+ * Consumer B got 3
+ * ```
  */
 public interface ChannelIterator<out E> {
     /**

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1074,7 +1074,7 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
  *      channel.send(1)
  *      channel.send(2)
  *      channel.send(3)
- *      channel.close()  // NB: must close for iterators to finish
+ *      channel.close() // NB: must close for iterators to finish
  * }
  * launch {
  *      for (element in channel) {

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1052,7 +1052,7 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
  * Iterator for a [ReceiveChannel].
  * An instance of this interface is *not thread-safe*.
  * Multiple coroutines are allowed to create and use
- * its own instances of this interface for the same channel.
+ * their own instances of this interface for the same channel.
  *
  * Typically, an iterator is used indirectly in the `for` loop and is not instantiated explicitly.
  *

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -1050,8 +1050,9 @@ public inline fun <T> ChannelResult<T>.onClosed(action: (exception: Throwable?) 
 
 /**
  * Iterator for a [ReceiveChannel].
- * Instances of this interface are *not thread-safe*.
- * A coroutine is only allowed to call methods on those iterator instances which it instantiated.
+ * An instance of this interface is *not thread-safe*.
+ * Multiple coroutines are allowed to create and use
+ * its own instances of this interface for the same channel.
  *
  * Typically, an iterator is used indirectly in the `for` loop and is not instantiated explicitly.
  *


### PR DESCRIPTION
Add an example, stress that different coroutines *can* iterate over the channel, with their own iterator instance