### PR TITLE
Fix indentation in code example

### DIFF
--- a/docs/topics/cancellation-and-timeouts.md
+++ b/docs/topics/cancellation-and-timeouts.md
@@ -70,9 +70,9 @@ suspend fun main() {
 
         // async returns a Deferred handle, which inherits from Job
         val job2 = async {
-                  // If the coroutine is canceled before its body starts executing,
-                  // this line may not be printed
-                  println("The second coroutine has started")
+            // If the coroutine is canceled before its body starts executing,
+            // this line may not be printed
+            println("The second coroutine has started")
 
             try {
                 // Equivalent to delay(Duration.INFINITE)


### PR DESCRIPTION
<img width="643" height="424" alt="Screenshot 2026-01-29 at 9 20 06 AM" src="https://github.com/user-attachments/assets/c734efd2-547c-41ed-b7e1-e19a976a4738" />

This is how it looks today ☝️ 
See the coed and visit https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancel-coroutines

This PR fixes the indentation for the comment and the `println` statement.