### PR TITLE
Catch potential `NoClassDefFoundError` from `Class.getMethod`.

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstructor.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/ExceptionsConstructor.kt
@@ -47,6 +47,8 @@ private fun <E : Throwable> createConstructor(clz: Class<E>): Ctor {
         }
     } catch (_: NoSuchMethodException) {
         // Expected: there simply was no implementation of `StackTraceRecoverable`
+    } catch (_: NoClassDefFoundError) {
+        // clz has missing dependencies
     } catch (_: SecurityException) {
         // Restrictive SecurityManager
     }


### PR DESCRIPTION
It's possible for `Class.getMethod` to throw `NoClassDefFoundError` if the signature of a method in the class refers to some class that's missing from the classpath. Normally this would be fine as long as that method itself is not called, but calling `getMethod` on the class forces all class dependencies of all method signatures in the class to be satisfied.

For example, given `Foo.kt`:
```kotlin
fun main(args: Array<String>) {
	val foo = Foo()
	foo.javaClass.getMethod("foo").invoke(foo)
}

class Foo {
	fun foo() = println("okay")
	fun bar(): Bar? = null
}

class Bar
```
```
$ kotlinc Foo.kt
$ kotlin FooKt -cp .
okay
$ rm Bar.class
$ kotlin FooKt -cp .
Exception in thread "main" java.lang.NoClassDefFoundError: Bar
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3011)
	at java.base/java.lang.Class.getMethodsRecursive(Class.java:3147)
	at java.base/java.lang.Class.getMethod0(Class.java:3132)
	at java.base/java.lang.Class.getMethod(Class.java:2164)
	at FooKt.main(Foo.kt:3)
Caused by: java.lang.ClassNotFoundException: Bar
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:377)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:569)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
	... 6 more
```