### PR TITLE
Fix package name of `ToMapCollectionSamplesTest`.

### DIFF
--- a/kotlinx-coroutines-core/common/test/flow/terminal/ToMapCollectionSamplesTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/terminal/ToMapCollectionSamplesTest.kt
@@ -1,6 +1,5 @@
-package kotlinx.coroutines.flow.terminal
+package kotlinx.coroutines.flow
 
-import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.testing.*
 import kotlin.test.*
 


### PR DESCRIPTION
Other classes in the same directory use `package kotlinx.coroutines.flow`.

https://github.com/Kotlin/kotlinx.coroutines/blob/master/CONTRIBUTING.md#submitting-prs says

> All development (both new features and bug fixes) is performed in the `develop` branch.

and

> Documentation in markdown files can be updated directly in the `master` branch,

but it doesn't say anything about test-only changes.

I think updating tests directly in the `master` branch should be fine? It's not like any users would be affected by this.