### PR TITLE
Add the EXACTLY_ONCE contract to `suspendCancellableContinuation`

### DIFF
--- a/kotlinx-coroutines-core/common/test/CancellableContinuationTest.kt
+++ b/kotlinx-coroutines-core/common/test/CancellableContinuationTest.kt
@@ -134,4 +134,15 @@ class CancellableContinuationTest : TestBase() {
         })
         finish(5)
     }
+
+    /** Tests that the compiler recognizes that [suspendCancellableCoroutine] invokes its block exactly once. */
+    @Test
+    fun testSuspendCancellableCoroutineContract() = runTest {
+        val i: Int
+        suspendCancellableCoroutine { cont ->
+            i = 1
+            cont.resume(Unit)
+        }
+        assertEquals(1, i)
+    }
 }


### PR DESCRIPTION
`suspendCancellableContinuation` invokes its block exactly once. `suspendCoroutineUninterceptedOrReturn`,
which is used for implementing `suspendCancellableContinuation`, already has a contract stating just that,
so for consistency and completeness, we add a contract to `suspendCancellableContinuation` itself as well.

This will let the compiler recognize that `val`-variables can be safely assigned inside the lambda, as they won't be reassigned or left uninitialized (which would be the case if the lambda executed more than once or possibly not execute at all).

There were no use cases actually reported for this.