### PR TITLE
Make `Dispatchers.Main` access fail fast

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -1364,18 +1364,6 @@ public final class kotlinx/coroutines/internal/MainDispatcherFactory$DefaultImpl
 	public static fun hintOnError (Lkotlinx/coroutines/internal/MainDispatcherFactory;)Ljava/lang/String;
 }
 
-public final class kotlinx/coroutines/internal/MainDispatchersKt {
-	public static final fun isMissing (Lkotlinx/coroutines/MainCoroutineDispatcher;)Z
-	public static final fun tryCreateDispatcher (Lkotlinx/coroutines/internal/MainDispatcherFactory;Ljava/util/List;)Lkotlinx/coroutines/MainCoroutineDispatcher;
-}
-
-public final class kotlinx/coroutines/internal/MissingMainCoroutineDispatcherFactory : kotlinx/coroutines/internal/MainDispatcherFactory {
-	public static final field INSTANCE Lkotlinx/coroutines/internal/MissingMainCoroutineDispatcherFactory;
-	public fun createDispatcher (Ljava/util/List;)Lkotlinx/coroutines/MainCoroutineDispatcher;
-	public fun getLoadPriority ()I
-	public fun hintOnError ()Ljava/lang/String;
-}
-
 public final class kotlinx/coroutines/internal/StackTraceRecoveryKt {
 	public static final fun unwrap (Ljava/lang/Throwable;)Ljava/lang/Throwable;
 	public static final fun unwrapImpl (Ljava/lang/Throwable;)Ljava/lang/Throwable;

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
@@ -790,6 +790,9 @@ final object kotlinx.coroutines/Dispatchers { // kotlinx.coroutines/Dispatchers|
         final fun <get-Unconfined>(): kotlinx.coroutines/CoroutineDispatcher // kotlinx.coroutines/Dispatchers.Unconfined.<get-Unconfined>|<get-Unconfined>(){}[0]
 
     final fun injectMain(kotlinx.coroutines/MainCoroutineDispatcher) // kotlinx.coroutines/Dispatchers.injectMain|injectMain(kotlinx.coroutines.MainCoroutineDispatcher){}[0]
+
+    // Targets: [native]
+    final fun mainDispatcherOrNull(): kotlinx.coroutines/MainCoroutineDispatcher? // kotlinx.coroutines/Dispatchers.mainDispatcherOrNull|mainDispatcherOrNull(){}[0]
 }
 
 final object kotlinx.coroutines/GlobalScope : kotlinx.coroutines/CoroutineScope { // kotlinx.coroutines/GlobalScope|null[0]

--- a/kotlinx-coroutines-core/apple/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/apple/src/Dispatchers.kt
@@ -11,7 +11,7 @@ import kotlin.native.internal.NativePtr
 
 internal fun isMainThread(): Boolean = CFRunLoopGetCurrent() == CFRunLoopGetMain()
 
-internal actual fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher = DarwinMainDispatcher(false)
+internal actual fun createMainDispatcherOrNull(): MainCoroutineDispatcher? = DarwinMainDispatcher(false)
 
 internal actual fun createDefaultDispatcher(): CoroutineDispatcher = DarwinGlobalQueueDispatcher
 
@@ -28,7 +28,7 @@ private object DarwinGlobalQueueDispatcher : CoroutineDispatcher() {
 private class DarwinMainDispatcher(
     private val invokeImmediately: Boolean
 ) : MainCoroutineDispatcher(), Delay {
-    
+
     override val immediate: MainCoroutineDispatcher =
         if (invokeImmediately) this else DarwinMainDispatcher(true)
 
@@ -41,7 +41,7 @@ private class DarwinMainDispatcher(
             }
         }
     }
-    
+
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         val timer = Timer()
         val timerBlock: TimerBlock = {

--- a/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
+++ b/kotlinx-coroutines-core/common/src/Dispatchers.common.kt
@@ -20,7 +20,8 @@ public expect object Dispatchers {
      * A coroutine dispatcher that is confined to the Main thread operating with UI objects.
      * Usually such dispatchers are single-threaded.
      *
-     * Access to this property may throw an [IllegalStateException] if no main dispatchers are present in the classpath.
+     * Access to this property throws an [IllegalStateException] if no main dispatchers are present in the classpath
+     * or if loading the main dispatcher fails.
      *
      * Depending on platform and classpath, it can be mapped to different dispatchers:
      * - On JVM it is either the Android main thread dispatcher, JavaFx, or Swing EDT dispatcher. It is chosen by the

--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -68,10 +68,11 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
             return null
         }
         if (this === main) return "Dispatchers.Main"
-        val immediate =
-            try { main.immediate }
-            catch (e: UnsupportedOperationException) { null }
-        if (this === immediate) return "Dispatchers.Main.immediate"
-        return null
+        val immediate = try {
+            main.immediate
+        } catch (_: Throwable) {
+            return null
+        }
+        return if (this === immediate) "Dispatchers.Main.immediate" else null
     }
 }

--- a/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/MainCoroutineDispatcher.kt
@@ -62,7 +62,11 @@ public abstract class MainCoroutineDispatcher : CoroutineDispatcher() {
      */
     @InternalCoroutinesApi
     protected fun toStringInternalImpl(): String? {
-        val main = Dispatchers.Main
+        val main = try {
+            Dispatchers.Main
+        } catch (_: Throwable) {
+            return null
+        }
         if (this === main) return "Dispatchers.Main"
         val immediate =
             try { main.immediate }

--- a/kotlinx-coroutines-core/common/test/MainCoroutineDispatcherTest.kt
+++ b/kotlinx-coroutines-core/common/test/MainCoroutineDispatcherTest.kt
@@ -1,0 +1,19 @@
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.testing.*
+import kotlin.test.*
+
+class MainCoroutineDispatcherTest: TestBase() {
+    @Test
+    fun testToStringNotFailingIfMainDispatcherIsMissing() {
+        val myDispatcher = object: MainCoroutineDispatcher() {
+            override val immediate get() = TODO()
+
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                TODO()
+            }
+        }
+        myDispatcher.toString()
+    }
+}

--- a/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
+++ b/kotlinx-coroutines-core/jvm/src/DefaultExecutor.kt
@@ -9,16 +9,21 @@ private val defaultMainDelayOptIn = systemProp("kotlinx.coroutines.main.delay", 
 @PublishedApi
 internal actual val DefaultDelay: Delay = initializeDefaultDelay()
 
+/*
+ * When we already are working with UI and Main threads, it makes
+ * no sense to create a separate thread with timer that cannot be controlled
+ * by the UI runtime.
+ */
 private fun initializeDefaultDelay(): Delay {
     // Opt-out flag
     if (!defaultMainDelayOptIn) return DefaultExecutor
-    val main = Dispatchers.Main
     /*
-     * When we already are working with UI and Main threads, it makes
-     * no sense to create a separate thread with timer that cannot be controller
-     * by the UI runtime.
+     * Do not throw here: this code accesses the `Main` dispatcher only implicitly,
+     * probably inside a `delay` call.
+     * Any program that uses this code path is bound to access `Dispatchers.Main` at some point explicitly anyway
+     * and will observe the failure there.
      */
-    return if (main.isMissing() || main !is Delay) DefaultExecutor else main
+    return MainDispatcherLoader.dispatcherLoadResult.dispatcherOrNull as? Delay ?: DefaultExecutor
 }
 
 @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")

--- a/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/Dispatchers.kt
@@ -16,7 +16,12 @@ public actual object Dispatchers {
     public actual val Default: CoroutineDispatcher = DefaultScheduler
 
     @JvmStatic
-    public actual val Main: MainCoroutineDispatcher get() = MainDispatcherLoader.dispatcher
+    public actual val Main: MainCoroutineDispatcher get() = with(MainDispatcherLoader.dispatcherLoadResult) {
+        dispatcherOrNull ?: throw IllegalStateException(
+            failureMessageOrNull ?: "Failed to load Dispatchers.Main",
+            failureCauseOrNull
+        )
+    }
 
     @JvmStatic
     public actual val Unconfined: CoroutineDispatcher = kotlinx.coroutines.Unconfined

--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -2,7 +2,6 @@ package kotlinx.coroutines.internal
 
 import kotlinx.coroutines.*
 import java.util.*
-import kotlin.coroutines.*
 
 /**
  * Name of the boolean property that enables using of [FastServiceLoader].
@@ -15,115 +14,56 @@ internal object MainDispatcherLoader {
     private val FAST_SERVICE_LOADER_ENABLED = systemProp(FAST_SERVICE_LOADER_PROPERTY_NAME, true)
 
     @JvmField
-    val dispatcher: MainCoroutineDispatcher = loadMainDispatcher()
+    val dispatcherLoadResult = loadMainDispatcher()
 
-    private fun loadMainDispatcher(): MainCoroutineDispatcher {
-        return try {
-            val factories = if (FAST_SERVICE_LOADER_ENABLED) {
+    private fun loadMainDispatcher(): MainDispatcherLoadResult {
+        val factories: List<MainDispatcherFactory>
+        val preferredFactory = try {
+            factories = if (FAST_SERVICE_LOADER_ENABLED) {
                 FastServiceLoader.loadMainDispatcherFactory()
             } else {
                 // We are explicitly using the
                 // `ServiceLoader.load(MyClass::class.java, MyClass::class.java.classLoader).iterator()`
                 // form of the ServiceLoader call to enable R8 optimization when compiled on Android.
                 ServiceLoader.load(
-                        MainDispatcherFactory::class.java,
-                        MainDispatcherFactory::class.java.classLoader
+                    MainDispatcherFactory::class.java,
+                    MainDispatcherFactory::class.java.classLoader
                 ).iterator().asSequence().toList()
             }
-            @Suppress("ConstantConditionIf")
-            factories.maxByOrNull { it.loadPriority }?.tryCreateDispatcher(factories)
-                ?: createMissingDispatcher()
+            /* Since `loadPriority` is also user-supplied and can fail, we have to keep it in this `try`. */
+            factories.maxByOrNull { it.loadPriority }
         } catch (e: Throwable) {
-            // Service loader can throw an exception as well
-            createMissingDispatcher(e)
+            // Service loading failed for some internal, unpredictable reason.
+            // The best we can do is to propagate the exception, mentioning broadly that it's Dispatchers.Main-related.
+            return MainDispatcherLoadResult(null, null, e)
         }
+        if (preferredFactory == null) {
+            return MainDispatcherLoadResult(
+                null,
+                "Module with the Main dispatcher is missing. " +
+                "Add a dependency providing the Main dispatcher, such as 'kotlinx-coroutines-android' " +
+                "and ensure it has the same version as 'kotlinx-coroutines-core'",
+                null
+            )
+        }
+        val dispatcher = try {
+            preferredFactory.createDispatcher(factories)
+        } catch (cause: Throwable) {
+            val message = buildString {
+                append("Module with the Main dispatcher failed to initialize")
+                preferredFactory.hintOnError()?.let {
+                    append(". ")
+                    append(it)
+                }
+            }
+            return MainDispatcherLoadResult(null, message, cause)
+        }
+        return MainDispatcherLoadResult(dispatcher, null, null)
     }
 }
 
-/**
- * If anything goes wrong while trying to create main dispatcher (class not found,
- * initialization failed, etc), then replace the main dispatcher with a special
- * stub that throws an error message on any attempt to actually use it.
- *
- * @suppress internal API
- */
-@InternalCoroutinesApi
-public fun MainDispatcherFactory.tryCreateDispatcher(factories: List<MainDispatcherFactory>): MainCoroutineDispatcher =
-    try {
-        createDispatcher(factories)
-    } catch (cause: Throwable) {
-        createMissingDispatcher(cause, hintOnError())
-    }
-
-/** @suppress */
-@InternalCoroutinesApi
-public fun MainCoroutineDispatcher.isMissing(): Boolean =
-    // not checking `this`, as it may be wrapped in a `TestMainDispatcher`, whereas `immediate` never is.
-    this.immediate is MissingMainCoroutineDispatcher
-
-// R8 optimization hook, not const on purpose to enable R8 optimizations via "assumenosideeffects"
-@Suppress("MayBeConstant")
-private val SUPPORT_MISSING = true
-
-@Suppress(
-    "ConstantConditionIf",
-    "IMPLICIT_NOTHING_TYPE_ARGUMENT_AGAINST_NOT_NOTHING_EXPECTED_TYPE" // KT-47626
+internal class MainDispatcherLoadResult(
+    val dispatcherOrNull: MainCoroutineDispatcher?,
+    val failureMessageOrNull: String?,
+    val failureCauseOrNull: Throwable?
 )
-private fun createMissingDispatcher(cause: Throwable? = null, errorHint: String? = null) =
-    if (SUPPORT_MISSING) MissingMainCoroutineDispatcher(cause, errorHint) else
-        cause?.let { throw it } ?: throwMissingMainDispatcherException()
-
-internal fun throwMissingMainDispatcherException(): Nothing {
-    throw IllegalStateException(
-        "Module with the Main dispatcher is missing. " +
-            "Add dependency providing the Main dispatcher, e.g. 'kotlinx-coroutines-android' " +
-            "and ensure it has the same version as 'kotlinx-coroutines-core'"
-    )
-}
-
-private class MissingMainCoroutineDispatcher(
-    private val cause: Throwable?,
-    private val errorHint: String? = null
-) : MainCoroutineDispatcher(), Delay {
-
-    override val immediate: MainCoroutineDispatcher get() = this
-
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean =
-        missing()
-
-    override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher =
-        missing()
-
-    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle =
-        missing()
-
-    override fun dispatch(context: CoroutineContext, block: Runnable) =
-        missing()
-
-    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) =
-        missing()
-
-    private fun missing(): Nothing {
-        if  (cause == null) {
-            throwMissingMainDispatcherException()
-        } else {
-            val message = "Module with the Main dispatcher had failed to initialize" + (errorHint?.let { ". $it" } ?: "")
-            throw IllegalStateException(message, cause)
-        }
-    }
-
-    override fun toString(): String = "Dispatchers.Main[missing${if (cause != null) ", cause=$cause" else ""}]"
-}
-
-/**
- * @suppress
- */
-@InternalCoroutinesApi
-public object MissingMainCoroutineDispatcherFactory : MainDispatcherFactory {
-    override val loadPriority: Int
-        get() = -1
-
-    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
-        return MissingMainCoroutineDispatcher(null)
-    }
-}

