### PR TITLE
Train setup: get rid of kotlin_snapshot_version parameter. Use kotlin_version instead

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,11 +28,6 @@ val gradleProperties = Properties().apply {
 }
 
 fun version(target: String): String {
-    // Intercept reading from properties file
-    if (target == "kotlin") {
-        val snapshotVersion = properties["kotlin_snapshot_version"]
-        if (snapshotVersion != null) return snapshotVersion.toString()
-    }
     val version = "${target}_version"
     // Read from CLI first, used in aggregate builds
     return properties[version]?.let{"$it"} ?: gradleProperties.getProperty(version)

--- a/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
+++ b/buildSrc/src/main/kotlin/CommunityProjectsBuild.kt
@@ -17,7 +17,7 @@ private val LOGGER: Logger = Logger.getLogger("Kotlin settings logger")
  * are compatible with our libraries (aka "integration testing that substitutes lack of unit testing").
  *
  * When `build_snapshot_train` is set to true (and [isSnapshotTrainEnabled] returns `true`),
- * - `kotlin_version property` is overridden with `kotlin_snapshot_version` (see [getOverriddenKotlinVersion]),
+ * - `kotlin_version` is resolved from Gradle properties (and can be overridden from the command line),
  * - `atomicfu_version` is overwritten by TeamCity environment (AFU is built with snapshot and published to mavenLocal
  *   as previous step or the snapshot build).
  * Additionally, mavenLocal and Sonatype snapshots are added to repository list and stress tests are disabled
@@ -118,17 +118,6 @@ fun Project.configureCommunityBuildTweaks() {
         }
     }
 }
-
-/**
- * Ensures that, if [isSnapshotTrainEnabled] is true, the project is built with a snapshot version of Kotlin compiler.
- */
-fun getOverriddenKotlinVersion(project: Project): String? =
-    if (isSnapshotTrainEnabled(project)) {
-        project.providers.gradleProperty("kotlin_snapshot_version").orNull
-            ?: error("'kotlin_snapshot_version' should be defined when building with a snapshot compiler")
-    } else {
-        null
-    }
 
 /**
  * Checks if the project is built with a snapshot version of Kotlin compiler.

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -4,9 +4,6 @@ import org.gradle.api.*
 import org.gradle.api.tasks.*
 
 fun Project.version(target: String): String {
-    if (target == "kotlin") {
-        getOverriddenKotlinVersion(this)?.let { return it }
-    }
     return property("${target}_version") as String
 }
 

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -9,7 +9,8 @@ buildscript {
     /*
         These property group is used to build kotlinx.coroutines against Kotlin compiler snapshot.
         How does it work:
-        When build_snapshot_train is set to true, kotlin_version property is overridden with kotlin_snapshot_version,
+        When build_snapshot_train is set to true, kotlin_version is taken from Gradle properties
+        (and can be overridden from the command line),
         atomicfu_version is overwritten by TeamCity environment (AFU is built with snapshot and published to mavenLocal
         as previous step or the snapshot build).
         Additionally, mavenLocal and Sonatype snapshots are added to repository list and stress tests are disabled.
@@ -82,12 +83,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-val kotlinVersion = if (extra["build_snapshot_train"] == true) {
-    providers.gradleProperty("kotlin_snapshot_version").orNull
-        ?: throw IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with snapshot compiler")
-} else {
-    providers.gradleProperty("kotlin_version").get()
-}
+val kotlinVersion = providers.gradleProperty("kotlin_version").get()
 
 val asmVersion = property("asm_version")
 


### PR DESCRIPTION
I'm doing Train setup refactoring and gonna get rid of kotlin_snapshot_version parameter, as it just duplicates kotlin_version parameter and creates confusion. DO NOT MERGE - will merge as soon as train changes are accepted