### PR TITLE
Fix most of the unresolved links detected by Dokka/IDEA in the `main` source-sets

### DIFF
--- a/kotlinx-coroutines-core/common/src/CompletionState.kt
+++ b/kotlinx-coroutines-core/common/src/CompletionState.kt
@@ -34,11 +34,11 @@ internal open class CompletedExceptionally(
 }
 
 /**
- * A specific subclass of [CompletedExceptionally] for cancelled [AbstractContinuation].
+ * A specific subclass of [CompletedExceptionally] for cancelled [CancellableContinuationImpl].
  *
  * @param continuation the continuation that was cancelled.
  * @param cause the exceptional completion cause. If `cause` is null, then a [CancellationException]
- *        if created on first access to [exception] property.
+ *        if created on first access to [cause] property.
  */
 internal class CancelledContinuation(
     continuation: Continuation<*>,

--- a/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineDispatcher.kt
@@ -33,7 +33,7 @@ import kotlin.coroutines.*
  *   This allows creating private thread pools without spawning new threads.
  *   For example, `Dispatchers.IO.limitedParallelism(4)` creates a dispatcher that allows running at most
  *   4 tasks in parallel, reusing the existing IO dispatcher threads.
- * - When thread pools completely separate from [Dispatchers.Default] and [Dispatchers.IO] are required,
+ * - When thread pools completely separate from [Dispatchers.Default] and `Dispatchers.IO` are required,
  *   they can be created with `newSingleThreadContext` and `newFixedThreadPoolContext` on the JVM and Native targets.
  * - An arbitrary `java.util.concurrent.Executor` can be converted to a dispatcher with the
  *   `asCoroutineDispatcher` extension function.

--- a/kotlinx-coroutines-core/common/src/CoroutineExceptionHandler.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineExceptionHandler.kt
@@ -9,8 +9,8 @@ import kotlin.coroutines.*
  * cannot be rethrown. This is a last resort handler to prevent lost exceptions.
  *
  * If there is [CoroutineExceptionHandler] in the context, then it is used. If it throws an exception during handling
- * or is absent, all instances of [CoroutineExceptionHandler] found via [ServiceLoader] and
- * [Thread.uncaughtExceptionHandler] are invoked.
+ * or is absent, all instances of [CoroutineExceptionHandler] found via `ServiceLoader` and
+ * `Thread.uncaughtExceptionHandler` are invoked.
  *
  * @suppress **This is internal API and it is subject to change.**
  */
@@ -87,8 +87,8 @@ public inline fun CoroutineExceptionHandler(crossinline handler: (CoroutineConte
  * - If the exception is [CancellationException], it is ignored, as these exceptions are used to cancel coroutines.
  * - Otherwise, if there is a [Job] in the context, then [Job.cancel] is invoked.
  * - Otherwise, as a last resort, the exception is processed in a platform-specific manner:
- *   - On JVM, all instances of [CoroutineExceptionHandler] found via [ServiceLoader], as well as
- *     the current thread's [Thread.uncaughtExceptionHandler], are invoked.
+ *   - On JVM, all instances of [CoroutineExceptionHandler] found via `ServiceLoader`, as well as
+ *     the current thread's `Thread.uncaughtExceptionHandler`, are invoked.
  *   - On Native, the whole application crashes with the exception.
  *   - On JS and Wasm JS, the exception is propagated into the JavaScript runtime's event loop
  *     and is processed in a platform-specific way determined by the platform itself.

--- a/kotlinx-coroutines-core/common/src/Debug.common.kt
+++ b/kotlinx-coroutines-core/common/src/Debug.common.kt
@@ -7,7 +7,7 @@ internal expect fun assert(value: () -> Boolean)
 
 /**
  * Throwable which can be cloned during stacktrace recovery in a class-specific way.
- * For additional information about stacktrace recovery see [STACKTRACE_RECOVERY_PROPERTY_NAME]
+ * For additional information about stacktrace recovery see `STACKTRACE_RECOVERY_PROPERTY_NAME`
  *
  * Example of usage:
  * ```
@@ -30,7 +30,7 @@ public interface CopyableThrowable<T> where T : Throwable, T : CopyableThrowable
      * Creates a copy of the current instance.
      *
      * For better debuggability, it is recommended to use original exception as [cause][Throwable.cause] of the resulting one.
-     * Stacktrace of copied exception will be overwritten by stacktrace recovery machinery by [Throwable.setStackTrace] call.
+     * Stacktrace of copied exception will be overwritten by stacktrace recovery machinery by `Throwable.setStackTrace` call.
      * An exception can opt-out of copying by returning `null` from this function.
      * Suppressed exceptions of the original exception should not be copied in order to avoid circular exceptions.
      *

--- a/kotlinx-coroutines-core/common/src/EventLoop.common.kt
+++ b/kotlinx-coroutines-core/common/src/EventLoop.common.kt
@@ -91,7 +91,7 @@ internal abstract class EventLoop : CoroutineDispatcher() {
 
     fun incrementUseCount(unconfined: Boolean = false) {
         useCount += delta(unconfined)
-        if (!unconfined) shared = true 
+        if (!unconfined) shared = true
     }
 
     fun decrementUseCount(unconfined: Boolean = false) {
@@ -533,7 +533,7 @@ internal expect object DefaultExecutor {
  *
  * Coroutines on Darwin targets can call into the Objective-C world, where a callee may push a to-be-returned object to
  * the Autorelease Pool, so as to avoid a premature ARC release before it reaches the caller. This means the pool must
- * be eventually drained to avoid leaks. Since Kotlin Coroutines does not use [NSRunLoop], which provides automatic
+ * be eventually drained to avoid leaks. Since Kotlin Coroutines does not use `NSRunLoop`, which provides automatic
  * pool management, it must manage the pool creation and pool drainage manually.
  */
 internal expect inline fun platformAutoreleasePool(crossinline block: () -> Unit)

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -347,7 +347,7 @@ internal open class BufferedChannel<E>(
         }
     }
 
-    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of this issue: KT-65554. 
+    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of this issue: KT-65554.
     // For now, an inline function, which invokes atomic operations, may only be called within a parent class.
     protected fun trySendDropOldest(element: E): ChannelResult<Unit> =
         sendImpl( // <-- this is an inline function
@@ -1583,8 +1583,8 @@ internal open class BufferedChannel<E>(
      * From the implementation side, [receiveResult] stores the element retrieved by [hasNext]
      * (or a special [CHANNEL_CLOSED] token if the channel is closed).
      *
-     * The [invoke] function is a [CancelHandler] implementation,
-     * which requires knowing the [segment] and the [index] in it
+     * The [invokeOnCancellation] function is a [Waiter] implementation,
+     * which requires knowing the `segment` and the `index` in it
      * that specify the location of the stored iterator.
      *
      * To resume the suspended [hasNext] call, a special [tryResumeHasNext]

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -162,7 +162,7 @@ import kotlin.coroutines.*
  * ### Reactive streams
  *
  * Flow is [Reactive Streams](http://www.reactive-streams.org/) compliant, you can safely interop it with
- * reactive streams using [Flow.asPublisher] and [Publisher.asFlow] from `kotlinx-coroutines-reactive` module.
+ * reactive streams using `Flow.asPublisher` and `Publisher.asFlow` from `kotlinx-coroutines-reactive` module.
  *
  * ### Not stable for inheritance
  *
@@ -198,7 +198,7 @@ public interface Flow<out T> {
  * Base class for stateful implementations of `Flow`.
  * It tracks all the properties required for context preservation and throws an [IllegalStateException]
  * if any of the properties are violated.
- * 
+ *
  * Example of the implementation:
  *
  * ```

--- a/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt
+++ b/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt
@@ -117,8 +117,8 @@ internal abstract class DispatchedTask<in T> internal constructor(
      *    They usually have specific workarounds, but require careful study of the cause and should
      *    be reported to the maintainers and fixed on the library's side anyway.
      *
-     * 2) Exceptions from [ThreadContextElement.updateThreadContext] and [ThreadContextElement.restoreThreadContext].
-     *    While a user code can trigger such exception by providing an improper implementation of [ThreadContextElement],
+     * 2) Exceptions from `ThreadContextElement.updateThreadContext` and `ThreadContextElement.restoreThreadContext`.
+     *    While a user code can trigger such exception by providing an improper implementation of `ThreadContextElement`,
      *    we can't ignore it because it may leave coroutine in the inconsistent state.
      *    If you encounter such exception, you can either disable this context element or wrap it into
      *    another context element that catches all exceptions and handles it in the application specific manner.

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -416,7 +416,7 @@ internal open class SelectImplementation<R>(
      *
      * Unfortunately, we cannot store the result in the [state] field, as the latter stores
      * the clause object upon selection (see [ClauseData.clauseObject] and [SelectClause.clauseObject]).
-     * Instead, it is possible to merge the [internalResult] and [disposableHandle] fields into
+     * Instead, it is possible to merge the [internalResult] and [disposableHandleOrSegment] fields into
      * one that stores either result when the clause is successfully registered ([inRegistrationPhase] is `true`),
      * or [DisposableHandle] instance when the clause is completed during registration ([inRegistrationPhase] is `false`).
      * Yet, this optimization is omitted for code simplicity.

--- a/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.*
  *
  * For this operation it is guaranteed that [failure][ChannelResult.failed] always contains an exception in it.
  *
- * @throws `InterruptedException` on JVM if the current thread is interrupted during the blocking send operation.
+ * @throws InterruptedException on JVM if the current thread is interrupted during the blocking send operation.
  */
 public fun <E> SendChannel<E>.trySendBlocking(element: E): ChannelResult<Unit> {
     /*

--- a/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
+++ b/kotlinx-coroutines-core/concurrent/src/channels/Channels.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.*
  *
  * For this operation it is guaranteed that [failure][ChannelResult.failed] always contains an exception in it.
  *
- * @throws InterruptedException on JVM if the current thread is interrupted during the blocking send operation.
+ * Throws `InterruptedException` on JVM if the current thread is interrupted during the blocking send operation.
  */
 public fun <E> SendChannel<E>.trySendBlocking(element: E): ChannelResult<Unit> {
     /*

--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -19,7 +19,7 @@ private typealias Node = LockFreeLinkedListNode
  * Important notes:
  * - There are no operations to add items to left side of the list, only to the end (right side), because we cannot
  *   efficiently linearize them with atomic multi-step head-removal operations. In short,
- *   support for `TODO no such function` operation precludes ability to add items at the beginning.
+ *   support for the [remove] operation precludes ability to add items at the beginning.
  * - Previous pointers are not marked for removal. We don't support linearizable backwards traversal.
  * - Remove-helping logic is simplified and consolidated in [correctPrev] method.
  *

--- a/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/LockFreeLinkedList.kt
@@ -19,7 +19,7 @@ private typealias Node = LockFreeLinkedListNode
  * Important notes:
  * - There are no operations to add items to left side of the list, only to the end (right side), because we cannot
  *   efficiently linearize them with atomic multi-step head-removal operations. In short,
- *   support for [describeRemoveFirst] operation precludes ability to add items at the beginning.
+ *   support for `TODO no such function` operation precludes ability to add items at the beginning.
  * - Previous pointers are not marked for removal. We don't support linearizable backwards traversal.
  * - Remove-helping logic is simplified and consolidated in [correctPrev] method.
  *

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
@@ -24,7 +24,7 @@ internal class DebugCoroutineInfoImpl internal constructor(
     @JvmField public val sequenceNumber: Long
 ) {
     /**
-     * We cannot keep a strong reference to the context, because with the [Job] in the context it will indirectly
+     * We cannot keep a strong reference to the context, because with the [kotlinx.coroutines.Job] in the context it will indirectly
      * keep a reference to the last frame of an abandoned coroutine which the debugger should not be preventing
      * garbage-collection of. The reference to context will not disappear as long as the coroutine itself is not lost.
      */
@@ -145,7 +145,7 @@ internal class DebugCoroutineInfoImpl internal constructor(
 
     /**
      * Last observed stacktrace of the coroutine captured on its suspension or resumption point.
-     * It means that for [running][State.RUNNING] coroutines resulting stacktrace is inaccurate and
+     * It means that for [running][RUNNING] coroutines resulting stacktrace is inaccurate and
      * reflects stacktrace of the resumption point, not the actual current stacktrace.
      */
     internal fun lastObservedStackTrace(): List<StackTraceElement> {

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugCoroutineInfoImpl.kt
@@ -1,5 +1,6 @@
 package kotlinx.coroutines.debug.internal
 
+import kotlinx.coroutines.*
 import java.lang.ref.*
 import kotlin.coroutines.*
 import kotlin.coroutines.jvm.internal.*
@@ -24,7 +25,7 @@ internal class DebugCoroutineInfoImpl internal constructor(
     @JvmField public val sequenceNumber: Long
 ) {
     /**
-     * We cannot keep a strong reference to the context, because with the [kotlinx.coroutines.Job] in the context it will indirectly
+     * We cannot keep a strong reference to the context, because with the [Job] in the context it will indirectly
      * keep a reference to the last frame of an abandoned coroutine which the debugger should not be preventing
      * garbage-collection of. The reference to context will not disappear as long as the coroutine itself is not lost.
      */

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -86,7 +86,7 @@ import kotlin.math.*
  *
  * The scheduler does not limit the count of pending blocking tasks, potentially creating up to [maxPoolSize] threads.
  * End users do not have access to the scheduler directly and can dispatch blocking tasks only with
- * [LimitingDispatcher] that does control concurrency level by its own mechanism.
+ * [LimitedDispatcher] that does control concurrency level by its own mechanism.
  */
 @Suppress("NOTHING_TO_INLINE")
 internal class CoroutineScheduler(

--- a/kotlinx-coroutines-core/jvm/test/scheduling/BlockingCoroutineDispatcherLivenessStressTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/BlockingCoroutineDispatcherLivenessStressTest.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.*
 import kotlin.test.*
 
 /**
- * Test that ensures implementation correctness of [LimitingDispatcher] and
+ * Test that ensures implementation correctness of [kotlinx.coroutines.internal.LimitedDispatcher] and
  * designed to stress its particular implementation details.
  */
 class BlockingCoroutineDispatcherLivenessStressTest : SchedulerTestBase() {

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -97,7 +97,7 @@ abstract class SchedulerTestBase : TestBase() {
 
 /**
  * Implementation note:
- * Our [Dispatcher.IO] is a [limitedParallelism][CoroutineDispatcher.limitedParallelism] dispatcher
+ * Our [Dispatchers.IO] is a [limitedParallelism][CoroutineDispatcher.limitedParallelism] dispatcher
  * on top of unbounded scheduler. We want to test this scenario, but on top of non-singleton
  * scheduler so we can control the number of threads, thus this method.
  */

--- a/kotlinx-coroutines-debug/src/junit/junit5/CoroutinesTimeoutExtension.kt
+++ b/kotlinx-coroutines-debug/src/junit/junit5/CoroutinesTimeoutExtension.kt
@@ -3,6 +3,7 @@ package kotlinx.coroutines.debug.junit5
 import kotlinx.coroutines.debug.*
 import kotlinx.coroutines.debug.runWithTimeoutDumpingCoroutines
 import org.junit.jupiter.api.extension.*
+import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.platform.commons.support.AnnotationSupport
 import java.lang.reflect.*
 import java.util.*

--- a/reactive/kotlinx-coroutines-rx2/src/RxAwait.kt
+++ b/reactive/kotlinx-coroutines-rx2/src/RxAwait.kt
@@ -110,7 +110,7 @@ public suspend fun <T> MaybeSource<T>.await(): T? = awaitSingleOrNull()
  *
  * ### Deprecation
  *
- * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of [MaybeSource.await] for
+ * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of `MaybeSource.await` for
  * details).
  * @suppress
  */

--- a/reactive/kotlinx-coroutines-rx3/src/RxAwait.kt
+++ b/reactive/kotlinx-coroutines-rx3/src/RxAwait.kt
@@ -92,7 +92,7 @@ public suspend fun <T> MaybeSource<T & Any>.await(): T? = awaitSingleOrNull()
  *
  * ### Deprecation
  *
- * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of [MaybeSource.await] for
+ * Deprecated in favor of [awaitSingleOrNull] for naming consistency (see the deprecation of `MaybeSource.await` for
  * details).
  *
  * @suppress


### PR DESCRIPTION
_Based on the work related to https://github.com/Kotlin/dokka/pull/4479 where I tried to enable `failOnWarning=true` for all kotlinx projects._

The unresolved link fixes are split into different categories (and so commits):
- https://github.com/Kotlin/kotlinx.coroutines/commit/4a8a20c8870261f7293e0bf952a12fa061c416b6: accidentally unresolved
- https://github.com/Kotlin/kotlinx.coroutines/commit/741fe194807b69f214b8b4041833e86e41eb70b8: links to not accessible declarations, includes:
    - functions from modules, not from dependencies like `Flow.asPublisher` and `Publisher.asFlow` in the `core` module.
    - declarations from more platform-specific source sets, e.g., `Dispatchers.IO` or `ServiceLoader` in `commonMain`.
- https://github.com/Kotlin/kotlinx.coroutines/commit/998e916693624d6a6fd599aad998d284c7f21f0b: links to `HIDDEN` declarations
    - Note: this is unresolved only with the new KDoc links resolution.
- https://github.com/Kotlin/kotlinx.coroutines/commit/830e8ee7ac9098efeb550920a104a14866a95be7: **most likely** accidentally unresolved
    - **But** I'm not sure if the replacement is correct, as it touches coroutines internals...
    - Also, I haven't found a replacement for `describeRemoveFirst`.
- https://github.com/Kotlin/kotlinx.coroutines/commit/c2b0583e777f15e305847a76190125584b1f64ef: There is no way to make this link resolvable at all, so I'm not sure what to do here. Current state:
    - `InterruptedException` will always be highlighted by IDEA in yellow (warning)
    - `InterruptedException` will always be reported as unresolved by Dokka, but still render as plain text there

There are still unresolved links present in `module-level` documentation, because `README.md` is used both as documentation inside the repo, as well as an input for Dokka module documentation:
- sometimes it contains links to [local files](https://github.com/Kotlin/kotlinx.coroutines/blob/bf9509da7a0eff08e489555254d9662f2cc1894f/ui/kotlinx-coroutines-android/README.md?plain=1#L18-L23), which could not be resolved by Dokka.
- Some files [heavily](https://github.com/Kotlin/kotlinx.coroutines/blob/74cf9ea8598a9ab1328faa52ddaea1bb977d4470/kotlinx-coroutines-core/common/README.md?plain=1#L93-L153) use `knit` ability to add links to the website. At the same time, Dokka does support the resolution, at least `FQN` links in module docs, and even some relative links like `launch`, but not all of them: [`[CoroutineDispatcher]`](https://github.com/Kotlin/kotlinx.coroutines/blob/74cf9ea8598a9ab1328faa52ddaea1bb977d4470/kotlinx-coroutines-core/common/README.md?plain=1#L14) is not resolved for some reason...

**Ideally**, the usage should be split into two distinct files: one for Dokka and, if needed, one for README, like it's done in kotlinx-io ([per-module](https://github.com/Kotlin/kotlinx-io/blob/c06a6016db01df8bea53273a51932a4f4edd1359/core/Module.md)) or in kotlinx-serialization ([per-whole-project](https://github.com/Kotlin/kotlinx.serialization/blob/c0cac7cd981a4712bbc974b5efb59573532f93c7/dokka/moduledoc.md)).


**Note**: all of those links are unresolved and reported by Dokka (`master`) and IDEA (26.1) with [new KDoc links resolution](https://github.com/Kotlin/dokka/issues/4425) based on [KEEP#0389](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0389-kdoc-streamline-ambiguous-KDoc-links.md). With Dokka 2.2.0-Beta, most of those links are also unresolved, where new resolution is **not** enabled yet.

---

Feel free to ask questions or let me know if you just don't agree with something here. I'm open to discussions on how to resolve this. :)