### PR TITLE
Upgrade kotlinx-coroutines-guava to 32.0.0-jre

### DIFF
--- a/integration/kotlinx-coroutines-guava/build.gradle.kts
+++ b/integration/kotlinx-coroutines-guava/build.gradle.kts
@@ -1,4 +1,4 @@
-val guavaVersion = "31.0.1-jre"
+val guavaVersion = "32.0.0-jre"
 
 dependencies {
     api("com.google.guava:guava:$guavaVersion")


### PR DESCRIPTION
This version picks up fixes for CVE-2020-8908 to make sure a vulnerable version doesn't get pulled in when using kotlinx-coroutines-guava