### PR TITLE
Disable JvmEnhancedBridges to avoid ABI dump divergence

### DIFF
--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -188,6 +188,7 @@ fun KotlinCommonCompilerOptions.configureKotlinUserProject() {
     freeCompilerArgs.addAll(
         "-Xreport-all-warnings", // emit warnings even if there are also errors
         "-Xrender-internal-diagnostic-names", // render the diagnostic names in CLI
+        "-XXLanguage:-JvmEnhancedBridges", // temporary disable enhanced bridges to avoid ABI divergence
     )
 }
 


### PR DESCRIPTION
[KT-82467](https://youtrack.jetbrains.com/issue/KT-82467) will be enabled by default w/ language version 2.4, and the ABI dump for the library will change. Since there's no way to ignore a part of an ABI dump, or to use multiple dumps depending on a version (well, it's possible, but I would prefer to abstain from introducing such logic in our build scripts for now), I'm postposing to disable JvmEnhancedBridges until the library will enable it (one way, or another) in the main branch.

The ABI diff that would otherwise cause an ABI check check failure w/ LV 2.4:
```diff
--- /mnt/agent/work/ff8885566b60a51d/user-project/ui/kotlinx-coroutines-android/api/kotlinx-coroutines-android.api
+++ /mnt/agent/work/ff8885566b60a51d/user-project/ui/kotlinx-coroutines-android/build/kotlin/abi-legacy/kotlinx-coroutines-android.api
@@ -1,5 +1,6 @@
 public abstract class kotlinx/coroutines/android/HandlerDispatcher : kotlinx/coroutines/MainCoroutineDispatcher, kotlinx/coroutines/Delay {
   public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+  public synthetic fun getImmediate ()Lkotlinx/coroutines/MainCoroutineDispatcher;
   public abstract fun getImmediate ()Lkotlinx/coroutines/android/HandlerDispatcher;
   public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
 }
```