### PR TITLE
Depend on root components instead of platform-specific components

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -59,7 +59,7 @@ kotlin {
         outputModuleName = project.name
         nodejs()
         compilations["main"]?.dependencies {
-            api("org.jetbrains.kotlinx:atomicfu-js:${version("atomicfu")}")
+            api("org.jetbrains.kotlinx:atomicfu:${version("atomicfu")}")
         }
     }
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
@@ -69,14 +69,14 @@ kotlin {
         outputModuleName = project.name + "Wasm"
         nodejs()
         compilations["main"]?.dependencies {
-            api("org.jetbrains.kotlinx:atomicfu-wasm-js:${version("atomicfu")}")
+            api("org.jetbrains.kotlinx:atomicfu:${version("atomicfu")}")
         }
     }
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
     wasmWasi {
         nodejs()
         compilations["main"]?.dependencies {
-            api("org.jetbrains.kotlinx:atomicfu-wasm-wasi:${version("atomicfu")}")
+            api("org.jetbrains.kotlinx:atomicfu:${version("atomicfu")}")
         }
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -90,8 +90,7 @@ kotlin {
     sourceSets {
         commonTest {
             dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-common:${version("kotlin")}")
-                api("org.jetbrains.kotlin:kotlin-test-annotations-common:${version("kotlin")}")
+                api("org.jetbrains.kotlin:kotlin-test:${version("kotlin")}")
             }
         }
         jvmMain.dependencies {
@@ -100,7 +99,6 @@ kotlin {
             api("org.jetbrains:annotations:23.0.0")
         }
         jvmTest.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test:${version("kotlin")}")
             // Workaround to make addSuppressed work in tests
             api("org.jetbrains.kotlin:kotlin-reflect:${version("kotlin")}")
             api("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version("kotlin")}")
@@ -112,24 +110,13 @@ kotlin {
             api("org.jetbrains.kotlinx:atomicfu:0.23.1")
         }
         jsMain { }
-        jsTest {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-js:${version("kotlin")}")
-            }
-        }
         val wasmJsMain by getting {
         }
         val wasmJsTest by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-js:${version("kotlin")}")
-            }
         }
         val wasmWasiMain by getting {
         }
         val wasmWasiTest by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-wasi:${version("kotlin")}")
-            }
         }
         groupSourceSets("jsAndWasmJsShared", listOf("js", "wasmJs"), emptyList())
         groupSourceSets("jsAndWasmShared", listOf("jsAndWasmJsShared", "wasmWasi"), listOf("common"))

--- a/integration-testing/smokeTest/build.gradle.kts
+++ b/integration-testing/smokeTest/build.gradle.kts
@@ -45,26 +45,11 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
-            }
-        }
-        jsTest {
-            dependencies {
-                implementation(kotlin("test-js"))
-            }
-        }
-        wasmJsTest {
-            dependencies {
-                implementation(kotlin("test-wasm-js"))
-            }
-        }
-        wasmWasiTest {
-            dependencies {
-                implementation(kotlin("test-wasm-wasi"))
+                implementation(kotlin("test"))
             }
         }
         jvmTest {
             dependencies {
-                implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
             }
         }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -5,29 +5,14 @@
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test-common:${version("kotlin")}")
-            api("org.jetbrains.kotlin:kotlin-test-annotations-common:${version("kotlin")}")
+            api("org.jetbrains.kotlin:kotlin-test:${version("kotlin")}")
         }
         jvmMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test:${version("kotlin")}")
             // Workaround to make addSuppressed work in tests
             api("org.jetbrains.kotlin:kotlin-reflect:${version("kotlin")}")
             api("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version("kotlin")}")
             api("org.jetbrains.kotlin:kotlin-test-junit:${version("kotlin")}")
             api("junit:junit:${version("junit")}")
-        }
-        jsMain.dependencies {
-            api("org.jetbrains.kotlin:kotlin-test-js:${version("kotlin")}")
-        }
-        val wasmJsMain by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-js:${version("kotlin")}")
-            }
-        }
-        val wasmWasiMain by getting {
-            dependencies {
-                api("org.jetbrains.kotlin:kotlin-test-wasm-wasi:${version("kotlin")}")
-            }
         }
     }
 }


### PR DESCRIPTION
The "-js" dependencies are an uncoventional way to specify dependencies and these dependencies are problematic for testing lenient KMP resolution.