### PR TITLE
Restore Promise-related functions on Wasm/JS as HIDDEN

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
@@ -1295,7 +1295,19 @@ final fun <#A: kotlin.js/JsAny?> (kotlinx.coroutines/CoroutineScope).kotlinx.cor
 final fun <#A: kotlin.js/JsAny?> (kotlinx.coroutines/Deferred<#A>).kotlinx.coroutines/asPromise(): kotlin.js/Promise<#A> // kotlinx.coroutines/asPromise|asPromise@kotlinx.coroutines.Deferred<0:0>(){0§<kotlin.js.JsAny?>}[0]
 
 // Targets: [wasmJs]
+final fun <#A: kotlin/Any?> (kotlin.js/Promise<kotlin.js/JsAny?>).kotlinx.coroutines/asDeferred(): kotlinx.coroutines/Deferred<#A> // kotlinx.coroutines/asDeferred|asDeferred@kotlin.js.Promise<kotlin.js.JsAny?>(){0§<kotlin.Any?>}[0]
+
+// Targets: [wasmJs]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines/CoroutineScope).kotlinx.coroutines/promise(kotlin.coroutines/CoroutineContext = ..., kotlinx.coroutines/CoroutineStart = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A>): kotlin.js/Promise<kotlin.js/JsAny?> // kotlinx.coroutines/promise|promise@kotlinx.coroutines.CoroutineScope(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.CoroutineStart;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
+
+// Targets: [wasmJs]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines/Deferred<#A>).kotlinx.coroutines/asPromise(): kotlin.js/Promise<kotlin.js/JsAny?> // kotlinx.coroutines/asPromise|asPromise@kotlinx.coroutines.Deferred<0:0>(){0§<kotlin.Any?>}[0]
+
+// Targets: [wasmJs]
 final suspend fun <#A: kotlin.js/JsAny?> (kotlin.js/Promise<#A>).kotlinx.coroutines/await(): #A // kotlinx.coroutines/await|await@kotlin.js.Promise<0:0>(){0§<kotlin.js.JsAny?>}[0]
+
+// Targets: [wasmJs]
+final suspend fun <#A: kotlin/Any?> (kotlin.js/Promise<kotlin.js/JsAny?>).kotlinx.coroutines/await(): #A // kotlinx.coroutines/await|await@kotlin.js.Promise<kotlin.js.JsAny?>(){0§<kotlin.Any?>}[0]
 
 // Targets: [wasmWasi]
 final fun kotlinx.coroutines.internal/runTestCoroutine(kotlin.coroutines/CoroutineContext, kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, kotlin/Unit>) // kotlinx.coroutines.internal/runTestCoroutine|runTestCoroutine(kotlin.coroutines.CoroutineContext;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,kotlin.Unit>){}[0]

--- a/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
+++ b/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
@@ -1,4 +1,8 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
 package kotlinx.coroutines
+
+import kotlin.coroutines.*
+import kotlin.js.*
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal actual fun JsPromiseError.toThrowable(): Throwable = try {
@@ -9,3 +13,61 @@ internal actual fun JsPromiseError.toThrowable(): Throwable = try {
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal actual fun Throwable.toJsPromiseError(): JsPromiseError = toJsReference()
+
+/*
+ * All code after this line is preserved for compatibility with versions 1.10.2 and below.
+ */
+
+@Suppress("UNUSED_PARAMETER")
+private fun promiseSetDeferred(promise: Promise<JsAny?>, deferred: JsAny): Unit =
+    js("promise.deferred = deferred")
+
+@Suppress("UNUSED_PARAMETER")
+private fun promiseGetDeferred(promise: Promise<JsAny?>): JsAny? = js("""{
+    console.assert(promise instanceof Promise, "promiseGetDeferred must receive a promise, but got ", promise);
+    return promise.deferred == null ? null : promise.deferred;
+}""")
+
+@Deprecated("Moved to the 'web' source set", level = DeprecationLevel.HIDDEN)
+public fun <T> CoroutineScope.promise(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> T
+): Promise<JsAny?> =
+    async(context, start, block).oldAsPromiseImpl()
+
+@Deprecated("Moved to the 'web' source set", level = DeprecationLevel.HIDDEN)
+public fun <T> Deferred<T>.asPromise(): Promise<JsAny?> = oldAsPromiseImpl()
+
+private fun <T> Deferred<T>.oldAsPromiseImpl(): Promise<JsAny?> {
+    val promise = Promise<JsAny?> { resolve, reject ->
+        invokeOnCompletion {
+            val e = getCompletionExceptionOrNull()
+            if (e != null) {
+                reject(e.toJsReference())
+            } else {
+                resolve(getCompleted()?.toJsReference())
+            }
+        }
+    }
+    promiseSetDeferred(promise, this.toJsReference())
+    return promise
+}
+
+@Deprecated("Moved to the 'web' source set", level = DeprecationLevel.HIDDEN)
+@Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE", "UNCHECKED_CAST")
+public fun <T> Promise<JsAny?>.asDeferred(): Deferred<T> {
+    val deferred = promiseGetDeferred(this) as? JsReference<Deferred<T>>
+    return deferred?.get() ?: GlobalScope.async(start = CoroutineStart.UNDISPATCHED) { oldAwaitImpl() }
+}
+
+@Deprecated("Moved to the 'web' source set", level = DeprecationLevel.HIDDEN)
+public suspend fun <T> Promise<JsAny?>.await(): T = oldAwaitImpl()
+
+@Suppress("UNCHECKED_CAST")
+private suspend fun <T> Promise<JsAny?>.oldAwaitImpl(): T = suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
+    this@oldAwaitImpl.then(
+        onFulfilled = { cont.resume(it as T); null },
+        onRejected = { cont.resumeWithException(it.toThrowableOrNull() ?: error("Unexpected non-Kotlin exception $it")); null }
+    )
+}


### PR DESCRIPTION
`1.11.0-rc01` broke binary compatibility with Compose on Wasm/JS in b872360a0d322654e8b89972aef26668245f2bbe. Compose is using APIs related to the experimental `Promise`.

This PR restores the binary compatibility by re-introducing the removed functions with `DeprecationLevel.HIDDEN`, meaning you can't write code that will call them, but binaries already compiled with such calls will work.

To reproduce the problem,
1. Checkout https://github.com/terrakok/mobicon/commit/bb8fdaae751f46a81f6b1c6c28b3f203b0ff29fa
2. Set `kotlinx-coroutines = "1.11.0-rc01"` in `gradle/libs.versions.toml`
3. Run `./gradlew wJBDR`
4. In the *browser window*, there should be error messages.

To validate the fix,
1. Publish the code in this PR to the local Maven repository with `./gradlew clean publishToMavenLocal`.
2. In the `mobicon` project, add `mavenLocal()` to line 30 of `settings.gradle.kts` (in the `dependencyResolutionManagement { repositories {` block).
3. In the `mobicon` project, set `kotlinx-coroutines = "1.11.0-rc01-SNAPSHOT"` in `gradle/libs.versions.toml`.
4. Run `./gradlew wJBDR`
5. In the browser window, the application should run with no errors.