### PR TITLE
Prepare for `kotlin.coroutines.StackTraceRecoverable`

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstructor.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstructor.kt
@@ -28,6 +28,28 @@ internal fun <E : Throwable> tryCopyException(exception: E): E? {
 
 private fun <E : Throwable> createConstructor(clz: Class<E>): Ctor {
     val nullResult: Ctor = { null } // Pre-cache class
+    /* Prepare for the introduction of `StackTraceRecoverable` in the standard library.
+     * The exact interface to be added is still under discussion,
+     * but the name `StackTraceRecoverable#copyForStackTraceRecovery`,
+     * returning either `(E: Throwable)?` or `Throwable?` is already agreed on.
+     *
+     * To anyone reading this: don't try adding `copyForStackTraceRecovery` in your own code.
+     * This will work for now, but break later.
+     * Once `StackTraceRecoverable` enters the standard library,
+     * `kotlinx.coroutines` will move to using an `is StackTraceRecoverable`-check.
+     * This is the reason this behavior is left undocumented. */
+    try {
+        val copyForStackTraceRecovery = clz.getMethod("copyForStackTraceRecovery")
+        return { e ->
+            runCatching {
+                (copyForStackTraceRecovery.invoke(e) as Throwable?)
+            }.getOrNull()
+        }
+    } catch (_: NoSuchMethodException) {
+        // Expected: there simply was no implementation of `StackTraceRecoverable`
+    } catch (_: SecurityException) {
+        // Restrictive SecurityManager
+    }
     // Skip reflective copy if an exception has additional fields (that are typically populated in user-defined constructors)
     if (throwableFields != clz.fieldsCountOrDefault(0)) return nullResult
     /*

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryCopyableThrowableTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryCopyableThrowableTest.kt
@@ -4,15 +4,14 @@ import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
 import kotlin.test.*
 
-// Copied from StackTraceRecoveryCustomExceptionsTest
 @Suppress("UNREACHABLE_CODE", "UNUSED", "UNUSED_PARAMETER")
-class StackTraceRecoveryStdlibInterfaceTest : TestBase() {
+class StackTraceRecoveryCopyableThrowableTest : TestBase() {
 
-    internal class Copyable(val customData: Int) : Throwable(), StackTraceRecoverableWithNoTypeBounds {
+    internal class Copyable(val customData: Int) : Throwable(), CopyableThrowable<Copyable> {
         // Bait
         constructor(cause: Throwable) : this(42)
 
-        override fun copyForStackTraceRecovery(): Throwable {
+        override fun createCopy(): Copyable {
             val copy = Copyable(customData)
             copy.initCause(this)
             return copy
@@ -38,9 +37,9 @@ class StackTraceRecoveryStdlibInterfaceTest : TestBase() {
         message: String?,
         cause: Throwable? = null
     ) : RuntimeException(message, cause),
-        StackTraceRecoverableWithNoTypeBounds {
+        CopyableThrowable<CopyableWithCustomMessage> {
 
-        override fun copyForStackTraceRecovery(): Throwable {
+        override fun createCopy(): CopyableWithCustomMessage {
             return CopyableWithCustomMessage("Recovered: [$message]", cause)
         }
     }
@@ -59,8 +58,8 @@ class StackTraceRecoveryStdlibInterfaceTest : TestBase() {
 
     @Test
     fun testTryCopyThrows() = runTest {
-        class FailingException : Exception(), StackTraceRecoverableWithNoTypeBounds {
-            override fun copyForStackTraceRecovery(): Throwable? {
+        class FailingException : Exception(), CopyableThrowable<FailingException> {
+            override fun createCopy(): FailingException? {
                 TODO("Not yet implemented")
             }
         }
@@ -74,31 +73,4 @@ class StackTraceRecoveryStdlibInterfaceTest : TestBase() {
 
         assertSame(e, result.exceptionOrNull())
     }
-
-    @Test
-    fun testImplementationOverriding() = runTest {
-        open class FailingException(val data: String) : Exception(), StackTraceRecoverableWithNoTypeBounds {
-            override fun copyForStackTraceRecovery(): Throwable? {
-                return FailingException("This will not be invoked")
-            }
-        }
-        open class FailingExceptionChild(data: String): FailingException(data) {
-            override fun copyForStackTraceRecovery(): Throwable? {
-                return FailingExceptionChild("This will be the result")
-            }
-        }
-        class FailingExceptionGrandchild: FailingExceptionChild("Something")
-        val result = runCatching {
-            coroutineScope<Unit> {
-                throw FailingExceptionGrandchild()
-            }
-        }
-        val ex = result.exceptionOrNull() ?: error("Expected to fail")
-        assertIs<FailingExceptionChild>(ex)
-        assertEquals("This will be the result", ex.data)
-    }
-}
-
-private interface StackTraceRecoverableWithNoTypeBounds {
-    fun copyForStackTraceRecovery(): Throwable?
 }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryExceptionConstructorsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryExceptionConstructorsTest.kt
@@ -2,54 +2,24 @@ package kotlinx.coroutines.exceptions
 
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
-import org.junit.Test
+import kotlinx.coroutines.channels.produce
 import kotlin.test.*
 
-@Suppress("UNREACHABLE_CODE", "UNUSED", "UNUSED_PARAMETER")
-class StackTraceRecoveryCustomExceptionsTest : TestBase() {
-
+class StackTraceRecoveryExceptionConstructorsTest: TestBase() {
     internal class NonCopyable(val customData: Int) : Throwable() {
         // Bait
         constructor(cause: Throwable) : this(42)
     }
 
-    internal class Copyable(val customData: Int) : Throwable(), CopyableThrowable<Copyable> {
-        // Bait
-        constructor(cause: Throwable) : this(42)
-
-        override fun createCopy(): Copyable {
-            val copy = Copyable(customData)
-            copy.initCause(this)
-            return copy
-        }
-    }
-
     @Test
     fun testStackTraceNotRecovered() = runTest {
+        val exception = NonCopyable(239)
         try {
             withContext(wrapperDispatcher(coroutineContext)) {
-                throw NonCopyable(239)
+                throw exception
             }
-            expectUnreached()
         } catch (e: NonCopyable) {
-            assertEquals(239, e.customData)
-            assertNull(e.cause)
-        }
-    }
-
-    @Test
-    fun testStackTraceRecovered() = runTest {
-        try {
-            withContext(wrapperDispatcher(coroutineContext)) {
-                throw Copyable(239)
-            }
-            expectUnreached()
-        } catch (e: Copyable) {
-            assertEquals(239, e.customData)
-            val cause = e.cause
-            assertIs<Copyable>(cause)
-            assertEquals(239, cause.customData)
+            assertSame(exception, e)
         }
     }
 
@@ -61,7 +31,6 @@ class StackTraceRecoveryCustomExceptionsTest : TestBase() {
             withContext(wrapperDispatcher(coroutineContext)) {
                 throw WithDefault("custom")
             }
-            expectUnreached()
         } catch (e: WithDefault) {
             assertEquals("custom", e.message)
             val cause = e.cause
@@ -83,6 +52,7 @@ class StackTraceRecoveryCustomExceptionsTest : TestBase() {
         assertIs<WrongMessageException>(ex)
         assertEquals("Token OK", ex.message)
     }
+
 
     @Test
     fun testNestedExceptionWithCause() = runTest {
@@ -117,46 +87,5 @@ class StackTraceRecoveryCustomExceptionsTest : TestBase() {
         }.exceptionOrNull() ?: error("Expected to fail")
         assertIs<WrongMessageException>(ex)
         assertEquals("Token OK", ex.message)
-    }
-
-    class CopyableWithCustomMessage(
-        message: String?,
-        cause: Throwable? = null
-    ) : RuntimeException(message, cause),
-        CopyableThrowable<CopyableWithCustomMessage> {
-
-        override fun createCopy(): CopyableWithCustomMessage {
-            return CopyableWithCustomMessage("Recovered: [$message]", cause)
-        }
-    }
-
-    @Test
-    fun testCustomCopyableMessage() = runTest {
-        val result = runCatching {
-            coroutineScope<Unit> {
-                throw CopyableWithCustomMessage("OK")
-            }
-        }
-        val ex = result.exceptionOrNull() ?: error("Expected to fail")
-        assertIs<CopyableWithCustomMessage>(ex)
-        assertEquals("Recovered: [OK]", ex.message)
-    }
-
-    @Test
-    fun testTryCopyThrows() = runTest {
-        class FailingException : Exception(), CopyableThrowable<FailingException> {
-            override fun createCopy(): FailingException? {
-                TODO("Not yet implemented")
-            }
-        }
-
-        val e = FailingException()
-        val result = runCatching {
-            coroutineScope<Unit> {
-                throw e
-            }
-        }
-
-        assertSame(e, result.exceptionOrNull())
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceTest.kt
@@ -1,0 +1,189 @@
+package kotlinx.coroutines.exceptions
+
+import kotlinx.coroutines.testing.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+// Copied from StackTraceRecoveryCustomExceptionsTest
+@Suppress("UNREACHABLE_CODE", "UNUSED", "UNUSED_PARAMETER")
+class StackTraceRecoveryStdlibInterfaceTest : TestBase() {
+
+    internal class NonCopyable(val customData: Int) : Throwable() {
+        // Bait
+        constructor(cause: Throwable) : this(42)
+    }
+
+    internal class Copyable(val customData: Int) : Throwable(), StackTraceRecoverableWithNoTypeBounds {
+        // Bait
+        constructor(cause: Throwable) : this(42)
+
+        override fun copyForStackTraceRecovery(): Throwable {
+            val copy = Copyable(customData)
+            copy.initCause(this)
+            return copy
+        }
+    }
+
+    @Test
+    fun testStackTraceNotRecovered() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw NonCopyable(239)
+            }
+            expectUnreached()
+        } catch (e: NonCopyable) {
+            assertEquals(239, e.customData)
+            assertNull(e.cause)
+        }
+    }
+
+    @Test
+    fun testStackTraceRecovered() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw Copyable(239)
+            }
+            expectUnreached()
+        } catch (e: Copyable) {
+            assertEquals(239, e.customData)
+            val cause = e.cause
+            assertIs<Copyable>(cause)
+            assertEquals(239, cause.customData)
+        }
+    }
+
+    internal class WithDefault(message: String = "default") : Exception(message)
+
+    @Test
+    fun testStackTraceRecoveredWithCustomMessage() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw WithDefault("custom")
+            }
+            expectUnreached()
+        } catch (e: WithDefault) {
+            assertEquals("custom", e.message)
+            val cause = e.cause
+            assertIs<WithDefault>(cause)
+            assertEquals("custom", cause.message)
+        }
+    }
+
+    class WrongMessageException(token: String) : RuntimeException("Token $token")
+
+    @Test
+    fun testWrongMessageException() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw WrongMessageException("OK")
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<WrongMessageException>(ex)
+        assertEquals("Token OK", ex.message)
+    }
+
+    @Test
+    fun testNestedExceptionWithCause() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw NestedException(IllegalStateException("ERROR"))
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<NestedException>(ex)
+        assertIs<NestedException>(ex.cause)
+        val originalCause = ex.cause?.cause
+        assertIs<IllegalStateException>(originalCause)
+        assertEquals("ERROR", originalCause.message)
+    }
+
+    class NestedException : RuntimeException {
+        constructor(cause: Throwable) : super(cause)
+        constructor() : super()
+    }
+
+    @Test
+    fun testWrongMessageExceptionInChannel() = runTest {
+        val result = produce<Unit>(SupervisorJob() + Dispatchers.Unconfined) {
+            throw WrongMessageException("OK")
+        }
+        val ex = runCatching {
+            @Suppress("ControlFlowWithEmptyBody")
+            for (unit in result) {
+                // Iterator has a special code path
+            }
+        }.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<WrongMessageException>(ex)
+        assertEquals("Token OK", ex.message)
+    }
+
+    class CopyableWithCustomMessage(
+        message: String?,
+        cause: Throwable? = null
+    ) : RuntimeException(message, cause),
+        StackTraceRecoverableWithNoTypeBounds {
+
+        override fun copyForStackTraceRecovery(): Throwable {
+            return CopyableWithCustomMessage("Recovered: [$message]", cause)
+        }
+    }
+
+    @Test
+    fun testCustomCopyableMessage() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw CopyableWithCustomMessage("OK")
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<CopyableWithCustomMessage>(ex)
+        assertEquals("Recovered: [OK]", ex.message)
+    }
+
+    @Test
+    fun testTryCopyThrows() = runTest {
+        class FailingException : Exception(), StackTraceRecoverableWithNoTypeBounds {
+            override fun copyForStackTraceRecovery(): Throwable? {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val e = FailingException()
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw e
+            }
+        }
+
+        assertSame(e, result.exceptionOrNull())
+    }
+
+    @Test
+    fun testImplementationOverriding() = runTest {
+        open class FailingException(val data: String) : Exception(), StackTraceRecoverableWithNoTypeBounds {
+            override fun copyForStackTraceRecovery(): Throwable? {
+                return FailingException("This will not be invoked")
+            }
+        }
+        open class FailingExceptionChild(data: String): FailingException(data) {
+            override fun copyForStackTraceRecovery(): Throwable? {
+                return FailingExceptionChild("This will be the result")
+            }
+        }
+        class FailingExceptionGrandchild: FailingExceptionChild("Something")
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw FailingExceptionGrandchild()
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<FailingExceptionChild>(ex)
+        assertEquals("This will be the result", ex.data)
+    }
+}
+
+private interface StackTraceRecoverableWithNoTypeBounds {
+    fun copyForStackTraceRecovery(): Throwable?
+}

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest.kt
@@ -1,0 +1,193 @@
+package kotlinx.coroutines.exceptions
+
+import kotlinx.coroutines.testing.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlin.test.*
+
+// Copied from StackTraceRecoveryCustomExceptionsTest
+@Suppress("UNREACHABLE_CODE", "UNUSED", "UNUSED_PARAMETER")
+class StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest : TestBase() {
+
+    internal class NonCopyable(val customData: Int) : Throwable() {
+        // Bait
+        constructor(cause: Throwable) : this(42)
+    }
+
+    internal class Copyable(val customData: Int) : Throwable(), StackTraceRecoverableWithTypeBounds<Copyable> {
+        // Bait
+        constructor(cause: Throwable) : this(42)
+
+        override fun copyForStackTraceRecovery(): Copyable {
+            val copy = Copyable(customData)
+            copy.initCause(this)
+            return copy
+        }
+    }
+
+    @Test
+    fun testStackTraceNotRecovered() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw NonCopyable(239)
+            }
+            expectUnreached()
+        } catch (e: NonCopyable) {
+            assertEquals(239, e.customData)
+            assertNull(e.cause)
+        }
+    }
+
+    @Test
+    fun testStackTraceRecovered() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw Copyable(239)
+            }
+            expectUnreached()
+        } catch (e: Copyable) {
+            assertEquals(239, e.customData)
+            val cause = e.cause
+            assertIs<Copyable>(cause)
+            assertEquals(239, cause.customData)
+        }
+    }
+
+    internal class WithDefault(message: String = "default") : Exception(message)
+
+    @Test
+    fun testStackTraceRecoveredWithCustomMessage() = runTest {
+        try {
+            withContext(wrapperDispatcher(coroutineContext)) {
+                throw WithDefault("custom")
+            }
+            expectUnreached()
+        } catch (e: WithDefault) {
+            assertEquals("custom", e.message)
+            val cause = e.cause
+            assertIs<WithDefault>(cause)
+            assertEquals("custom", cause.message)
+        }
+    }
+
+    class WrongMessageException(token: String) : RuntimeException("Token $token")
+
+    @Test
+    fun testWrongMessageException() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw WrongMessageException("OK")
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<WrongMessageException>(ex)
+        assertEquals("Token OK", ex.message)
+    }
+
+    @Test
+    fun testNestedExceptionWithCause() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw NestedException(IllegalStateException("ERROR"))
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<NestedException>(ex)
+        assertIs<NestedException>(ex.cause)
+        val originalCause = ex.cause?.cause
+        assertIs<IllegalStateException>(originalCause)
+        assertEquals("ERROR", originalCause.message)
+    }
+
+    class NestedException : RuntimeException {
+        constructor(cause: Throwable) : super(cause)
+        constructor() : super()
+    }
+
+    @Test
+    fun testWrongMessageExceptionInChannel() = runTest {
+        val result = produce<Unit>(SupervisorJob() + Dispatchers.Unconfined) {
+            throw WrongMessageException("OK")
+        }
+        val ex = runCatching {
+            @Suppress("ControlFlowWithEmptyBody")
+            for (unit in result) {
+                // Iterator has a special code path
+            }
+        }.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<WrongMessageException>(ex)
+        assertEquals("Token OK", ex.message)
+    }
+
+    class CopyableWithCustomMessage(
+        message: String?,
+        cause: Throwable? = null
+    ) : RuntimeException(message, cause),
+        StackTraceRecoverableWithTypeBounds<CopyableWithCustomMessage> {
+
+        override fun copyForStackTraceRecovery(): CopyableWithCustomMessage {
+            return CopyableWithCustomMessage("Recovered: [$message]", cause)
+        }
+    }
+
+    @Test
+    fun testCustomCopyableMessage() = runTest {
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw CopyableWithCustomMessage("OK")
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<CopyableWithCustomMessage>(ex)
+        assertEquals("Recovered: [OK]", ex.message)
+    }
+
+    @Test
+    fun testTryCopyThrows() = runTest {
+        class FailingException : Exception(), StackTraceRecoverableWithTypeBounds<FailingException> {
+            override fun copyForStackTraceRecovery(): FailingException {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val e = FailingException()
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw e
+            }
+        }
+
+        assertSame(e, result.exceptionOrNull())
+    }
+
+    @Test
+    fun testImplementationOverriding() = runTest {
+        open class FailingException(
+            val data: String
+        ) : Exception(), StackTraceRecoverableWithTypeBounds<FailingException> {
+            override fun copyForStackTraceRecovery(): FailingException? {
+                return FailingException("This will not be invoked")
+            }
+        }
+        open class FailingExceptionChild(data: String): FailingException(data) {
+            override fun copyForStackTraceRecovery(): FailingExceptionChild? {
+                return FailingExceptionChild("This will be the result")
+            }
+        }
+        class FailingExceptionGrandchild: FailingExceptionChild("Something")
+        val result = runCatching {
+            coroutineScope<Unit> {
+                throw FailingExceptionGrandchild()
+            }
+        }
+        val ex = result.exceptionOrNull() ?: error("Expected to fail")
+        assertIs<FailingExceptionChild>(ex)
+        assertEquals("This will be the result", ex.data)
+    }
+}
+
+private interface StackTraceRecoverableWithTypeBounds<E>
+    where E : Throwable, E : StackTraceRecoverableWithTypeBounds<E>
+{
+    fun copyForStackTraceRecovery(): E?
+}

--- a/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/exceptions/StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest.kt
@@ -2,17 +2,11 @@ package kotlinx.coroutines.exceptions
 
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
 import kotlin.test.*
 
 // Copied from StackTraceRecoveryCustomExceptionsTest
 @Suppress("UNREACHABLE_CODE", "UNUSED", "UNUSED_PARAMETER")
 class StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest : TestBase() {
-
-    internal class NonCopyable(val customData: Int) : Throwable() {
-        // Bait
-        constructor(cause: Throwable) : this(42)
-    }
 
     internal class Copyable(val customData: Int) : Throwable(), StackTraceRecoverableWithTypeBounds<Copyable> {
         // Bait
@@ -22,19 +16,6 @@ class StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest : TestBase() {
             val copy = Copyable(customData)
             copy.initCause(this)
             return copy
-        }
-    }
-
-    @Test
-    fun testStackTraceNotRecovered() = runTest {
-        try {
-            withContext(wrapperDispatcher(coroutineContext)) {
-                throw NonCopyable(239)
-            }
-            expectUnreached()
-        } catch (e: NonCopyable) {
-            assertEquals(239, e.customData)
-            assertNull(e.cause)
         }
     }
 
@@ -51,72 +32,6 @@ class StackTraceRecoveryStdlibInterfaceWithTypeBoundsTest : TestBase() {
             assertIs<Copyable>(cause)
             assertEquals(239, cause.customData)
         }
-    }
-
-    internal class WithDefault(message: String = "default") : Exception(message)
-
-    @Test
-    fun testStackTraceRecoveredWithCustomMessage() = runTest {
-        try {
-            withContext(wrapperDispatcher(coroutineContext)) {
-                throw WithDefault("custom")
-            }
-            expectUnreached()
-        } catch (e: WithDefault) {
-            assertEquals("custom", e.message)
-            val cause = e.cause
-            assertIs<WithDefault>(cause)
-            assertEquals("custom", cause.message)
-        }
-    }
-
-    class WrongMessageException(token: String) : RuntimeException("Token $token")
-
-    @Test
-    fun testWrongMessageException() = runTest {
-        val result = runCatching {
-            coroutineScope<Unit> {
-                throw WrongMessageException("OK")
-            }
-        }
-        val ex = result.exceptionOrNull() ?: error("Expected to fail")
-        assertIs<WrongMessageException>(ex)
-        assertEquals("Token OK", ex.message)
-    }
-
-    @Test
-    fun testNestedExceptionWithCause() = runTest {
-        val result = runCatching {
-            coroutineScope<Unit> {
-                throw NestedException(IllegalStateException("ERROR"))
-            }
-        }
-        val ex = result.exceptionOrNull() ?: error("Expected to fail")
-        assertIs<NestedException>(ex)
-        assertIs<NestedException>(ex.cause)
-        val originalCause = ex.cause?.cause
-        assertIs<IllegalStateException>(originalCause)
-        assertEquals("ERROR", originalCause.message)
-    }
-
-    class NestedException : RuntimeException {
-        constructor(cause: Throwable) : super(cause)
-        constructor() : super()
-    }
-
-    @Test
-    fun testWrongMessageExceptionInChannel() = runTest {
-        val result = produce<Unit>(SupervisorJob() + Dispatchers.Unconfined) {
-            throw WrongMessageException("OK")
-        }
-        val ex = runCatching {
-            @Suppress("ControlFlowWithEmptyBody")
-            for (unit in result) {
-                // Iterator has a special code path
-            }
-        }.exceptionOrNull() ?: error("Expected to fail")
-        assertIs<WrongMessageException>(ex)
-        assertEquals("Token OK", ex.message)
     }
 
     class CopyableWithCustomMessage(


### PR DESCRIPTION
We would like to remove `kotlinx.coroutines.CopyableThrowable` in favor of an interface with the same functionality in the standard library. This way, libraries that expose exception classes will not have to depend on `kotlinx.coroutines` to provide stacktrace recovery support.

The likely migration procedure is:
- `kotlinx.coroutines` introduces a hidden code path that reflectively discovers the stdlib method. This is what this commit does. A `kotlinx.coroutines` release is published.
- An stdlib release includes `StackTraceRecoverable`. Any exception classes using `StackTraceRecoverable` will immediately receive stacktrace recovery support.
- A `kotlinx.coroutines` release that switches to the Kotlin version with `StackTraceRecoverable` removes the hidden code path and replaces it by an `is`-check. The same release deprecates `CopyableThrowable` with a warning.
- After the stdlib stabilizes `StackTraceRecoverable`, `CopyableThrowable` is deprecated with an error and eventually removed.

It is slightly concerning that as this PR is written, `CopyableThrowable` takes priority over `StackTraceRecoverable` if both interfaces are implemented. I expect this to be okay, because the semantics of the two interfaces are exactly the same, and their implementations should be equivalent as well. Making priorities the opposite would introduce a slight performance degradation for `CopyableThrowable` implementations and complicate the code.