### PR TITLE
Update composing-suspending-functions.md

### DIFF
--- a/docs/topics/composing-suspending-functions.md
+++ b/docs/topics/composing-suspending-functions.md
@@ -206,7 +206,7 @@ We name such functions with the
 to use the resulting deferred value to get the result.
 
 > [GlobalScope] is a delicate API that can backfire in non-trivial ways, one of which will be explained
-> below, so you must explicitly opt-in into using `GlobalScope` with `@OptIn(DelicateCoroutinesApi::class)`. 
+> below, so you must explicitly opt-in into using `GlobalScope`. 
 >
 {style="note"}
 


### PR DESCRIPTION
The deleted annotation is merely a technical requirement. It does not help to explain the conceptual danger of GlobalScope, so mentioning it distracts from the main point.

Sincerely,  
Maria Pomazkina  
LinkedIn: https://www.linkedin.com/in/maria-pomazkina-7972a2a3/