### PR TITLE
Implemented preparations for new ABI validations' DSL

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -47,11 +47,6 @@ tasks.withType<Test> {
     if (stressTest != null) systemProperties["stressTest"] = stressTest
 }
 
-// TODO: delete this after starting to use Kotlin 2.3.20
-tasks.check {
-    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
-}
-
 tasks.named<Jar>("jar") {
     fillManifestImplementationAttributes(project)
 }

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -15,9 +15,11 @@ java {
 }
 
 kotlin {
-    @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        enabled = abiCheckEnabled
+    if (abiCheckEnabled) {
+        @OptIn(ExperimentalAbiValidation::class)
+        abiValidation {
+            enabled = true
+        }
     }
 
     compilerOptions {
@@ -45,8 +47,9 @@ tasks.withType<Test> {
     if (stressTest != null) systemProperties["stressTest"] = stressTest
 }
 
+// TODO: delete this after starting to use Kotlin 2.3.20
 tasks.check {
-   dependsOn(tasks.checkLegacyAbi)
+    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
 }
 
 tasks.named<Jar>("jar") {

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -14,9 +14,11 @@ java {
 }
 
 kotlin {
-    @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        enabled = abiCheckEnabled
+    if (abiCheckEnabled) {
+        @OptIn(ExperimentalAbiValidation::class)
+        abiValidation {
+            enabled = true
+        }
     }
 
     compilerOptions {
@@ -44,6 +46,7 @@ tasks.withType<Test> {
     if (stressTest != null) systemProperties["stressTest"] = stressTest
 }
 
+// TODO: delete this after starting to use Kotlin 2.3.20
 tasks.check {
-   dependsOn(tasks.checkLegacyAbi)
+    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
 }

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -142,11 +142,6 @@ tasks.named("jvmTest", Test::class) {
     project.properties["stressTest"]?.let { systemProperty("stressTest", it) }
 }
 
-// TODO: delete this after starting to use Kotlin 2.3.20
-tasks.check {
-    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
-}
-
 kotlin.targets.withType<KotlinJvmTarget>().configureEach {
     // Fill attributes for the JVM implementation Jar only
     tasks.named<Jar>(artifactsTaskName) {

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -12,9 +12,11 @@ java {
 }
 
 kotlin {
-    @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        enabled = abiCheckEnabled
+    if (abiCheckEnabled) {
+        @OptIn(ExperimentalAbiValidation::class)
+        abiValidation {
+            enabled = true
+        }
     }
 
     jvm {
@@ -143,6 +145,7 @@ tasks.named("jvmTest", Test::class) {
     project.properties["stressTest"]?.let { systemProperty("stressTest", it) }
 }
 
+// TODO: delete this after starting to use Kotlin 2.3.20
 tasks.check {
-   dependsOn(tasks.checkLegacyAbi)
+    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
 }

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-conventions.gradle.kts
@@ -14,9 +14,11 @@ java {
 }
 
 kotlin {
-    @OptIn(ExperimentalAbiValidation::class)
-    abiValidation {
-        enabled = abiCheckEnabled
+    if (abiCheckEnabled) {
+        @OptIn(ExperimentalAbiValidation::class)
+        abiValidation {
+            enabled = true
+        }
     }
 
     jvm {
@@ -140,8 +142,9 @@ tasks.named("jvmTest", Test::class) {
     project.properties["stressTest"]?.let { systemProperty("stressTest", it) }
 }
 
+// TODO: delete this after starting to use Kotlin 2.3.20
 tasks.check {
-   dependsOn(tasks.checkLegacyAbi)
+    dependsOn(tasks.matching { it.name == "checkLegacyAbi" })
 }
 
 kotlin.targets.withType<KotlinJvmTarget>().configureEach {


### PR DESCRIPTION
In the stable DSL of Kotlin Gradle plugin, `checkLegacyAbi` task is created only if the `abiValidation` block is explicitly called.

For this reason, the `tasks.checkLegacyAbi` accessor does not exist, and `abiValidation { ... }` should be called only by condition.