### PR TITLE
Publish `kotlinx-coroutines` for integration testing in `build/`

### DIFF
--- a/KOTLIN_UPGRADE.md
+++ b/KOTLIN_UPGRADE.md
@@ -23,7 +23,7 @@
    Set the compiler version of Kotlin Playground to the same major version as `<version>`,
    click "Copy link", and replace the original link in `README.md` with the new one.
 
-5. Perform a full build: `gradle clean check publishAllPublicationsToIntegrationTestingRepository`,
+5. Perform a full build: `gradle clean check publishAllPublicationsToBuildLocalRepository`,
    followed by `gradle clean check` in the `integration-testing` directory.
    Fix any issues that arise.
 

--- a/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
@@ -16,8 +16,8 @@ publishing {
     repositories {
         configureMavenPublication(this, project)
         maven {
-            name = "IntegrationTesting"
-            url = uri(project.rootProject.layout.buildDirectory.dir("integration-testing-repository"))
+            name = "BuildLocal"
+            url = uri(project.rootProject.layout.buildDirectory.dir("build-local-repository"))
         }
     }
 
@@ -73,5 +73,5 @@ tasks.register("bintrayUpload") { dependsOn(tasks.matching { it.name == "publish
 
 // Compatibility with old TeamCity configurations that perform `publishToMavenLocal`
 tasks.named("publishToMavenLocal") {
-    dependsOn(tasks.matching { it.name == "publishAllPublicationsToIntegrationTestingRepository" })
+    dependsOn(tasks.matching { it.name == "publishAllPublicationsToBuildLocalRepository" })
 }

--- a/integration-testing/README.md
+++ b/integration-testing/README.md
@@ -14,4 +14,4 @@ The tests are the following:
 
 The `integration-testing` project is expected to be in a subdirectory of the main `kotlinx.coroutines` project.
 
-To run all the available tests: `./gradlew publishAllPublicationsToIntegrationTestingRepository` + `cd integration-testing` + `./gradlew check`.
+To run all the available tests: `./gradlew publishAllPublicationsToBuildLocalRepository` + `cd integration-testing` + `./gradlew check`.

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -73,7 +73,7 @@ allprojects {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
         mavenLocal()
-        maven(rootProject.layout.projectDirectory.dir("../build/integration-testing-repository/"))
+        maven(rootProject.layout.projectDirectory.dir("../build/build-local-repository/"))
     }
 }
 


### PR DESCRIPTION
Before this change, the tests in `integration-testing` were expecting the local Maven repository to contain the artifacts from `kotlinx-coroutines`.
The full build process looked like this:
```sh
./gradlew clean build publishToMavenLocal
cd integration-testing
./gradlew clean build
```
This was problematic:
* Builds could not be run in parallel, as they would interfere with one another via the local Maven repository.
* Moreover, even sequential builds could suffer due to not every file in the local Maven repository being overwritten.

With this change, the build process is:
```sh
./gradlew clean build publishAllPublicationsToIntegrationTestingRepository
cd integration-testing
./gradlew clean build
```