### PR TITLE
Update kotlin-test dependency declaration in test-utils

### DIFF
--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -5,29 +5,14 @@
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test-common:${version("kotlin")}")
-            api("org.jetbrains.kotlin:kotlin-test-annotations-common:${version("kotlin")}")
+            api(kotlin("test"))
         }
         jvmMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test:${version("kotlin")}")
             // Workaround to make addSuppressed work in tests
             api("org.jetbrains.kotlin:kotlin-reflect:${version("kotlin")}")
             api("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version("kotlin")}")
             api("org.jetbrains.kotlin:kotlin-test-junit:${version("kotlin")}")
             api("junit:junit:${version("junit")}")
-        }
-        jsMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test-js:${version("kotlin")}")
-        }
-        val wasmJsMain by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-js:${version("kotlin")}")
-            }
-        }
-        val wasmWasiMain by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-wasi:${version("kotlin")}")
-            }
         }
     }
 }


### PR DESCRIPTION
kotlin-test is KMP dependency that is intended to be consumed via root coordinates.

There is no need to depend on kotlin-test-common explicitly and on platfom-specific source sets.

It also fixes potential problems with SourceSet visibility algorithm. i.e. it is curcial to have connected graph of dependencies.
i.e. kotlin-test-common and kotlin-test-js for example is not connected from this algorithm point of view. 
