### PR TITLE
Optimize attaching the debug probes

### DIFF
--- a/kotlinx-coroutines-debug/src/Attach.kt
+++ b/kotlinx-coroutines-debug/src/Attach.kt
@@ -16,23 +16,30 @@ internal class ByteBuddyDynamicAttach : Function1<Boolean, Unit> {
 
     private fun attach() {
         ByteBuddyAgent.install(ByteBuddyAgent.AttachmentProvider.ForEmulatedAttachment.INSTANCE)
-        val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
-        val cl2 = Class.forName("kotlinx.coroutines.debug.internal.DebugProbesKt")
-
-        ByteBuddy()
-            .redefine(cl2)
-            .name(cl.name)
-            .make()
-            .load(cl.classLoader, ClassReloadingStrategy.fromInstalledAgent())
+        dynamicTypeWithProbes.load(targetClassLoader, ClassReloadingStrategy.fromInstalledAgent())
     }
 
     private fun detach() {
-        val cl = Class.forName("kotlin.coroutines.jvm.internal.DebugProbesKt")
-        val cl2 = Class.forName("kotlinx.coroutines.debug.NoOpProbesKt")
-        ByteBuddy()
-            .redefine(cl2)
-            .name(cl.name)
-            .make()
-            .load(cl.classLoader, ClassReloadingStrategy.fromInstalledAgent())
+        dynamicTypeWithoutProbes.load(targetClassLoader, ClassReloadingStrategy.fromInstalledAgent())
     }
+}
+
+private val targetClassLoader = Class.forName(classNameToOverride).classLoader
+
+private const val classNameToOverride = "kotlin.coroutines.jvm.internal.DebugProbesKt"
+
+private val dynamicTypeWithProbes by lazy {
+    val classWithProbes = Class.forName("kotlinx.coroutines.debug.internal.DebugProbesKt")
+    ByteBuddy()
+        .redefine(classWithProbes)
+        .name(classNameToOverride)
+        .make()
+}
+
+private val dynamicTypeWithoutProbes by lazy {
+    val classWithoutProbes = Class.forName("kotlinx.coroutines.debug.NoOpProbesKt")
+    ByteBuddy()
+        .redefine(classWithoutProbes)
+        .name(classNameToOverride)
+        .make()
 }

--- a/kotlinx-coroutines-debug/src/Attach.kt
+++ b/kotlinx-coroutines-debug/src/Attach.kt
@@ -22,24 +22,28 @@ internal class ByteBuddyDynamicAttach : Function1<Boolean, Unit> {
     private fun detach() {
         dynamicTypeWithoutProbes.load(targetClassLoader, ClassReloadingStrategy.fromInstalledAgent())
     }
-}
 
-private val targetClassLoader = Class.forName(classNameToOverride).classLoader
+    private companion object {
+        private const val classNameToOverride = "kotlin.coroutines.jvm.internal.DebugProbesKt"
 
-private const val classNameToOverride = "kotlin.coroutines.jvm.internal.DebugProbesKt"
+        private val targetClassLoader by lazy {
+            Class.forName(classNameToOverride).classLoader
+        }
 
-private val dynamicTypeWithProbes by lazy {
-    val classWithProbes = Class.forName("kotlinx.coroutines.debug.internal.DebugProbesKt")
-    ByteBuddy()
-        .redefine(classWithProbes)
-        .name(classNameToOverride)
-        .make()
-}
+        private val dynamicTypeWithProbes by lazy {
+            val classWithProbes = Class.forName("kotlinx.coroutines.debug.internal.DebugProbesKt")
+            ByteBuddy()
+                .redefine(classWithProbes)
+                .name(classNameToOverride)
+                .make()
+        }
 
-private val dynamicTypeWithoutProbes by lazy {
-    val classWithoutProbes = Class.forName("kotlinx.coroutines.debug.NoOpProbesKt")
-    ByteBuddy()
-        .redefine(classWithoutProbes)
-        .name(classNameToOverride)
-        .make()
+        private val dynamicTypeWithoutProbes by lazy {
+            val classWithoutProbes = Class.forName("kotlinx.coroutines.debug.NoOpProbesKt")
+            ByteBuddy()
+                .redefine(classWithoutProbes)
+                .name(classNameToOverride)
+                .make()
+        }
+    }
 }


### PR DESCRIPTION
I see a notable speed improvement even without any benchmarks, simply by running `DebugProbes.withDebugProbes { }` in a loop.

As I see, the change should be completely transparent for the user. `Class.forName` used to run with the class loader of the `ByteBuddyDynamicAttach` class, which itself is loaded by `ByteBuddyDynamicAttach`. This hasn't changed—there is still no other code that can access `ByteBuddyDynamicAttach`, and transitively, the `AttachKt` fields.