### PR TITLE
Prevent R8 from removing the job GC anchor in ReadonlySharedFlow/ReadonlyStateFlow

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -69,6 +69,7 @@ allprojects {
         if (!kotlinRepoUrl.isNullOrBlank()) {
             maven(kotlinRepoUrl)
         }
+        google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
@@ -244,7 +245,8 @@ tasks {
             ":jpmsTest:check",
             "smokeTest:build",
             "java8Test:check",
-            "safeDebugAgentTest:attachAgentWithoutKotlinStdlib"
+            "safeDebugAgentTest:attachAgentWithoutKotlinStdlib",
+            "r8Test:testGcAnchor"
         )
     }
 

--- a/integration-testing/r8Test/build.gradle.kts
+++ b/integration-testing/r8Test/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     "r8"("com.android.tools.build:builder:8.1.0")
 }
 
+// The R8 logic below was taken from `ui/kotlinx-coroutines-android/build.gradle.kts`
+
 val r8OutputDir = layout.buildDirectory.dir("r8out")
 
 val runR8 by tasks.registering(RunR8::class) {

--- a/integration-testing/r8Test/build.gradle.kts
+++ b/integration-testing/r8Test/build.gradle.kts
@@ -1,0 +1,71 @@
+plugins {
+    kotlin("jvm")
+}
+
+val coroutinesVersion = property("coroutines_version").toString()
+
+configurations {
+    create("r8")
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    "r8"("com.android.tools.build:builder:8.1.0")
+}
+
+val r8OutputDir = layout.buildDirectory.dir("r8out")
+
+val runR8 by tasks.registering(RunR8::class) {
+    outputDir = r8OutputDir.get().asFile
+    inputConfig = file("r8-rules.pro")
+
+    dependsOn("jar")
+}
+
+tasks.register("testGcAnchor") {
+    dependsOn(runR8)
+
+    doLast {
+        project.javaexec {
+            mainClass.set("GcAnchorKt")
+            classpath = files(r8OutputDir)
+        }
+    }
+}
+
+open class RunR8 : JavaExec() {
+
+    @OutputDirectory
+    lateinit var outputDir: File
+
+    @InputFile
+    lateinit var inputConfig: File
+
+    @InputFiles
+    val jarFile: File = project.tasks.named<Zip>("jar").get().archiveFile.get().asFile
+
+    init {
+        classpath = project.configurations["r8"]
+        mainClass = "com.android.tools.r8.R8"
+    }
+
+    override fun exec() {
+        val arguments = mutableListOf(
+            "--classfile",
+            "--release",
+            "--no-minification", // avoid class name collisions on case-insensitive filesystems
+            "--pg-conf", inputConfig.absolutePath,
+            "--lib", System.getProperty("java.home"),
+            "--output", outputDir.absolutePath,
+        )
+        arguments.addAll(project.configurations["runtimeClasspath"].files.map { it.absolutePath })
+        arguments.add(jarFile.absolutePath)
+
+        args = arguments
+
+        project.delete(outputDir)
+        outputDir.mkdirs()
+
+        super.exec()
+    }
+}

--- a/integration-testing/r8Test/r8-rules.pro
+++ b/integration-testing/r8Test/r8-rules.pro
@@ -1,0 +1,2 @@
+# App entry point
+-keep class GcAnchorKt { *; }

--- a/integration-testing/r8Test/src/main/kotlin/GcAnchor.kt
+++ b/integration-testing/r8Test/src/main/kotlin/GcAnchor.kt
@@ -1,0 +1,44 @@
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.*
+import java.lang.ref.WeakReference
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verifies that R8 doesn't strip the GC anchor (`job` field) from ReadonlyStateFlow.
+ *
+ * The test uses a callbackFlow where a separate coroutine emits values through a WeakReference.
+ * If the sharing coroutine is collected by GC (because R8 removed the anchor), the callbackFlow
+ * is cancelled, the weak reference is cleared, and emissions stop.
+ */
+val shared = callbackFlow {
+    val emitter = Runnable { trySend(Unit) }
+    val weak = WeakReference(emitter)
+    CoroutineScope(EmptyCoroutineContext).launch {
+        while (true) {
+            weak.get()?.run() ?: break
+            delay(1.seconds)
+        }
+    }
+    awaitClose { emitter.run() } // strong ref to emitter prevents GC before close
+}.runningFold(0) { count, _ ->
+    count + 1
+}.stateIn(
+    scope = CoroutineScope(EmptyCoroutineContext),
+    started = SharingStarted.Eagerly,
+    initialValue = 0
+)
+
+fun main(): Unit = runBlocking {
+    delay(100.milliseconds)
+    repeat(5) {
+        System.gc()
+        delay(1.seconds)
+    }
+    val lastValue = shared.value
+    check(lastValue >= 5) {
+        "Expected the sharing coroutine to survive GC (at least 5 emissions), but the last emitted value was $lastValue"
+    }
+}

--- a/integration-testing/r8Test/src/main/kotlin/GcAnchor.kt
+++ b/integration-testing/r8Test/src/main/kotlin/GcAnchor.kt
@@ -2,43 +2,30 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
 import java.lang.ref.WeakReference
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
+import kotlin.coroutines.ContinuationInterceptor
 
 /**
  * Verifies that R8 doesn't strip the GC anchor (`job` field) from ReadonlyStateFlow.
  *
- * The test uses a callbackFlow where a separate coroutine emits values through a WeakReference.
- * If the sharing coroutine is collected by GC (because R8 removed the anchor), the callbackFlow
- * is cancelled, the weak reference is cleared, and emissions stop.
+ * If the sharing coroutine is collected by GC (because R8 removed the anchor),
+ * the channelFlow coroutine gets dropped, together with the WeakReference.
  */
-val shared = callbackFlow {
-    val emitter = Runnable { trySend(Unit) }
-    val weak = WeakReference(emitter)
-    CoroutineScope(EmptyCoroutineContext).launch {
-        while (true) {
-            weak.get()?.run() ?: break
-            delay(1.seconds)
-        }
-    }
-    awaitClose { emitter.run() } // strong ref to emitter prevents GC before close
-}.runningFold(0) { count, _ ->
-    count + 1
-}.stateIn(
-    scope = CoroutineScope(EmptyCoroutineContext),
-    started = SharingStarted.Eagerly,
-    initialValue = 0
-)
-
+@OptIn(DelicateCoroutinesApi::class)
 fun main(): Unit = runBlocking {
-    delay(100.milliseconds)
-    repeat(5) {
-        System.gc()
-        delay(1.seconds)
-    }
-    val lastValue = shared.value
-    check(lastValue >= 5) {
-        "Expected the sharing coroutine to survive GC (at least 5 emissions), but the last emitted value was $lastValue"
-    }
+    val latch = Channel<Unit>(1)
+    lateinit var weak: WeakReference<() -> Unit>
+    val shared = channelFlow {
+        val emitter: () -> Unit = { trySend(Unit) }
+        weak = WeakReference(emitter)
+        latch.trySend(Unit)
+        awaitClose { emitter() } // strong ref to emitter prevents GC before close
+    }.stateIn(
+        scope = GlobalScope + currentCoroutineContext()[ContinuationInterceptor]!!,
+        started = SharingStarted.Eagerly,
+        initialValue = Unit
+    )
+    latch.receive() // the weak reference got initialized by this point
+    System.gc()
+    check(weak.get() != null) { "The weak reference got collected but shouldn't have been." }
+    shared.value // a strong reference to `shared`
 }

--- a/integration-testing/settings.gradle.kts
+++ b/integration-testing/settings.gradle.kts
@@ -15,5 +15,6 @@ include("smokeTest")
 include("safeDebugAgentTest")
 include("java8Test")
 include(":jpmsTest")
+include("r8Test")
 
 rootProject.name = "kotlinx-coroutines-integration-testing"

--- a/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Share.kt
@@ -395,6 +395,7 @@ public fun <T> MutableSharedFlow<T>.asSharedFlow(): SharedFlow<T> =
 public fun <T> MutableStateFlow<T>.asStateFlow(): StateFlow<T> =
     ReadonlyStateFlow(this, null)
 
+// Note: referenced by name in bundled ProGuard/R8 rules.
 @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
 private class ReadonlySharedFlow<T>(
     flow: SharedFlow<T>,
@@ -405,6 +406,7 @@ private class ReadonlySharedFlow<T>(
         fuseSharedFlow(context, capacity, onBufferOverflow)
 }
 
+// Note: referenced by name in bundled ProGuard/R8 rules.
 @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
 private class ReadonlyStateFlow<T>(
     flow: StateFlow<T>,

--- a/kotlinx-coroutines-core/jvm/resources/META-INF/com.android.tools/proguard/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/com.android.tools/proguard/coroutines.pro
@@ -29,3 +29,11 @@
 
 # An annotation used for build tooling, won't be directly accessed.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Keep GC anchor fields that prevent the sharing coroutine from being collected.
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlySharedFlow {
+    kotlinx.coroutines.Job job;
+}
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlyStateFlow {
+    kotlinx.coroutines.Job job;
+}

--- a/kotlinx-coroutines-core/jvm/resources/META-INF/com.android.tools/r8/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/com.android.tools/r8/coroutines.pro
@@ -25,3 +25,11 @@
 
 # An annotation used for build tooling, won't be directly accessed.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Keep GC anchor fields that prevent the sharing coroutine from being collected.
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlySharedFlow {
+    kotlinx.coroutines.Job job;
+}
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlyStateFlow {
+    kotlinx.coroutines.Job job;
+}

--- a/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+++ b/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
@@ -29,3 +29,11 @@
 
 # An annotation used for build tooling, won't be directly accessed.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Keep GC anchor fields that prevent the sharing coroutine from being collected.
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlySharedFlow {
+    kotlinx.coroutines.Job job;
+}
+-keepclassmembers class kotlinx.coroutines.flow.ReadonlyStateFlow {
+    kotlinx.coroutines.Job job;
+}


### PR DESCRIPTION
Fixes #4646 

R8 full mode strips fields that are written but never read. The `job` field in `ReadonlySharedFlow` and `ReadonlyStateFlow` is a GC anchor keeping the sharing coroutine alive (added in the fix for #2557), but since it is only assigned and never read, R8 removes it, making the sharing coroutine eligible for collection.

This adds `-keepclassmembers` rules targeting the specific `job` field to all three bundled `.pro` files.

Verified with a standalone R8 Gradle JVM reproduction project available in the original issue.