### PR TITLE
Removed redundant enabling tracking klib-based targets

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -15,10 +15,6 @@ kotlin {
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
         enabled = abiCheckEnabled
-
-        klib {
-            enabled = true
-        }
     }
 
     jvm {


### PR DESCRIPTION
In the BCV implementation as part of KGP, klib-based targets tracking is enabled by default, so there is no need to explicitly enable it.