### PR TITLE
Safe debug agent. Part 2.

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -233,7 +233,7 @@ tasks {
             ":jpmsTest:check",
             "smokeTest:build",
             "java8Test:check",
-            "safeDebugAgentTest:runWithExpectedFailure"
+            "safeDebugAgentTest:runWithExpectedFailure",
             "safeDebugAgentTest:runWithIgnoredError"
         )
     }

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -234,6 +234,7 @@ tasks {
             "smokeTest:build",
             "java8Test:check",
             "safeDebugAgentTest:runWithExpectedFailure"
+            "safeDebugAgentTest:runWithIgnoredError"
         )
     }
 

--- a/integration-testing/safeDebugAgentTest/build.gradle.kts
+++ b/integration-testing/safeDebugAgentTest/build.gradle.kts
@@ -60,7 +60,7 @@ tasks.register<Test>("runWithIgnoredError") {
         jvmArgs = listOf("-javaagent:$agentJar=kotlinx.coroutines.ignore.debug.agent.error")
         errorOutput = errorOutputStream
         standardOutput = standardOutputStream
-        isIgnoreExitValue = false
+        isIgnoreExitValue = true
     }
 
     val errorOutput = errorOutputStream.toString()

--- a/integration-testing/safeDebugAgentTest/build.gradle.kts
+++ b/integration-testing/safeDebugAgentTest/build.gradle.kts
@@ -13,6 +13,12 @@ application {
     mainClass.set("Main")
 }
 
+val expectedAgentError =
+    "kotlinx.coroutines debug agent failed to load.\n" +
+        "Please ensure that the Kotlin standard library is present in the classpath.\n" +
+        "Alternatively, you can disable kotlinx.coroutines debug agent by removing `-javaagent=/path/kotlinx-coroutines-core.jar` from your VM arguments.\n"
+
+
 // In this test coroutine debug agent is attached as a javaagent vm argument
 // to a pure Java project (safeDebugAgentTest) with no Kotlin stdlib dependency.
 // In this case the error should be thrown from AgetnPremain class:
@@ -31,13 +37,35 @@ tasks.register<Test>("runWithExpectedFailure") {
         isIgnoreExitValue = true
     }
 
-    val expectedAgentError =
-        "kotlinx.coroutines debug agent failed to load.\n" +
-            "Please ensure that the Kotlin standard library is present in the classpath.\n" +
-            "Alternatively, you can disable kotlinx.coroutines debug agent by removing `-javaagent=/path/kotlinx-coroutines-core.jar` from your VM arguments.\n"
     val errorOutput = errorOutputStream.toString()
     val standardOutput = standardOutputStream.toString()
     if (!errorOutput.contains(expectedAgentError)) {
         throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+    }
