### PR TITLE
integration-testing: add kotlin_repo_url to subproject repositories f…

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -39,6 +39,7 @@ buildscript {
 
     val usingSnapshotVersion = checkIsSnapshotVersion()
     val hasSnapshotTrainProperty = checkIsSnapshotTrainProperty()
+    val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
 
     extra.apply {
         set("using_snapshot_version", usingSnapshotVersion)
@@ -49,7 +50,12 @@ buildscript {
         repositories {
             mavenLocal()
             maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+            maven("https://redirector.kotlinlang.org/maven/dev")
+            if (!kotlinRepoUrl.isNullOrBlank()) {
+                maven(kotlinRepoUrl)
+            }
         }
+
     }
 }
 
@@ -57,12 +63,17 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version extra["kotlin_version"].toString()
 }
 
-repositories {
-    if (extra["using_snapshot_version"] == true) {
+allprojects {
+    repositories {
+        val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
+        if (!kotlinRepoUrl.isNullOrBlank()) {
+            maven(kotlinRepoUrl)
+        }
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+        maven("https://redirector.kotlinlang.org/maven/dev")
+        mavenLocal()
     }
-    mavenLocal()
-    mavenCentral()
 }
 
 java {

--- a/integration-testing/java8Test/build.gradle.kts
+++ b/integration-testing/java8Test/build.gradle.kts
@@ -2,13 +2,6 @@ plugins {
     kotlin("jvm")
 }
 
-repositories {
-    mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
-    // Coroutines from the outer project are published by previous CI buils step
-    mavenLocal()
-}
-
 tasks.test {
     useJUnitPlatform()
 }

--- a/integration-testing/jpmsTest/build.gradle.kts
+++ b/integration-testing/jpmsTest/build.gradle.kts
@@ -5,14 +5,6 @@ plugins {
 
 val coroutines_version: String by project
 
-repositories {
-    if (project.properties["build_snapshot_train"]?.toString()?.toBoolean() == true) {
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
-    }
-    mavenLocal()
-    mavenCentral()
-}
-
 java {
     modularity.inferModulePath.set(true)
 }

--- a/integration-testing/settings.gradle.kts
+++ b/integration-testing/settings.gradle.kts
@@ -4,6 +4,10 @@ pluginManagement {
         maven("https://plugins.gradle.org/m2/")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         mavenLocal()
+        val kotlinRepoUrl = providers.gradleProperty("kotlin_repo_url").orNull
+        if (!kotlinRepoUrl.isNullOrBlank()) {
+            maven(kotlinRepoUrl)
+        }
     }
 }
 

--- a/integration-testing/smokeTest/build.gradle.kts
+++ b/integration-testing/smokeTest/build.gradle.kts
@@ -8,13 +8,6 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
 }
 
-repositories {
-    mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
-    // Coroutines from the outer project are published by previous CI builds step
-    mavenLocal()
-}
-
 kotlin {
     jvm()
     js(IR) {


### PR DESCRIPTION
I'm refactoring train, so the kotlin artefacts from the TeamCity agent are used instead of artefacts from space. This adjustment is needed for it