--- a/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/MainDispatchers.kt
@@ -63,7 +63,7 @@ internal object MainDispatcherLoader {
 }
 
 internal class MainDispatcherLoadResult(
-    val dispatcherOrNull: MainCoroutineDispatcher?,
-    val failureMessageOrNull: String?,
-    val failureCauseOrNull: Throwable?
+    @JvmField val dispatcherOrNull: MainCoroutineDispatcher?,
+    @JvmField val failureMessageOrNull: String?,
+    @JvmField val failureCauseOrNull: Throwable?
 )

--- a/kotlinx-coroutines-core/jvm/test/DispatcherKeyTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/DispatcherKeyTest.kt
@@ -23,10 +23,10 @@ class DispatcherKeyTest : TestBase() {
         assertNull(context[CoroutineDispatcher])
         assertSame(CustomInterceptor, context[ContinuationInterceptor])
 
-        val updated = context + Dispatchers.Main
+        val updated = context + Dispatchers.Default
         val result: CoroutineDispatcher? = updated[CoroutineDispatcher]
-        assertSame(Dispatchers.Main, result)
-        assertSame(Dispatchers.Main, updated[ContinuationInterceptor])
+        assertSame(Dispatchers.Default, result)
+        assertSame(Dispatchers.Default, updated[ContinuationInterceptor])
         assertEquals(name, updated.minusKey(CoroutineDispatcher))
         assertEquals(name, updated.minusKey(ContinuationInterceptor))
     }
