### PR TITLE
Fix a deprecated select's replaceWith

### DIFF
--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -106,7 +106,7 @@ public sealed interface SelectBuilder<in R> {
     @Deprecated(
         message = "Replaced with the same extension function",
         level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith(expression = "onTimeout", imports = ["kotlinx.coroutines.selects.onTimeout"])
+        replaceWith = ReplaceWith(expression = "onTimeout(timeMillis, block)", imports = ["kotlinx.coroutines.selects.onTimeout"])
     ) // Since 1.7.0, was experimental
     public fun onTimeout(timeMillis: Long, block: suspend () -> R): Unit = onTimeout(timeMillis, block)
 }


### PR DESCRIPTION
[KTIJ-37637](https://youtrack.jetbrains.com/issue/KTIJ-37637) ReplaceWith. Incorrect code replacement for deprecated onTimeout in kotlinx.coroutines

[KT-84371](https://youtrack.jetbrains.com/issue/KT-84371) Incorrect @Deprecated annotation and implementation for onTimeout in kotlinx.coroutines

https://github.com/user-attachments/assets/d98f11a8-ae7c-4c2c-8e23-bf5df6c37028

