### PR TITLE
Update kotlinx-atomicfu version to 0.32.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group=org.jetbrains.kotlinx
 # ONLY rename these properties alongside adapting kotlinx.train build chain
 # and the `firstPartyDependencies` list in `buildSrc`.
 kotlin_version=2.2.20
-atomicfu_version=0.30.0-beta
+atomicfu_version=0.32.1
 
 # Dependencies
 benchmarks_version=0.4.13


### PR DESCRIPTION
AFU `0.32.1` addresses `SynchronizedObject`'s performance regression introduced in `0.30.0-beta` (see for details about the regression https://github.com/Kotlin/kotlinx-atomicfu/issues/584).