### PR TITLE
Remove old maven repository settings

### DIFF
--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -50,31 +50,15 @@ fun MavenPom.configureMavenCentralMetadata(project: Project) {
  */
 private val spacePublicationEnabled = System.getenv("libs.space.pub")?.equals("true") ?: false
 
-fun mavenRepositoryUri(): URI {
+fun configureSpaceRepository(rh: RepositoryHandler, project: Project) {
     if (spacePublicationEnabled) {
-        return URI("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
-    }
+        rh.maven {
+            url = URI("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
 
-    val repositoryId: String? = System.getenv("libs.repository.id")
-    return if (repositoryId == null) {
-        URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-    } else {
-        URI("https://oss.sonatype.org/service/local/staging/deployByRepositoryId/$repositoryId")
-    }
-}
-
-fun configureMavenPublication(rh: RepositoryHandler, project: Project) {
-    rh.maven {
-        url = mavenRepositoryUri()
-        credentials {
-            if (spacePublicationEnabled) {
+            credentials {
                 // Configure space credentials
                 username = project.getSensitiveProperty("libs.space.user")
                 password = project.getSensitiveProperty("libs.space.password")
-            } else {
-                // Configure sonatype credentials
-                username = project.getSensitiveProperty("libs.sonatype.user")
-                password = project.getSensitiveProperty("libs.sonatype.password")
             }
         }
     }

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -4,7 +4,6 @@ import groovy.util.Node
 import groovy.util.NodeList
 import org.gradle.api.Project
 import org.gradle.api.XmlProvider
-import org.gradle.api.artifacts.dsl.*
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.*
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
@@ -12,7 +11,6 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.signing.*
-import java.net.*
 
 // Pom configuration
 
@@ -40,27 +38,6 @@ fun MavenPom.configureMavenCentralMetadata(project: Project) {
 
     scm {
         url = "https://github.com/Kotlin/kotlinx.coroutines"
-    }
-}
-
-/**
- * 'libs.space.pub' is a dev option that is set on our CI in order to publish
- * dev build into 'https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven' Maven repository.
- * In order to use it, pass the corresponding ENV to the TC 'Deploy' task.
- */
-private val spacePublicationEnabled = System.getenv("libs.space.pub")?.equals("true") ?: false
-
-fun configureSpaceRepository(rh: RepositoryHandler, project: Project) {
-    if (spacePublicationEnabled) {
-        rh.maven {
-            url = URI("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
-
-            credentials {
-                // Configure space credentials
-                username = project.getSensitiveProperty("libs.space.user")
-                password = project.getSensitiveProperty("libs.space.password")
-            }
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
@@ -14,7 +14,7 @@ apply(plugin = "signing")
 
 publishing {
     repositories {
-        configureMavenPublication(this, project)
+        configureSpaceRepository(this, project)
         maven {
             name = "BuildLocal"
             url = uri(project.rootProject.layout.buildDirectory.dir("build-local-repository"))

--- a/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pub-conventions.gradle.kts
@@ -14,7 +14,6 @@ apply(plugin = "signing")
 
 publishing {
     repositories {
-        configureSpaceRepository(this, project)
         maven {
             name = "BuildLocal"
             url = uri(project.rootProject.layout.buildDirectory.dir("build-local-repository"))


### PR DESCRIPTION
Neither sonatype snapshot repositories, nor `maven.pkg.jetbrains.space` repo exist anymore. So corresponding settings could be now removed