### PR TITLE
Update Flow.cancellable() and collect() KDoc to mention prompt cancel…

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -183,6 +183,12 @@ public interface Flow<out T> {
      * myFlow.collect { value -> println("Collected $value") }
      * ```
      *
+     * ### Cancellation
+     *
+     * Flows built with the [flow] builder and all [SharedFlow] implementations provide a
+     * **prompt cancellation guarantee**: the collector's cancellation status is checked on each emission.
+     * For other [Flow] implementations, the [cancellable] operator can be used to ensure the same guarantee.
+     *
      * ### Method inheritance
      *
      * To ensure the context preservation property, it is not recommended implementing this method directly.

--- a/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Context.kt
@@ -252,9 +252,13 @@ public fun <T> Flow<T>.flowOn(context: CoroutineContext): Flow<T> {
 }
 
 /**
- * Returns a flow which checks cancellation status on each emission and throws
- * the corresponding cancellation cause if flow collector was cancelled.
- * Note that [flow] builder and all implementations of [SharedFlow] are [cancellable] by default.
+ * Returns a flow that provides a **prompt cancellation guarantee**: on each emission, the
+ * flow collector's cancellation status is checked, and if the collector was cancelled,
+ * the corresponding cancellation cause is thrown.
+ *
+ * The [flow] builder and all implementations of [SharedFlow] are [cancellable] by default.
+ * This operator is useful for custom [Flow] implementations or flows created without the [flow]
+ * builder to ensure they promptly respond to the collector's cancellation.
  *
  * This operator provides a shortcut for `.onEach { currentCoroutineContext().ensureActive() }`.
  * See [ensureActive][CoroutineContext.ensureActive] for details.


### PR DESCRIPTION
## Summary
Update KDoc for `Flow.cancellable()` and `Flow.collect()` to mention the **prompt cancellation guarantee**, addressing outdated documentation that only described atomic-style cancellation checking.

Fixes #3803

## Changes
- **`Flow.cancellable()`**: Reworded to explicitly state it provides a prompt cancellation guarantee, and clarified when this operator is needed (custom `Flow` implementations not using the `flow` builder).
- **`Flow.collect()`**: Added a "Cancellation" section explaining that `flow` builder and `SharedFlow` implementations are cancellable by default, and that the `cancellable` operator can be used for other implementations.