### PR TITLE
Cleanup: remove the `BuilderInference` annotation

### DIFF
--- a/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/FlowPlaysScrabbleOpt.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/flow/scrabble/FlowPlaysScrabbleOpt.kt
@@ -181,7 +181,7 @@ public fun <T, R> Flow<T>.flatMapConcatIterable(transformer: (T) -> Iterable<R>)
     }
 }
 
-public inline fun <T> flow(@BuilderInference crossinline block: suspend FlowCollector<T>.() -> Unit): Flow<T> {
+public inline fun <T> flow(crossinline block: suspend FlowCollector<T>.() -> Unit): Flow<T> {
     return object : Flow<T> {
         override suspend fun collect(collector: FlowCollector<T>) {
             collector.block()

--- a/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Broadcast.kt
@@ -39,7 +39,7 @@ public fun <E> CoroutineScope.broadcast(
     capacity: Int = 1,
     start: CoroutineStart = CoroutineStart.LAZY,
     onCompletion: CompletionHandler? = null,
-    @BuilderInference block: suspend ProducerScope<E>.() -> Unit
+    block: suspend ProducerScope<E>.() -> Unit
 ): BroadcastChannel<E> {
     val newContext = newCoroutineContext(context)
     val channel = BroadcastChannel<E>(capacity)

--- a/kotlinx-coroutines-core/common/src/channels/Produce.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Produce.kt
@@ -239,7 +239,7 @@ public suspend fun ProducerScope<*>.awaitClose(block: () -> Unit = {}) {
 public fun <E> CoroutineScope.produce(
     context: CoroutineContext = EmptyCoroutineContext,
     capacity: Int = Channel.RENDEZVOUS,
-    @BuilderInference block: suspend ProducerScope<E>.() -> Unit
+    block: suspend ProducerScope<E>.() -> Unit
 ): ReceiveChannel<E> =
     produce(context, capacity, BufferOverflow.SUSPEND, CoroutineStart.DEFAULT, onCompletion = null, block = block)
 
@@ -261,7 +261,7 @@ public fun <E> CoroutineScope.produce(
     capacity: Int = 0,
     start: CoroutineStart = CoroutineStart.DEFAULT,
     onCompletion: CompletionHandler? = null,
-    @BuilderInference block: suspend ProducerScope<E>.() -> Unit
+    block: suspend ProducerScope<E>.() -> Unit
 ): ReceiveChannel<E> =
     produce(context, capacity, BufferOverflow.SUSPEND, start, onCompletion, block)
 
@@ -273,7 +273,7 @@ internal fun <E> CoroutineScope.produce(
     onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
     start: CoroutineStart = CoroutineStart.DEFAULT,
     onCompletion: CompletionHandler? = null,
-    @BuilderInference block: suspend ProducerScope<E>.() -> Unit
+    block: suspend ProducerScope<E>.() -> Unit
 ): ReceiveChannel<E> {
     val channel = Channel<E>(capacity, onBufferOverflow)
     val newContext = newCoroutineContext(context)

--- a/kotlinx-coroutines-core/common/src/flow/Builders.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Builders.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
  *
  * If you want to switch the context of execution of a flow, use the [flowOn] operator.
  */
-public fun <T> flow(@BuilderInference block: suspend FlowCollector<T>.() -> Unit): Flow<T> = SafeFlow(block)
+public fun <T> flow(block: suspend FlowCollector<T>.() -> Unit): Flow<T> = SafeFlow(block)
 
 // Named anonymous object
 private class SafeFlow<T>(private val block: suspend FlowCollector<T>.() -> Unit) : AbstractFlow<T>() {
@@ -236,7 +236,7 @@ public fun LongRange.asFlow(): Flow<Long> = flow {
  * }
  * ```
  */
-public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T> =
+public fun <T> channelFlow(block: suspend ProducerScope<T>.() -> Unit): Flow<T> =
     ChannelFlowBuilder(block)
 
 /**
@@ -300,7 +300,7 @@ public fun <T> channelFlow(@BuilderInference block: suspend ProducerScope<T>.() 
  * > `awaitClose` block can be called at any time due to asynchronous nature of cancellation, even
  * > concurrently with the call of the callback.
  */
-public fun <T> callbackFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T> = CallbackFlowBuilder(block)
+public fun <T> callbackFlow(block: suspend ProducerScope<T>.() -> Unit): Flow<T> = CallbackFlowBuilder(block)
 
 // ChannelFlow implementation that is the first in the chain of flow operations and introduces (builds) a flow
 private open class ChannelFlowBuilder<T>(

--- a/kotlinx-coroutines-core/common/src/flow/Migration.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Migration.kt
@@ -269,7 +269,7 @@ public fun <T> Flow<T>.forEach(action: suspend (value: T) -> Unit): Unit = noImp
     message = "Flow has less verbose 'scan' shortcut",
     replaceWith = ReplaceWith("scan(initial, operation)")
 )
-public fun <T, R> Flow<T>.scanFold(initial: R, @BuilderInference operation: suspend (accumulator: R, value: T) -> R): Flow<R> =
+public fun <T, R> Flow<T>.scanFold(initial: R, operation: suspend (accumulator: R, value: T) -> R): Flow<R> =
     noImpl()
 
 /**

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowCoroutine.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
  * } // <- CE will be rethrown here
  * ```
  */
-internal suspend fun <R> flowScope(@BuilderInference block: suspend CoroutineScope.() -> R): R =
+internal suspend fun <R> flowScope(block: suspend CoroutineScope.() -> R): R =
     suspendCoroutineUninterceptedOrReturn { uCont ->
         val coroutine = FlowCoroutine(uCont.context, uCont)
         coroutine.startUndispatchedOrReturn(coroutine, block)
@@ -42,7 +42,7 @@ internal suspend fun <R> flowScope(@BuilderInference block: suspend CoroutineSco
  * with additional constraint on cancellation.
  * To cancel child without cancelling itself, `cancel(ChildCancelledException())` should be used.
  */
-internal fun <R> scopedFlow(@BuilderInference block: suspend CoroutineScope.(FlowCollector<R>) -> Unit): Flow<R> =
+internal fun <R> scopedFlow(block: suspend CoroutineScope.(FlowCollector<R>) -> Unit): Flow<R> =
     flow {
         flowScope { block(this@flow) }
     }

--- a/kotlinx-coroutines-core/common/src/flow/internal/SafeCollector.common.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/SafeCollector.common.kt
@@ -101,7 +101,7 @@ internal tailrec fun Job?.transitiveCoroutineParent(collectJob: Job?): Job? {
  * Used in our own operators where we trust the context of invocations.
  */
 @PublishedApi
-internal inline fun <T> unsafeFlow(@BuilderInference crossinline block: suspend FlowCollector<T>.() -> Unit): Flow<T> {
+internal inline fun <T> unsafeFlow(crossinline block: suspend FlowCollector<T>.() -> Unit): Flow<T> {
     return object : Flow<T> {
         override suspend fun collect(collector: FlowCollector<T>) {
             collector.block()

--- a/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Emitters.kt
@@ -31,7 +31,7 @@ import kotlin.jvm.*
  * ```
  */
 public inline fun <T, R> Flow<T>.transform(
-    @BuilderInference crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
+    crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
 ): Flow<R> = flow { // Note: safe flow is used here, because collector is exposed to transform on each operation
     collect { value ->
         transform(value)
@@ -41,7 +41,7 @@ public inline fun <T, R> Flow<T>.transform(
 // For internal operator implementation
 @PublishedApi
 internal inline fun <T, R> Flow<T>.unsafeTransform(
-    @BuilderInference crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
+    crossinline transform: suspend FlowCollector<R>.(value: T) -> Unit
 ): Flow<R> = unsafeFlow { // Note: unsafe flow is used here, because unsafeTransform is only for internal use
     collect { value ->
         transform(value)

--- a/kotlinx-coroutines-core/common/src/flow/operators/Limit.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Limit.kt
@@ -110,7 +110,7 @@ public fun <T> Flow<T>.takeWhile(predicate: suspend (T) -> Boolean): Flow<T> = f
  * ```
  */
 public fun <T, R> Flow<T>.transformWhile(
-    @BuilderInference transform: suspend FlowCollector<R>.(value: T) -> Boolean
+    transform: suspend FlowCollector<R>.(value: T) -> Boolean
 ): Flow<R> =
     safeFlow { // Note: safe flow is used here, because collector is exposed to transform on each operation
         // This return is needed to work around a bug in JS BE: KT-39227

--- a/kotlinx-coroutines-core/common/src/flow/operators/Merge.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Merge.kt
@@ -159,7 +159,7 @@ public fun <T> Flow<Flow<T>>.flattenMerge(concurrency: Int = DEFAULT_CONCURRENCY
  * and size of its output buffer can be changed by applying subsequent [buffer] operator.
  */
 @ExperimentalCoroutinesApi
-public fun <T, R> Flow<T>.transformLatest(@BuilderInference transform: suspend FlowCollector<R>.(value: T) -> Unit): Flow<R> =
+public fun <T, R> Flow<T>.transformLatest(transform: suspend FlowCollector<R>.(value: T) -> Unit): Flow<R> =
     ChannelFlowTransformLatest(transform, this)
 
 /**
@@ -185,7 +185,7 @@ public fun <T, R> Flow<T>.transformLatest(@BuilderInference transform: suspend F
  * This operator is [buffered][buffer] by default and size of its output buffer can be changed by applying subsequent [buffer] operator.
  */
 @ExperimentalCoroutinesApi
-public inline fun <T, R> Flow<T>.flatMapLatest(@BuilderInference crossinline transform: suspend (value: T) -> Flow<R>): Flow<R> =
+public inline fun <T, R> Flow<T>.flatMapLatest(crossinline transform: suspend (value: T) -> Flow<R>): Flow<R> =
     transformLatest { emitAll(transform(it)) }
 
 /**
@@ -209,5 +209,5 @@ public inline fun <T, R> Flow<T>.flatMapLatest(@BuilderInference crossinline tra
  * This operator is [buffered][buffer] by default and size of its output buffer can be changed by applying subsequent [buffer] operator.
  */
 @ExperimentalCoroutinesApi
-public fun <T, R> Flow<T>.mapLatest(@BuilderInference transform: suspend (value: T) -> R): Flow<R> =
+public fun <T, R> Flow<T>.mapLatest(transform: suspend (value: T) -> R): Flow<R> =
     transformLatest { emit(transform(it)) }

--- a/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Transform.kt
@@ -87,7 +87,7 @@ public fun <T> Flow<T>.onEach(action: suspend (T) -> Unit): Flow<T> = transform 
  *
  * This function is an alias to [runningFold] operator.
  */
-public fun <T, R> Flow<T>.scan(initial: R, @BuilderInference operation: suspend (accumulator: R, value: T) -> R): Flow<R> = runningFold(initial, operation)
+public fun <T, R> Flow<T>.scan(initial: R, operation: suspend (accumulator: R, value: T) -> R): Flow<R> = runningFold(initial, operation)
 
 /**
  * Folds the given flow with [operation], emitting every intermediate result, including [initial] value.
@@ -98,7 +98,7 @@ public fun <T, R> Flow<T>.scan(initial: R, @BuilderInference operation: suspend 
  * ```
  * will produce `[[], [1], [1, 2], [1, 2, 3]]`.
  */
-public fun <T, R> Flow<T>.runningFold(initial: R, @BuilderInference operation: suspend (accumulator: R, value: T) -> R): Flow<R> = flow {
+public fun <T, R> Flow<T>.runningFold(initial: R, operation: suspend (accumulator: R, value: T) -> R): Flow<R> = flow {
     var accumulator: R = initial
     emit(accumulator)
     collect { value ->

--- a/kotlinx-coroutines-core/common/src/flow/operators/Zip.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Zip.kt
@@ -67,7 +67,7 @@ public fun <T1, T2, R> combine(flow: Flow<T1>, flow2: Flow<T2>, transform: suspe
 @JvmName("flowCombineTransform")
 public fun <T1, T2, R> Flow<T1>.combineTransform(
     flow: Flow<T2>,
-    @BuilderInference transform: suspend FlowCollector<R>.(a: T1, b: T2) -> Unit
+    transform: suspend FlowCollector<R>.(a: T1, b: T2) -> Unit
 ): Flow<R> = combineTransformUnsafe(this, flow) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -95,7 +95,7 @@ public fun <T1, T2, R> Flow<T1>.combineTransform(
 public fun <T1, T2, R> combineTransform(
     flow: Flow<T1>,
     flow2: Flow<T2>,
-    @BuilderInference transform: suspend FlowCollector<R>.(a: T1, b: T2) -> Unit
+    transform: suspend FlowCollector<R>.(a: T1, b: T2) -> Unit
 ): Flow<R> = combineTransformUnsafe(flow, flow2) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -111,7 +111,7 @@ public fun <T1, T2, T3, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
-    @BuilderInference transform: suspend (T1, T2, T3) -> R
+    transform: suspend (T1, T2, T3) -> R
 ): Flow<R> = combineUnsafe(flow, flow2, flow3) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -130,7 +130,7 @@ public fun <T1, T2, T3, R> combineTransform(
     flow: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
-    @BuilderInference transform: suspend FlowCollector<R>.(T1, T2, T3) -> Unit
+    transform: suspend FlowCollector<R>.(T1, T2, T3) -> Unit
 ): Flow<R> = combineTransformUnsafe(flow, flow2, flow3) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -169,7 +169,7 @@ public fun <T1, T2, T3, T4, R> combineTransform(
     flow2: Flow<T2>,
     flow3: Flow<T3>,
     flow4: Flow<T4>,
-    @BuilderInference transform: suspend FlowCollector<R>.(T1, T2, T3, T4) -> Unit
+    transform: suspend FlowCollector<R>.(T1, T2, T3, T4) -> Unit
 ): Flow<R> = combineTransformUnsafe(flow, flow2, flow3, flow4) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -212,7 +212,7 @@ public fun <T1, T2, T3, T4, T5, R> combineTransform(
     flow3: Flow<T3>,
     flow4: Flow<T4>,
     flow5: Flow<T5>,
-    @BuilderInference transform: suspend FlowCollector<R>.(T1, T2, T3, T4, T5) -> Unit
+    transform: suspend FlowCollector<R>.(T1, T2, T3, T4, T5) -> Unit
 ): Flow<R> = combineTransformUnsafe(flow, flow2, flow3, flow4, flow5) { args: Array<*> ->
     transform(
         args[0] as T1,
@@ -242,7 +242,7 @@ public inline fun <reified T, R> combine(
  */
 public inline fun <reified T, R> combineTransform(
     vararg flows: Flow<T>,
-    @BuilderInference crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
+    crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
 ): Flow<R> = safeFlow {
     combineInternal(flows, { arrayOfNulls(flows.size) }, { transform(it) })
 }
@@ -264,7 +264,7 @@ private inline fun <reified T, R> combineUnsafe(
  */
 private inline fun <reified T, R> combineTransformUnsafe(
     vararg flows: Flow<T>,
-    @BuilderInference crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
+    crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
 ): Flow<R> = safeFlow {
     combineInternal(flows, nullArrayFactory(), { transform(it) })
 }
@@ -297,7 +297,7 @@ public inline fun <reified T, R> combine(
  */
 public inline fun <reified T, R> combineTransform(
     flows: Iterable<Flow<T>>,
-    @BuilderInference crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
+    crossinline transform: suspend FlowCollector<R>.(Array<T>) -> Unit
 ): Flow<R> {
     val flowArray = flows.toList().toTypedArray()
     return safeFlow {

--- a/reactive/kotlinx-coroutines-jdk9/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-jdk9/src/Publish.kt
@@ -30,5 +30,5 @@ import org.reactivestreams.FlowAdapters
  */
 public fun <T> flowPublish(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flow.Publisher<T> = FlowAdapters.toFlowPublisher(publish(context, block))

--- a/reactive/kotlinx-coroutines-reactive/src/Publish.kt
+++ b/reactive/kotlinx-coroutines-reactive/src/Publish.kt
@@ -31,7 +31,7 @@ import kotlin.coroutines.*
  */
 public fun <T> publish(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Publisher<T> {
     require(context[Job] === null) { "Publisher context cannot contain job in it." +
             "Its lifecycle should be managed via subscription. Had $context" }
@@ -331,5 +331,5 @@ public class PublisherCoroutine<in T>(
 ) // Since 1.3.0, will be error in 1.3.1 and hidden in 1.4.0. Binary compatibility with Spring
 public fun <T> CoroutineScope.publish(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Publisher<T> = publishInternal(this, context, DEFAULT_HANDLER, block)

--- a/reactive/kotlinx-coroutines-reactor/src/Flux.kt
+++ b/reactive/kotlinx-coroutines-reactor/src/Flux.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.*
  */
 public fun <T> flux(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flux<T> {
     require(context[Job] === null) { "Flux context cannot contain job in it." +
         "Its lifecycle should be managed via Disposable handle. Had $context" }
@@ -37,7 +37,7 @@ public fun <T> flux(
 private fun <T> reactorPublish(
     scope: CoroutineScope,
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Publisher<T> = Publisher onSubscribe@{ subscriber: Subscriber<in T>? ->
     if (subscriber !is CoreSubscriber) {
         subscriber.reject(IllegalArgumentException("Subscriber is not an instance of CoreSubscriber, context can not be extracted."))
@@ -89,6 +89,6 @@ private fun <T> Subscriber<T>?.reject(t: Throwable) {
 ) // Since 1.3.0, will be error in 1.3.1 and hidden in 1.4.0. Binary compatibility with Spring
 public fun <T> CoroutineScope.flux(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flux<T> =
     Flux.from(reactorPublish(this, context, block))

--- a/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxFlowable.kt
@@ -29,7 +29,7 @@ import kotlin.internal.*
  */
 public fun <T: Any> rxFlowable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flowable<T> {
     require(context[Job] === null) { "Flowable context cannot contain job in it." +
             "Its lifecycle should be managed via Disposable handle. Had $context" }
@@ -45,7 +45,7 @@ public fun <T: Any> rxFlowable(
 @LowPriorityInOverloadResolution
 public fun <T: Any> CoroutineScope.rxFlowable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flowable<T> = Flowable.fromPublisher(publishInternal(this, context, RX_HANDLER, block))
 
 private val RX_HANDLER: (Throwable, CoroutineContext) -> Unit = ::handleUndeliverableException

--- a/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxObservable.kt
@@ -28,7 +28,7 @@ import kotlin.coroutines.*
  */
 public fun <T : Any> rxObservable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Observable<T> {
     require(context[Job] === null) { "Observable context cannot contain job in it." +
             "Its lifecycle should be managed via Disposable handle. Had $context" }
@@ -212,5 +212,5 @@ private class RxObservableCoroutine<T : Any>(
 ) // Since 1.3.0, will be error in 1.3.1 and hidden in 1.4.0
 public fun <T : Any> CoroutineScope.rxObservable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Observable<T> = rxObservableInternal(this, context, block)

--- a/reactive/kotlinx-coroutines-rx3/src/RxFlowable.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxFlowable.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.*
  */
 public fun <T: Any> rxFlowable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Flowable<T> {
     require(context[Job] === null) { "Flowable context cannot contain job in it." +
             "Its lifecycle should be managed via Disposable handle. Had $context" }

--- a/reactive/kotlinx-coroutines-rx3/src/RxObservable.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxObservable.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.internal.*
  */
 public fun <T : Any> rxObservable(
     context: CoroutineContext = EmptyCoroutineContext,
-    @BuilderInference block: suspend ProducerScope<T>.() -> Unit
+    block: suspend ProducerScope<T>.() -> Unit
 ): Observable<T> {
     require(context[Job] === null) { "Observable context cannot contain job in it." +
             "Its lifecycle should be managed via Disposable handle. Had $context" }


### PR DESCRIPTION
The `BuilderInference` annotation has no effect since Kotlin 2.0 and can be safely removed.