### PR TITLE
Revert "Ensure that inline functions only access atomics from the same class (#4041)"

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -238,7 +238,7 @@ internal open class BufferedChannel<E>(
     /**
      * Abstract send implementation.
      */
-    private inline fun <R> sendImpl(
+    protected inline fun <R> sendImpl(
         /* The element to be sent. */
         element: E,
         /* The waiter to be stored in case of suspension,
@@ -346,29 +346,6 @@ internal open class BufferedChannel<E>(
             }
         }
     }
-
-    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of this issue: KT-65554.
-    // For now, an inline function, which invokes atomic operations, may only be called within a parent class.
-    protected fun trySendDropOldest(element: E): ChannelResult<Unit> =
-        sendImpl( // <-- this is an inline function
-            element = element,
-            // Put the element into the logical buffer even
-            // if this channel is already full, the `onSuspend`
-            // callback below extract the first (oldest) element.
-            waiter = BUFFERED,
-            // Finish successfully when a rendezvous has happened
-            // or the element has been buffered.
-            onRendezvousOrBuffered = { return success(Unit) },
-            // In case the algorithm decided to suspend, the element
-            // was added to the buffer. However, as the buffer is now
-            // overflowed, the first (oldest) element has to be extracted.
-            onSuspend = { segm, i ->
-                dropFirstElementUntilTheSpecifiedCellIsInTheBuffer(segm.id * SEGMENT_SIZE + i)
-                return success(Unit)
-            },
-            // If the channel is closed, return the corresponding result.
-            onClosed = { return closed(sendException) }
-        )
 
     private inline fun sendImplOnNoWaiter(
         /* The working cell is specified by

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBufferedChannel.kt
@@ -1,6 +1,7 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.channels.BufferOverflow.*
+import kotlinx.coroutines.channels.ChannelResult.Companion.closed
 import kotlinx.coroutines.channels.ChannelResult.Companion.success
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.*
@@ -67,6 +68,27 @@ internal open class ConflatedBufferedChannel<E>(
         }
         return success(Unit)
     }
+
+    private fun trySendDropOldest(element: E): ChannelResult<Unit> =
+        sendImpl( // <-- this is an inline function
+            element = element,
+            // Put the element into the logical buffer even
+            // if this channel is already full, the `onSuspend`
+            // callback below extract the first (oldest) element.
+            waiter = BUFFERED,
+            // Finish successfully when a rendezvous has happened
+            // or the element has been buffered.
+            onRendezvousOrBuffered = { return success(Unit) },
+            // In case the algorithm decided to suspend, the element
+            // was added to the buffer. However, as the buffer is now
+            // overflowed, the first (oldest) element has to be extracted.
+            onSuspend = { segm, i ->
+                dropFirstElementUntilTheSpecifiedCellIsInTheBuffer(segm.id * SEGMENT_SIZE + i)
+                return success(Unit)
+            },
+            // If the channel is closed, return the corresponding result.
+            onClosed = { return closed(sendException) }
+        )
 
     @Suppress("UNCHECKED_CAST")
     override fun registerSelectForSend(select: SelectInstance<*>, element: Any?) {


### PR DESCRIPTION
#4041 was created as a temporary fix to mitigate [KT-65554](https://youtrack.jetbrains.com/issue/KT-65554) and [KT-78508](https://youtrack.jetbrains.com/issue/KT-78508). Both are now obsolete.