+}
+
+// This test checks, that if the argument `kotlinx.coroutines.ignore.debug.agent.error` is passed to the javaagent,
+// then the initialization error will be just logged to the stderr and the execution will continue.
+tasks.register<Test>("runWithIgnoredError") {
+    val agentJar = System.getProperty("coroutines.debug.agent.path")
+    val errorOutputStream = ByteArrayOutputStream()
+    val standardOutputStream = ByteArrayOutputStream()
+
+    project.javaexec {
+        mainClass.set("Main")
+        classpath = sourceSets.main.get().runtimeClasspath
+        jvmArgs = listOf("-javaagent:$agentJar=kotlinx.coroutines.ignore.debug.agent.error")
+        errorOutput = errorOutputStream
+        standardOutput = standardOutputStream
+        isIgnoreExitValue = false
+    }
+
+    val errorOutput = errorOutputStream.toString()
+    val standardOutput = standardOutputStream.toString()
+    if (!errorOutput.contains(expectedAgentError)) {
+        throw GradleException("':safeDebugAgentTest:runWithIgnoredError' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+    }
+    if (!standardOutput.contains("OK!")) {
+        throw GradleException("':safeDebugAgentTest:runWithIgnoredError' was expected to log the agent initialization error and proceed with the execution of Main, but it completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
     }
 }

--- a/integration-testing/safeDebugAgentTest/build.gradle.kts
+++ b/integration-testing/safeDebugAgentTest/build.gradle.kts
@@ -23,52 +23,60 @@ val expectedAgentError =
 // to a pure Java project (safeDebugAgentTest) with no Kotlin stdlib dependency.
 // In this case the error should be thrown from AgetnPremain class:
 // "java.lang.IllegalStateException: kotlinx.coroutines debug agent failed to load."
-tasks.register<Test>("runWithExpectedFailure") {
+tasks.register<Task>("runWithExpectedFailure") {
+    dependsOn("compileJava")
     val agentJar = System.getProperty("coroutines.debug.agent.path")
-    val errorOutputStream = ByteArrayOutputStream()
-    val standardOutputStream = ByteArrayOutputStream()
 
-    project.javaexec {
-        mainClass.set("Main")
-        classpath = sourceSets.main.get().runtimeClasspath
-        jvmArgs = listOf("-javaagent:$agentJar")
-        errorOutput = errorOutputStream
-        standardOutput = standardOutputStream
-        isIgnoreExitValue = true
-    }
+    doFirst {
+        val errorOutputStream = ByteArrayOutputStream()
+        val standardOutputStream = ByteArrayOutputStream()
 
-    val errorOutput = errorOutputStream.toString()
-    val standardOutput = standardOutputStream.toString()
-    if (!errorOutput.contains(expectedAgentError)) {
-        throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
-    }
-    if (standardOutput.contains("OK!")) {
-        throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' was expected to throw the agent initializaion error, but Main was executed:\n" + standardOutput + "\n" + errorOutput)
+        project.javaexec {
+            mainClass.set("Main")
+            classpath = sourceSets.main.get().runtimeClasspath
+            jvmArgs = listOf("-javaagent:$agentJar")
+            errorOutput = errorOutputStream
+            standardOutput = standardOutputStream
+            isIgnoreExitValue = true
+        }
+
+        val errorOutput = errorOutputStream.toString()
+        val standardOutput = standardOutputStream.toString()
+        if (!errorOutput.contains(expectedAgentError)) {
+            throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+        }
+        if (standardOutput.contains("OK!")) {
+            throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' was expected to throw the agent initializaion error, but Main was executed:\n" + standardOutput + "\n" + errorOutput)
+        }
     }
 }
 
 // This test checks, that if the argument `kotlinx.coroutines.ignore.debug.agent.error` is passed to the javaagent,
 // then the initialization error will be just logged to the stderr and the execution will continue.
-tasks.register<Test>("runWithIgnoredError") {
+tasks.register<Task>("runWithIgnoredError") {
+    dependsOn("compileJava")
     val agentJar = System.getProperty("coroutines.debug.agent.path")
-    val errorOutputStream = ByteArrayOutputStream()
-    val standardOutputStream = ByteArrayOutputStream()
 
-    project.javaexec {
-        mainClass.set("Main")
-        classpath = sourceSets.main.get().runtimeClasspath
-        jvmArgs = listOf("-javaagent:$agentJar=kotlinx.coroutines.ignore.debug.agent.error")
-        errorOutput = errorOutputStream
-        standardOutput = standardOutputStream
-        isIgnoreExitValue = true
-    }
+    doFirst {
+        val errorOutputStream = ByteArrayOutputStream()
+        val standardOutputStream = ByteArrayOutputStream()
 
-    val errorOutput = errorOutputStream.toString()
-    val standardOutput = standardOutputStream.toString()
-    if (!errorOutput.contains(expectedAgentError)) {
-        throw GradleException("':safeDebugAgentTest:runWithIgnoredError' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
-    }
-    if (!standardOutput.contains("OK!")) {
-        throw GradleException("':safeDebugAgentTest:runWithIgnoredError' was expected to log the agent initialization error and proceed with the execution of Main, but it completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+        project.javaexec {
+            mainClass.set("Main")
+            classpath = sourceSets.main.get().runtimeClasspath
+            jvmArgs = listOf("-javaagent:$agentJar=kotlinx.coroutines.ignore.debug.agent.error")
+            errorOutput = errorOutputStream
+            standardOutput = standardOutputStream
+            isIgnoreExitValue = true
+        }
+
+        val errorOutput = errorOutputStream.toString()
+        val standardOutput = standardOutputStream.toString()
+        if (!errorOutput.contains(expectedAgentError)) {
+            throw GradleException("':safeDebugAgentTest:runWithIgnoredError' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+        }
+        if (!standardOutput.contains("OK!")) {
+            throw GradleException("':safeDebugAgentTest:runWithIgnoredError' was expected to log the agent initialization error and proceed with the execution of Main, but it completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
+        }
     }
 }

--- a/integration-testing/safeDebugAgentTest/build.gradle.kts
+++ b/integration-testing/safeDebugAgentTest/build.gradle.kts
@@ -42,6 +42,9 @@ tasks.register<Test>("runWithExpectedFailure") {
     if (!errorOutput.contains(expectedAgentError)) {
         throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' completed with an unexpected output:\n" + standardOutput + "\n" + errorOutput)
     }
+    if (standardOutput.contains("OK!")) {
+        throw GradleException("':safeDebugAgentTest:runWithExpectedFailure' was expected to throw the agent initializaion error, but Main was executed:\n" + standardOutput + "\n" + errorOutput)
+    }
 }
 
 // This test checks, that if the argument `kotlinx.coroutines.ignore.debug.agent.error` is passed to the javaagent,

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/AgentPremain.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/AgentPremain.kt
@@ -3,6 +3,8 @@ package kotlinx.coroutines.debug.internal
 import android.annotation.*
 import org.codehaus.mojo.animal_sniffer.*
 import sun.misc.*
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.lang.IllegalStateException
 import java.lang.instrument.*
 import java.lang.instrument.ClassFileTransformer
@@ -15,26 +17,7 @@ import java.security.*
 @Suppress("unused")
 @SuppressLint("all")
 @IgnoreJRERequirement // Never touched on Android
-internal object AgentPremain {
-
-    // This should be the first property to ensure the check happens first! Add new properties only below!
-    private val dummy = checkIfStdlibIsAvailable()
-
-    /**
-     * This check ensures that kotlin-stdlib classes are loaded by the time AgentPremain is initialized;
-     * otherwise the debug session would fail with `java.lang.NoClassDefFoundError: kotlin/Result`.
-     */
-    private fun checkIfStdlibIsAvailable() {
-        try {
-            Result.success(42)
-        } catch (t: Throwable) {
-            throw IllegalStateException("kotlinx.coroutines debug agent failed to load.\n" +
-                "Please ensure that the Kotlin standard library is present in the classpath.\n" +
-                "Alternatively, you can disable kotlinx.coroutines debug agent by removing `-javaagent=/path/kotlinx-coroutines-core.jar` from your VM arguments.\n" +
-                t.cause
-            )
-        }
-    }
+internal object AgentPremainImpl {
 
     private val enableCreationStackTraces = runCatching {
         System.getProperty("kotlinx.coroutines.debug.enable.creation.stack.trace")?.toBoolean()
@@ -86,6 +69,40 @@ internal object AgentPremain {
             }
         } catch (t: Throwable) {
             // Do nothing, signal cannot be installed, e.g. because we are on Windows
+        }
+    }
+}
+
+/**
+ * This class serves as a "safe" wrapper around [AgentPremainImpl] that does not require any kotlin-stdlib classes to be loaded for its initialization.
+ * It may throw an error containing the cause of the agent initialization failure or just log the error to the error output.
+ *
+ * By default, if agent initialization fails, e.g., if kotlin-stdlib is not found in the classpath,
+ * the agent will throw an [IllegalStateException].
+ *
+ * If `kotlinx.coroutines.ignore.debug.agent.error` is passed as an argument to the debug agent
+ * (like this: `-javaagent:/path/kotlinx-coroutines-core.jar=kotlinx.coroutines.ignore.debug.agent.error`),
+ * then the initialization error will be logged to stderr, the agent will not be attached, but the execution will continue.
+ */
+internal object AgentPremain {
+    @JvmStatic
+    @Suppress("UNUSED_PARAMETER")
+    fun premain(args: String?, instrumentation: Instrumentation) {
+        val shouldIgnoreError = (args as? java.lang.String)?.contains("kotlinx.coroutines.ignore.debug.agent.error") ?: false
+        try {
+            AgentPremainImpl.premain(args, instrumentation)
+        } catch (t: Throwable) {
+            val sw = StringWriter()
+            t.printStackTrace(PrintWriter(sw))
+            val errorMessage = "kotlinx.coroutines debug agent failed to load.\n" +
+                "Please ensure that the Kotlin standard library is present in the classpath.\n" +
+                "Alternatively, you can disable kotlinx.coroutines debug agent by removing `-javaagent=/path/kotlinx-coroutines-core.jar` from your VM arguments.\n" +
+                sw.toString()
+            if (shouldIgnoreError) {
+                System.err.println(errorMessage)
+            } else {
+                throw IllegalStateException( errorMessage)
+            }
         }
     }
 }


### PR DESCRIPTION
The previous changes to the debug agent provided a more detailed error message when agent initialization fails. 
Though the question still remains: should we log an error and continue execution, or should we always throw an error?

For users who apply the agent manually and expect it to be attached, throwing an error that indicates the agent failed to load would be more helpful. But for the debugger users who didn't apply the agent manually (the debugger did it for them), a thrown exception is confusing —they have no idea where to add stdlib to the classpath or how to remove the javaagent, for them it just means that the debugger is broken.

To address both cases, I propose adding a special argument that the debugger can set to log an error and proceed with execution, while by default, an error will be thrown for manual agent users.