### PR TITLE
Fix an inconsistent KDoc for CoroutineDispatcher#dispatch

### DIFF
--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -244,7 +244,7 @@ public abstract class CoroutineDispatcher :
      * may leave the coroutines that use this dispatcher in an inconsistent and hard-to-debug state.
      * It is assumed that if any exceptions do get thrown from this method, then [block] will not be executed.
      *
-     * Most implementations should avoid calling [block] inline. Doing so may result in `StackOverflowError`
+     * Most implementations should avoid calling [block] in-place. Doing so may result in `StackOverflowError`
      * when `dispatch` is invoked repeatedly, for example when [yield] is called in a loop.
      * In order to execute a block in place, it is recommended to return `false` from [isDispatchNeeded]
      * and delegate the `dispatch` implementation to `Dispatchers.Unconfined.dispatch` in such cases.


### PR DESCRIPTION
Before this change, the documentation stated that `dispatch` may run the block in its own implementation, but also said that implementations are not allowed to call `block` directly. This is a clear contradiction.

The situation is nuanced. An implementation of
`CoroutineDispatcher` that directly calls `block` is occasionally useful and maybe even unavoidable. In particular, this is useful when integrating with RxJava,
which follows the immediate dispatching behavior:
<https://github.com/Kotlin/kotlinx.coroutines/issues/3458#issuecomment-1258060548>

Therefore, the documentation now allows immediately calling `block` in `dispatch`. Warnings about the potential issues with that are already in place and should be enough to inform the implementor about the inherent tradeoffs.