@@ -35,7 +35,7 @@ class DispatcherKeyTest : TestBase() {
     fun testExecutorCoroutineDispatcher() {
         val context = name + CustomInterceptor
         assertNull(context[ExecutorCoroutineDispatcher])
-        val updated = context + Dispatchers.Main
+        val updated = context + Dispatchers.Unconfined
         assertNull(updated[ExecutorCoroutineDispatcher])
         val executor = Dispatchers.Default
         val updated2 = updated + executor

--- a/kotlinx-coroutines-core/jvm/test/DispatchersToStringTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/DispatchersToStringTest.kt
@@ -11,8 +11,6 @@ class DispatchersToStringTest {
         assertEquals("Dispatchers.Unconfined", Dispatchers.Unconfined.toString())
         assertEquals("Dispatchers.Default", Dispatchers.Default.toString())
         assertEquals("Dispatchers.IO", Dispatchers.IO.toString())
-        assertEquals("Dispatchers.Main[missing]", Dispatchers.Main.toString())
-        assertEquals("Dispatchers.Main[missing]", Dispatchers.Main.immediate.toString())
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
@@ -5,10 +5,8 @@ package kotlinx.coroutines
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import org.junit.*
-import org.junit.Test
+import org.junit.Rule
 import org.junit.rules.*
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
@@ -21,71 +19,71 @@ class FailFastOnStartTest : TestBase() {
     @JvmField
     val timeout: Timeout = Timeout.seconds(5)
 
-    @Test
-    fun testLaunch() = runTest(expected = ::mainException) {
-        launch(Dispatchers.Main) {}
+    val brokenDispatcher = newSingleThreadContext("BrokenDispatcher").also {
+        it.close() // immediately close it so that it can't be used
     }
 
     @Test
-    fun testLaunchLazy() = runTest(expected = ::mainException) {
-        val job = launch(Dispatchers.Main, start = CoroutineStart.LAZY) { fail() }
+    fun testLaunch() = runTest(expected = ::isRejectedExecutionException) {
+        launch(brokenDispatcher) {}
+    }
+
+    @Test
+    fun testLaunchLazy() = runTest(expected = ::isRejectedExecutionException) {
+        val job = launch(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         job.join()
     }
 
     @Test
-    fun testLaunchUndispatched() = runTest(expected = ::mainException) {
-        launch(Dispatchers.Main, start = CoroutineStart.UNDISPATCHED) {
+    fun testLaunchUndispatched() = runTest(expected = ::isRejectedExecutionException) {
+        launch(brokenDispatcher, start = CoroutineStart.UNDISPATCHED) {
             yield()
             fail()
         }
     }
 
     @Test
-    fun testAsync() = runTest(expected = ::mainException) {
-        async(Dispatchers.Main) {}
+    fun testAsync() = runTest(expected = ::isRejectedExecutionException) {
+        async(brokenDispatcher) {}
     }
 
     @Test
-    fun testAsyncLazy() = runTest(expected = ::mainException) {
-        val job = async(Dispatchers.Main, start = CoroutineStart.LAZY) { fail() }
+    fun testAsyncLazy() = runTest(expected = ::isRejectedExecutionException) {
+        val job = async(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         job.await()
     }
 
     @Test
-    fun testWithContext() = runTest(expected = ::mainException) {
-        withContext(Dispatchers.Main) {
+    fun testWithContext() = runTest(expected = ::isRejectedExecutionException) {
+        withContext(brokenDispatcher) {
             fail()
         }
     }
 
     @Test
-    fun testProduce() = runTest(expected = ::mainException) {
-        produce<Int>(Dispatchers.Main) { fail() }
+    fun testProduce() = runTest(expected = ::isRejectedExecutionException) {
+        produce<Int>(brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testActor() = runTest(expected = ::mainException) {
-        actor<Int>(Dispatchers.Main) { fail() }
+    fun testActor() = runTest(expected = ::isRejectedExecutionException) {
+        actor<Int>(brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testActorLazy() = runTest(expected = ::mainException) {
-        val actor = actor<Int>(Dispatchers.Main, start = CoroutineStart.LAZY) { fail() }
+    fun testActorLazy() = runTest(expected = ::isRejectedExecutionException) {
+        val actor = actor<Int>(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         actor.send(1)
     }
 
-    private fun mainException(e: Throwable): Boolean {
-        return e is IllegalStateException && e.message?.contains("Module with the Main dispatcher is missing") ?: false
+    @Test
+    fun testProduceNonChild() = runTest(expected = ::isRejectedExecutionException) {
+        produce<Int>(Job() + brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testProduceNonChild() = runTest(expected = ::mainException) {
-        produce<Int>(Job() + Dispatchers.Main) { fail() }
-    }
-
-    @Test
-    fun testAsyncNonChild() = runTest(expected = ::mainException) {
-        async<Int>(Job() + Dispatchers.Main) { fail() }
+    fun testAsyncNonChild() = runTest(expected = ::isRejectedExecutionException) {
+        async<Int>(Job() + brokenDispatcher) { fail() }
     }
 
     @Test
@@ -96,9 +94,9 @@ class FailFastOnStartTest : TestBase() {
         expect(1)
         val caller = suspend {
             try {
-                emptyFlow<Int>().flowOn(Dispatchers.Main).collect { fail() }
+                emptyFlow<Int>().flowOn(brokenDispatcher).collect { fail() }
             } catch (e: Throwable) {
-                assertTrue(mainException(e))
+                assertTrue(isRejectedExecutionException(e))
                 expect(2)
             }
         }
@@ -107,4 +105,7 @@ class FailFastOnStartTest : TestBase() {
             finish(3)
         })
     }
+
+    private fun isRejectedExecutionException(e: Throwable): Boolean =
+        e is java.util.concurrent.RejectedExecutionException
 }

--- a/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
@@ -2,7 +2,6 @@
 
 package kotlinx.coroutines
 
-import java.util.concurrent.RejectedExecutionException
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.emptyFlow
@@ -11,6 +10,7 @@ import org.junit.Rule
 import org.junit.rules.*
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
 import kotlin.test.*
 
@@ -20,23 +20,25 @@ class FailFastOnStartTest : TestBase() {
     @JvmField
     val timeout: Timeout = Timeout.seconds(5)
 
-    val brokenDispatcher = newSingleThreadContext("BrokenDispatcher").also {
-        it.close() // immediately close it so that it can't be used
+    val brokenDispatcher = object: CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            throw TestException("Dispatcher refuses to execute code")
+        }
     }
 
     @Test
-    fun testLaunch() = runTest(expected = ::isRejectedExecutionException) {
+    fun testLaunch() = runTest(expected = ::isTestException) {
         launch(brokenDispatcher) {}
     }
 
     @Test
-    fun testLaunchLazy() = runTest(expected = ::isRejectedExecutionException) {
+    fun testLaunchLazy() = runTest(expected = ::isTestException) {
         val job = launch(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         job.join()
     }
 
     @Test
-    fun testLaunchUndispatched() = runTest(expected = ::isRejectedExecutionException) {
+    fun testLaunchUndispatched() = runTest(expected = ::isTestException) {
         launch(brokenDispatcher, start = CoroutineStart.UNDISPATCHED) {
             yield()
             fail()
@@ -44,46 +46,46 @@ class FailFastOnStartTest : TestBase() {
     }
 
     @Test
-    fun testAsync() = runTest(expected = ::isRejectedExecutionException) {
+    fun testAsync() = runTest(expected = ::isTestException) {
         async(brokenDispatcher) {}
     }
 
     @Test
-    fun testAsyncLazy() = runTest(expected = ::isRejectedExecutionException) {
+    fun testAsyncLazy() = runTest(expected = ::isTestException) {
         val job = async(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         job.await()
     }
 
     @Test
-    fun testWithContext() = runTest(expected = ::isRejectedExecutionException) {
+    fun testWithContext() = runTest(expected = ::isTestException) {
         withContext(brokenDispatcher) {
             fail()
         }
     }
 
     @Test
-    fun testProduce() = runTest(expected = ::isRejectedExecutionException) {
+    fun testProduce() = runTest(expected = ::isTestException) {
         produce<Int>(brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testActor() = runTest(expected = ::isRejectedExecutionException) {
+    fun testActor() = runTest(expected = ::isTestException) {
         actor<Int>(brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testActorLazy() = runTest(expected = ::isRejectedExecutionException) {
+    fun testActorLazy() = runTest(expected = ::isTestException) {
         val actor = actor<Int>(brokenDispatcher, start = CoroutineStart.LAZY) { fail() }
         actor.send(1)
     }
 
     @Test
-    fun testProduceNonChild() = runTest(expected = ::isRejectedExecutionException) {
+    fun testProduceNonChild() = runTest(expected = ::isTestException) {
         produce<Int>(Job() + brokenDispatcher) { fail() }
     }
 
     @Test
-    fun testAsyncNonChild() = runTest(expected = ::isRejectedExecutionException) {
+    fun testAsyncNonChild() = runTest(expected = ::isTestException) {
         async<Int>(Job() + brokenDispatcher) { fail() }
     }
 
@@ -97,7 +99,7 @@ class FailFastOnStartTest : TestBase() {
             try {
                 emptyFlow<Int>().flowOn(brokenDispatcher).collect { fail() }
             } catch (e: Throwable) {
-                assertTrue(isRejectedExecutionException(e))
+                assertTrue(isTestException(e))
                 expect(2)
             }
         }
@@ -107,6 +109,6 @@ class FailFastOnStartTest : TestBase() {
         })
     }
 
-    private fun isRejectedExecutionException(e: Throwable): Boolean =
-        e is RejectedExecutionException
+    private fun isTestException(e: Throwable): Boolean =
+        e is TestException
 }

--- a/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
@@ -2,6 +2,7 @@
 
 package kotlinx.coroutines
 
+import java.util.concurrent.RejectedExecutionException
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.emptyFlow
@@ -107,5 +108,5 @@ class FailFastOnStartTest : TestBase() {
     }
 
     private fun isRejectedExecutionException(e: Throwable): Boolean =
-        e is java.util.concurrent.RejectedExecutionException
+        e is RejectedExecutionException
 }

--- a/kotlinx-coroutines-core/jvm/test/MissingMainDispatcherTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/MissingMainDispatcherTest.kt
@@ -1,0 +1,43 @@
+package kotlinx.coroutines
+
+import kotlinx.coroutines.testing.TestBase
+import kotlin.test.*
+
+class MissingMainDispatcherTest : TestBase() {
+
+    /**
+     * Tests that a missing [Dispatchers.Main] throws an exception.
+     *
+     * In `kotlinx-coroutines-core`, there is no [Dispatchers.Main] dispatcher by default.
+     */
+    @Test
+    fun testMissingMainDispatcher() {
+        assertFailsWith<IllegalStateException> { Dispatchers.Main }
+    }
+
+    /**
+     * Tests that several independent exceptions are created with relevant stack traces
+     * for different [Dispatchers.Main] calls.
+     */
+    @Test
+    fun testMissingMainDispatcherExceptionStackTrace() {
+        val fooException = assertFailsWith<IllegalStateException> { foo() }
+        val barException = assertFailsWith<IllegalStateException> { bar() }
+        fooException.stackTraceToString().let {
+            assertTrue(it.contains("foo"))
+            assertFalse(it.contains("bar"))
+        }
+        barException.stackTraceToString().let {
+            assertFalse(it.contains("foo"))
+            assertTrue(it.contains("bar"))
+        }
+    }
+
+    private fun foo() {
+        Dispatchers.Main
+    }
+
+    private fun bar() {
+        Dispatchers.Main
+    }
+}

--- a/kotlinx-coroutines-core/native/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/native/src/Dispatchers.kt
@@ -1,16 +1,19 @@
 package kotlinx.coroutines
 
-import kotlinx.coroutines.internal.*
 import kotlin.coroutines.*
 
 
 public actual object Dispatchers {
     public actual val Default: CoroutineDispatcher = createDefaultDispatcher()
+
     public actual val Main: MainCoroutineDispatcher
-        get() = injectedMainDispatcher ?: mainDispatcher
+        get() = injectedMainDispatcher
+            ?: mainDispatcherOrNull
+            ?: error("Dispatchers.Main is not supported on this platform")
+
     public actual val Unconfined: CoroutineDispatcher get() = kotlinx.coroutines.Unconfined // Avoid freezing
 
-    private val mainDispatcher = createMainDispatcher(Default)
+    private val mainDispatcherOrNull = createMainDispatcherOrNull()
 
     private var injectedMainDispatcher: MainCoroutineDispatcher? = null
 
@@ -18,6 +21,10 @@ public actual object Dispatchers {
     internal fun injectMain(dispatcher: MainCoroutineDispatcher) {
         injectedMainDispatcher = dispatcher
     }
+
+    @PublishedApi
+    internal fun mainDispatcherOrNull(): MainCoroutineDispatcher? =
+        injectedMainDispatcher ?: mainDispatcherOrNull
 
     internal val IO: CoroutineDispatcher = DefaultIoScheduler
 }
@@ -48,4 +55,4 @@ internal object DefaultIoScheduler : CoroutineDispatcher() {
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 public actual val Dispatchers.IO: CoroutineDispatcher get() = IO
 
-internal expect fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher
+internal expect fun createMainDispatcherOrNull(): MainCoroutineDispatcher?

--- a/kotlinx-coroutines-core/nativeOther/src/Dispatchers.kt
+++ b/kotlinx-coroutines-core/nativeOther/src/Dispatchers.kt
@@ -3,8 +3,7 @@ package kotlinx.coroutines
 import kotlin.coroutines.*
 import kotlin.native.*
 
-internal actual fun createMainDispatcher(default: CoroutineDispatcher): MainCoroutineDispatcher =
-    MissingMainDispatcher
+internal actual fun createMainDispatcherOrNull(): MainCoroutineDispatcher? = null
 
 internal actual fun createDefaultDispatcher(): CoroutineDispatcher = DefaultDispatcher
 
@@ -15,16 +14,6 @@ private object DefaultDispatcher : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         ctx.dispatch(context, block)
     }
-}
-
-private object MissingMainDispatcher : MainCoroutineDispatcher() {
-    override val immediate: MainCoroutineDispatcher
-        get() = notImplemented()
-    override fun dispatch(context: CoroutineContext, block: Runnable) = notImplemented()
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean = notImplemented()
-    override fun dispatchYield(context: CoroutineContext, block: Runnable) = notImplemented()
-
-    private fun notImplemented(): Nothing = TODO("Dispatchers.Main is missing on the current platform")
 }
 
 internal actual inline fun platformAutoreleasePool(crossinline block: () -> Unit) = block()

--- a/kotlinx-coroutines-test/common/src/TestDispatchers.kt
+++ b/kotlinx-coroutines-test/common/src/TestDispatchers.kt
@@ -18,7 +18,7 @@ import kotlin.jvm.*
 @ExperimentalCoroutinesApi
 public fun Dispatchers.setMain(dispatcher: CoroutineDispatcher) {
     require(dispatcher !is TestMainDispatcher) { "Dispatchers.setMain(Dispatchers.Main) is prohibited, probably Dispatchers.resetMain() should be used instead" }
-    getTestMainDispatcher().setDispatcher(dispatcher)
+    getOrInstallTestMainDispatcher().setDispatcher(dispatcher)
 }
 
 /**
@@ -31,5 +31,5 @@ public fun Dispatchers.setMain(dispatcher: CoroutineDispatcher) {
  */
 @ExperimentalCoroutinesApi
 public fun Dispatchers.resetMain() {
-    getTestMainDispatcher().resetDispatcher()
+    getOrInstallTestMainDispatcher().resetDispatcher()
 }

--- a/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
@@ -15,11 +15,16 @@ internal class TestMainDispatcher(createInnerMain: () -> CoroutineDispatcher):
 {
     internal constructor(delegate: CoroutineDispatcher): this({ delegate })
 
-    private val mainDispatcher by lazy(createInnerMain)
+    private val mainDispatcher: Result<CoroutineDispatcher> by lazy {
+        runCatching {
+            createInnerMain()
+        }
+    }
+
     private var delegate = NonConcurrentlyModifiable<CoroutineDispatcher?>(null, "Dispatchers.Main")
 
     private val dispatcher
-        get() = delegate.value ?: mainDispatcher
+        get() = delegate.value ?: mainDispatcher.getOrThrow()
 
     private val delay
         get() = dispatcher as? Delay ?: defaultDelay
@@ -49,7 +54,7 @@ internal class TestMainDispatcher(createInnerMain: () -> CoroutineDispatcher):
 
     companion object {
         internal val currentTestDispatcher
-            get() = (Dispatchers.Main as? TestMainDispatcher)?.delegate?.value as? TestDispatcher
+            get() = Dispatchers.getTestMainDispatcherOrNull()?.delegate?.value as? TestDispatcher
 
         internal val currentTestScheduler
             get() = currentTestDispatcher?.scheduler
@@ -96,5 +101,7 @@ internal class TestMainDispatcher(createInnerMain: () -> CoroutineDispatcher):
 private val defaultDelay
     inline get() = DefaultDelay
 
-@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // do not remove the INVISIBLE_REFERENCE suppression: required in K2
-internal expect fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher
+internal expect fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher
+
+// Is not allowed to throw exceptions, even if the `Main` dispatcher failed to initialize!
+internal expect fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher?

--- a/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/common/src/internal/TestMainDispatcher.kt
@@ -9,10 +9,9 @@ import kotlin.coroutines.*
  * The testable main dispatcher used by kotlinx-coroutines-test.
  * It is a [MainCoroutineDispatcher] that delegates all actions to a settable delegate.
  */
-internal class TestMainDispatcher(createInnerMain: () -> CoroutineDispatcher):
-    MainCoroutineDispatcher(),
-    Delay
-{
+internal class TestMainDispatcher(
+    createInnerMain: () -> CoroutineDispatcher
+): MainCoroutineDispatcher(), Delay {
     internal constructor(delegate: CoroutineDispatcher): this({ delegate })
 
     private val mainDispatcher: Result<CoroutineDispatcher> by lazy {

--- a/kotlinx-coroutines-test/js/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/js/src/internal/TestMainDispatcher.kt
@@ -2,8 +2,11 @@ package kotlinx.coroutines.test.internal
 import kotlinx.coroutines.*
 
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // do not remove the INVISIBLE_REFERENCE suppression: required in K2
-internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher =
+internal actual fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher =
     when (val mainDispatcher = Main) {
         is TestMainDispatcher -> mainDispatcher
         else -> TestMainDispatcher(mainDispatcher).also { injectMain(it) }
     }
+
+internal actual fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher? =
+    Main as? TestMainDispatcher

--- a/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
+++ b/kotlinx-coroutines-test/jvm/src/internal/TestMainDispatcherJvm.kt
@@ -5,27 +5,21 @@ import kotlinx.coroutines.internal.*
 
 internal class TestMainDispatcherFactory : MainDispatcherFactory {
 
-    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
-        val otherFactories = allFactories.filter { it !== this }
-        val secondBestFactory = otherFactories.maxByOrNull { it.loadPriority } ?: MissingMainCoroutineDispatcherFactory
-        /* Do not immediately create the alternative dispatcher, as with `SUPPORT_MISSING` set to `false`,
-        it will throw an exception. Instead, create it lazily. */
-        return TestMainDispatcher({
-            val dispatcher = try {
-                secondBestFactory.tryCreateDispatcher(otherFactories)
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher =
+        TestMainDispatcher(createInnerMain = {
+            /* Trying to allocate a non-test `Dispatchers.Main` may fail:
+               for example, `kotlinx-coroutines-android`'s implementation requires the Android runtime.
+               So, we won't even attempt to construct the alternative dispatcher until it's necessary. */
+            try {
+                val otherFactories = allFactories.filter { it !== this }
+                val secondBestFactory = otherFactories.maxByOrNull { it.loadPriority }
+                secondBestFactory?.createDispatcher(otherFactories)
             } catch (e: Throwable) {
+                /** Ignoring [MainDispatcherFactory.hintOnError] because the only implementation right now suggests
+                 * using `kotlinx-coroutines-test`, so the hint is useless in this scenario. */
                 reportMissingMainCoroutineDispatcher(e)
-            }
-            if (dispatcher.isMissing()) {
-                reportMissingMainCoroutineDispatcher(runCatching {
-                    // attempt to dispatch something to the missing dispatcher to trigger the exception.
-                    dispatcher.dispatch(dispatcher, Runnable { })
-                }.exceptionOrNull()) // can not be null, but it does not matter.
-            } else {
-                dispatcher
-            }
+            } ?: reportMissingMainCoroutineDispatcher()
         })
-    }
 
     /**
      * [Int.MAX_VALUE] -- test dispatcher always wins no matter what factories are present in the classpath.
@@ -35,10 +29,32 @@ internal class TestMainDispatcherFactory : MainDispatcherFactory {
         get() = Int.MAX_VALUE
 }
 
-internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher {
-    val mainDispatcher = Main
-    require(mainDispatcher is TestMainDispatcher) { "TestMainDispatcher is not set as main dispatcher, have $mainDispatcher instead." }
+internal actual fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher {
+    val mainDispatcher = try {
+        Main
+    } catch (e: IllegalStateException) {
+        /**
+         * This can happen if [Main] is some other Main dispatcher with a higher priority
+         * or if the [TestMainDispatcherFactory] wasn't discovered by [java.util.ServiceLoader].
+         * We do not have any first-party Main dispatchers with a higher priority than the test one,
+         * and we do not support them, so this exception assumes the second scenario.
+         */
+        throw IllegalStateException(
+            "Failed to install a `kotlinx.coroutines.test` Main dispatcher as Dispatchers.Main", e
+        )
+    }
+    check(mainDispatcher is TestMainDispatcher) { "TestMainDispatcher is not set as main dispatcher, have $mainDispatcher instead." }
     return mainDispatcher
+}
+
+internal actual fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher? = try {
+    Main as? TestMainDispatcher
+} catch (_: IllegalStateException) {
+    /**
+     * This may happen in one case only: [TestMainDispatcher] was not successfully installed as the Main dispatcher.
+     * Then, the current Main dispatcher isn't a [TestMainDispatcher], so we have to return `null`.
+     */
+    null
 }
 
 private fun reportMissingMainCoroutineDispatcher(e: Throwable? = null): Nothing {

--- a/kotlinx-coroutines-test/native/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/native/src/internal/TestMainDispatcher.kt
@@ -2,8 +2,17 @@ package kotlinx.coroutines.test.internal
 import kotlinx.coroutines.*
 
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // do not remove the INVISIBLE_REFERENCE suppression: required in K2
-internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher =
-    when (val mainDispatcher = Main) {
+internal actual fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher =
+    when (val mainDispatcher = mainDispatcherOrNull()) {
         is TestMainDispatcher -> mainDispatcher
+        null -> TestMainDispatcher(createInnerMain = {
+            // Duplicates the fallback from the `Dispatchers.Main` implementation on Native.
+            // Probably not yet worth introducing a new API for a clearer separation of concerns at this point.
+            error("Dispatchers.Main is not supported on this platform")
+        }).also { injectMain(it) }
         else -> TestMainDispatcher(mainDispatcher).also { injectMain(it) }
     }
+
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // do not remove the INVISIBLE_REFERENCE suppression: required in K2
+internal actual fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher? =
+    mainDispatcherOrNull() as? TestMainDispatcher

--- a/kotlinx-coroutines-test/wasmJs/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/wasmJs/src/internal/TestMainDispatcher.kt
@@ -2,8 +2,11 @@ package kotlinx.coroutines.test.internal
 import kotlinx.coroutines.*
 
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
-internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher =
+internal actual fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher =
     when (val mainDispatcher = Main) {
         is TestMainDispatcher -> mainDispatcher
         else -> TestMainDispatcher(mainDispatcher).also { injectMain(it) }
     }
+
+internal actual fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher? =
+    Main as? TestMainDispatcher

--- a/kotlinx-coroutines-test/wasmWasi/src/internal/TestMainDispatcher.kt
+++ b/kotlinx-coroutines-test/wasmWasi/src/internal/TestMainDispatcher.kt
@@ -2,8 +2,11 @@ package kotlinx.coroutines.test.internal
 import kotlinx.coroutines.*
 
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
-internal actual fun Dispatchers.getTestMainDispatcher(): TestMainDispatcher =
+internal actual fun Dispatchers.getOrInstallTestMainDispatcher(): TestMainDispatcher =
     when (val mainDispatcher = Main) {
         is TestMainDispatcher -> mainDispatcher
         else -> TestMainDispatcher(mainDispatcher).also { injectMain(it) }
     }
+
+internal actual fun Dispatchers.getTestMainDispatcherOrNull(): TestMainDispatcher? =
+    Main as? TestMainDispatcher

--- a/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
+++ b/ui/kotlinx-coroutines-android/resources/META-INF/com.android.tools/r8-from-1.6.0/coroutines.pro
@@ -9,11 +9,6 @@
     boolean ANDROID_DETECTED return true;
 }
 
-# Disable support for "Missing Main Dispatcher", since we always have Android main dispatcher
--assumenosideeffects class kotlinx.coroutines.internal.MainDispatchersKt {
-    boolean SUPPORT_MISSING return false;
-}
-
 # Statically turn off all debugging facilities and assertions
 -assumenosideeffects class kotlinx.coroutines.DebugKt {
     boolean getASSERTIONS_ENABLED() return false;

--- a/ui/kotlinx-coroutines-android/testdata/r8-test-rules.pro
+++ b/ui/kotlinx-coroutines-android/testdata/r8-test-rules.pro
@@ -8,8 +8,5 @@
 -checkdiscard class kotlinx.coroutines.internal.StackTraceRecoveryKt
 -checkdiscard class kotlinx.coroutines.debug.internal.DebugProbesKt
 
-# Real android projects do not keep this class, but somehow it is kept in this test (R8 bug)
-# -checkdiscard class kotlinx.coroutines.internal.MissingMainCoroutineDispatcher
-
 # Should not keep this class, but it is still there (R8 bug)
 #-checkdiscard class kotlinx.coroutines.CoroutineId


### PR DESCRIPTION
Before this change, calling `Dispatchers.Main` used to never fail. Instead, if the `Main` dispatcher was unavailable on the platform, trying to call `dispatch` would throw an exception.

This behavior is problematic. #4602 demonstrates a problem that would never have arisen if calling `Main` failed altogether. Another example is #880.
In #4325, the author attempts to recreate eager throwing. This makes total sense: failures *in* coroutine dispatchers are hard to meaningfully process (#4209), and surfacing errors to the client code is a more reliable way of dealing with them.

With this change, `Dispatchers.Main` will immediately throw an exception if the dispatcher failed to initialize.

Technically, this may be considered a breaking change, because such code is currently possible to use:
```kotlin
var dispatcher = Dispatchers.Main
if (!onAndroid) {
    dispatcher = newSingleThreadContextElement("Main thread")
}
```
With this commit, `Dispatchers.Main` will throw an exception.

Luckily, the behavior before the change contradicts the documentation at
<https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html>:

> Access to this property may throw an `IllegalStateException`
> if no main dispatchers are present in the classpath.

This commit aligns the actual behavior with what's documented.