### PR TITLE
Fix : Dispatcher failures may leave coroutines uncompleted #4209

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/DispatchCancelOnFailureTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/DispatchCancelOnFailureTest.kt
@@ -1,0 +1,50 @@
+package kotlinx.coroutines
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.coroutines.CoroutineContext
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class DispatchCancelOnFailureTest {
+    @Test
+    fun testCancelJobOnDispatchFailure() = runBlocking {
+        val dispatcher = object : CoroutineDispatcher() {
+            override fun isDispatchNeeded(context: CoroutineContext): Boolean = true
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                throw RuntimeException("dispatch failure")
+            }
+        }
+
+        val reported = AtomicReference<Throwable?>(null)
+        val handler = CoroutineExceptionHandler { _, t -> reported.set(t) }
+
+    val job = Job()
+        val finallyRan = AtomicBoolean(false)
+        val deferred = CompletableDeferred<Int>()
+
+        val coro = launch(job + dispatcher + handler, start = CoroutineStart.UNDISPATCHED) {
+            try {
+                deferred.await()
+            } finally {
+                finallyRan.set(true)
+            }
+        }
+
+        // resume from another dispatcher; this will cause dispatch to throw and safeDispatch
+        // should cancel the coroutine's Job and report the original exception
+        launch(Dispatchers.Default) {
+            delay(50)
+            deferred.complete(3)
+        }
+
+    coro.join()
+
+    // The coroutine that was launched (`coro`) should be cancelled when dispatch fails.
+    // Checking `coro.isCancelled` is more reliable than checking the parent `job` instance,
+    // because `launch` may create a child Job in the coroutine context.
+    assertTrue(coro.isCancelled, "coroutine should be cancelled on dispatch failure")
+        assertTrue(finallyRan.get(), "finally block must run")
+        assertTrue(reported.get() != null, "Dispatch failure should be reported via CoroutineExceptionHandler")
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/DispatchFailureReproducerTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/DispatchFailureReproducerTest.kt
@@ -1,0 +1,54 @@
+package kotlinx.coroutines
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class DispatchFailureReproducerTest {
+    @Test
+    fun testDispatcherCloseDuringResume_reportsFailureAndCompletes() = runBlocking {
+        val dispatcher = newSingleThreadContext("unreliable friend")
+
+        // Capture exceptions reported to the coroutine exception handler
+        val reported = AtomicReference<Throwable?>(null)
+        val handler = CoroutineExceptionHandler { _, t -> reported.set(t) }
+
+        val finallyRan = AtomicBoolean(false)
+
+        // Use a CompletableDeferred instead of suspendCancellableCoroutine to avoid
+        // depending on test-only APIs and to keep the scenario deterministic.
+        val deferred = CompletableDeferred<Int>()
+
+        val job = launch(dispatcher + handler, start = CoroutineStart.UNDISPATCHED) {
+            try {
+                // Await the deferred; it will be completed from another dispatcher
+                deferred.await()
+            } finally {
+                // Mark that finally ran
+                finallyRan.set(true)
+            }
+        }
+
+        // Resume from another dispatcher after a short delay and close the dispatcher
+        launch(Dispatchers.Default) {
+            delay(50)
+            dispatcher.close()
+            deferred.complete(3)
+        }
+
+        // Wait for completion
+        job.join()
+
+        // The coroutine should have completed and its finally should have run
+        assertTrue(finallyRan.get(), "finally block must run (no hang)")
+
+        // Assert that a dispatch failure was reported (via CoroutineExceptionHandler)
+        val reportedEx = reported.get()
+        assertTrue(reportedEx != null, "Dispatch failure should be reported via CoroutineExceptionHandler")
+
+        // Clean up
+        dispatcher.close()
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/SafeIsDispatchNeededFailureTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/SafeIsDispatchNeededFailureTest.kt
@@ -1,0 +1,33 @@
+package kotlinx.coroutines
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.internal.*
+
+class SafeIsDispatchNeededFailureTest {
+    @Test
+    fun testSafeIsDispatchNeededThrowsDispatchException() {
+        val dispatcher = object : CoroutineDispatcher() {
+            override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+                throw RuntimeException("isDispatchNeeded boom")
+            }
+
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                // no-op
+            }
+        }
+
+        var thrown: Throwable? = null
+        try {
+            dispatcher.safeIsDispatchNeeded(EmptyCoroutineContext)
+        } catch (e: Throwable) {
+            thrown = e
+        }
+
+        assertTrue(thrown is DispatchException, "safeIsDispatchNeeded should throw DispatchException, got: $thrown")
+        assertTrue(thrown?.cause is RuntimeException, "cause should be original RuntimeException")
+    }
+}
+                                // no-op


### PR DESCRIPTION
Prevent coroutine hang by safely handling synchronous dispatcher throws and falling back