### PR TITLE
Update the expected API dump according to the Kotlin compiler changes

### DIFF
--- a/ui/kotlinx-coroutines-android/api/kotlinx-coroutines-android.api
+++ b/ui/kotlinx-coroutines-android/api/kotlinx-coroutines-android.api
@@ -1,5 +1,6 @@
 public abstract class kotlinx/coroutines/android/HandlerDispatcher : kotlinx/coroutines/MainCoroutineDispatcher, kotlinx/coroutines/Delay {
 	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getImmediate ()Lkotlinx/coroutines/MainCoroutineDispatcher;
 	public abstract fun getImmediate ()Lkotlinx/coroutines/android/HandlerDispatcher;
 	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 }


### PR DESCRIPTION
The changes in Kotlin compiler were implemented according to https://youtrack.jetbrains.com/issue/KT-82467/Improve-binary-and-JVM-compatibility-by-generating-bridges-for-abstract-interface-methods.
This is the first part of changes, as the option that enables bridges in interfaces is disabled by default yet.