### PR TITLE
Have `Promise.await` on a rejected promise throw `JsError` on Wasm

### DIFF
--- a/kotlinx-coroutines-core/js/src/Promise.js.kt
+++ b/kotlinx-coroutines-core/js/src/Promise.js.kt
@@ -1,9 +1,11 @@
 package kotlinx.coroutines
 
-@Suppress("USELESS_CAST") // on JS, arbitrary objects can be thrown
+@Suppress("USELESS_CAST")
 @OptIn(ExperimentalWasmJsInterop::class)
-internal actual fun JsPromiseError.toThrowable(): Throwable = this as? Throwable ?:
-    Exception("Promise resolved with a non-Throwable exception '$this' (type ${this::class})")
+// The cast looks redundant, but the `JsPromiseError` being a type alias to `Throwable` is actually incorrect.
+// A promise can be rejected with any value, not just `Throwable`.
+internal actual fun JsPromiseError.toThrowableOrNull(): Throwable? =
+    this as? Throwable
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal actual fun Throwable.toJsPromiseError(): JsPromiseError = this

--- a/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
+++ b/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
@@ -3,15 +3,10 @@ package kotlinx.coroutines
 
 import kotlin.coroutines.*
 import kotlin.js.*
+import kotlin.js.toThrowableOrNull as stdlibToThrowableOrNull
 
-@OptIn(ExperimentalWasmJsInterop::class)
-internal actual fun JsPromiseError.toThrowable(): Throwable = try {
-    unsafeCast<JsReference<Throwable>>().get()
-} catch (_: Throwable) {
-    Exception("Non-Kotlin exception $this of type '${this::class}'")
-}
+internal actual fun JsPromiseError.toThrowableOrNull(): Throwable? = stdlibToThrowableOrNull()
 
-@OptIn(ExperimentalWasmJsInterop::class)
 internal actual fun Throwable.toJsPromiseError(): JsPromiseError = toJsReference()
 
 /*

--- a/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
+++ b/kotlinx-coroutines-core/wasmJs/src/Promise.wasm.kt
@@ -3,13 +3,10 @@ package kotlinx.coroutines
 
 import kotlin.coroutines.*
 import kotlin.js.*
+import kotlin.js.toThrowableOrNull as stdlibToThrowableOrNull
 
 @OptIn(ExperimentalWasmJsInterop::class)
-internal actual fun JsPromiseError.toThrowable(): Throwable = try {
-    unsafeCast<JsReference<Throwable>>().get()
-} catch (_: Throwable) {
-    Exception("Non-Kotlin exception $this of type '${this::class}'")
-}
+internal actual fun JsPromiseError.toThrowableOrNull(): Throwable? = stdlibToThrowableOrNull()
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal actual fun Throwable.toJsPromiseError(): JsPromiseError = toJsReference()

--- a/kotlinx-coroutines-core/web/src/Promise.kt
+++ b/kotlinx-coroutines-core/web/src/Promise.kt
@@ -79,11 +79,16 @@ public fun <T: JsAny?> Promise<T>.asDeferred(): Deferred<T> {
 public suspend fun <T: JsAny?> Promise<T>.await(): T = suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
     this@await.then(
         onFulfilled = { cont.resume(it); null },
-        onRejected = { cont.resumeWithException(it.toThrowable()); null })
+        onRejected = {
+            val exception = it.toThrowableOrNull()
+                ?: Exception("Promise resolved with a non-Throwable exception '$it' (type ${it::class})")
+            cont.resumeWithException(exception)
+            null
+        })
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
-internal expect fun JsPromiseError.toThrowable(): Throwable
+internal expect fun JsPromiseError.toThrowableOrNull(): Throwable?
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal expect fun Throwable.toJsPromiseError(): JsPromiseError

--- a/kotlinx-coroutines-core/web/src/Promise.kt
+++ b/kotlinx-coroutines-core/web/src/Promise.kt
@@ -79,11 +79,29 @@ public fun <T: JsAny?> Promise<T>.asDeferred(): Deferred<T> {
 public suspend fun <T: JsAny?> Promise<T>.await(): T = suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
     this@await.then(
         onFulfilled = { cont.resume(it); null },
-        onRejected = { cont.resumeWithException(it.toThrowable()); null })
+        onRejected = {
+            /**
+             * The observable behavior is:
+             * - For JS exceptions:
+             *   + On JS, they are thrown as is.
+             *   + On Wasm/JS, they are represented as a [JsException] object.
+             * - For non-exceptions:
+             *   + On JS, a plain [Exception] is thrown with a clarifying message.
+             *   + On Wasm/JS, they are wrapped in a [JsException] object, with [thrownValue] set to what was thrown.
+             * - Kotlin/Wasm/JS exceptions are rethrown as is.
+             *
+             * Since Wasm/JS support is experimental, the specifics may change.
+             * In any case, we consistently throw a [JsException] if this is a JS exception.
+             */
+            val exception = it.toThrowableOrNull()
+                ?: Exception("Promise rejected with a non-Throwable exception '$it' (type ${it::class})")
+            cont.resumeWithException(exception)
+            null
+        })
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
-internal expect fun JsPromiseError.toThrowable(): Throwable
+internal expect fun JsPromiseError.toThrowableOrNull(): Throwable?
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal expect fun Throwable.toJsPromiseError(): JsPromiseError

--- a/kotlinx-coroutines-core/web/src/Promise.kt
+++ b/kotlinx-coroutines-core/web/src/Promise.kt
@@ -74,27 +74,29 @@ public fun <T: JsAny?> Promise<T>.asDeferred(): Deferred<T> {
  * suspending function is waiting on the promise, this function immediately resumes with [CancellationException].
  * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
  * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
+ *
+ * ## Current behavior on promise rejection (that may change in future releases)
+ *
+ * - For JS exceptions:
+ *   + On JS, they are thrown as is.
+ *   + On Wasm/JS, they are represented as a [JsException] object.
+ * - For non-exceptions:
+ *   + On JS, a plain [Exception] is thrown with a clarifying message.
+ *   + On Wasm/JS, they are wrapped in a [JsException] object, with [thrownValue] set to what was thrown.
+ * - Kotlin/Wasm/JS exceptions are rethrown as is.
  */
 @OptIn(ExperimentalWasmJsInterop::class)
 public suspend fun <T: JsAny?> Promise<T>.await(): T = suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
     this@await.then(
         onFulfilled = { cont.resume(it); null },
         onRejected = {
-            /**
-             * The observable behavior is:
-             * - For JS exceptions:
-             *   + On JS, they are thrown as is.
-             *   + On Wasm/JS, they are represented as a [JsException] object.
-             * - For non-exceptions:
-             *   + On JS, a plain [Exception] is thrown with a clarifying message.
-             *   + On Wasm/JS, they are wrapped in a [JsException] object, with [thrownValue] set to what was thrown.
-             * - Kotlin/Wasm/JS exceptions are rethrown as is.
-             *
-             * Since Wasm/JS support is experimental, the specifics may change.
-             * In any case, we consistently throw a [JsException] if this is a JS exception.
-             */
-            val exception = it.toThrowableOrNull()
-                ?: Exception("Promise rejected with a non-Throwable exception '$it' (type ${it::class})")
+            // KT-86697 prevents us from handling `undefined` as the rejection value on Wasm/JS, but on JS, this works:
+            val exception = try {
+                it.toThrowableOrNull()
+                    ?: Exception("Promise rejected with a non-Throwable exception '$it' (type ${it::class})")
+            } catch (_: Throwable) {
+                Exception("Promise rejected with a non-Throwable exception")
+            }
             cont.resumeWithException(exception)
             null
         })

--- a/kotlinx-coroutines-core/web/test/PromiseTest.kt
+++ b/kotlinx-coroutines-core/web/test/PromiseTest.kt
@@ -103,13 +103,13 @@ class PromiseTestWeb : TestBase() {
     }
 
     @Test
-    fun testAwaitPromiseRejectedWithNonKotlinException() = GlobalScope.promise {
+    fun testAwaitPromiseRejectedWithNonThrowableException() = GlobalScope.promise {
         val toAwait = jsPromiseRejectedWithString()
         val throwable = async(start = CoroutineStart.UNDISPATCHED) {
-            assertFails { toAwait.await() }
+            assertFailsWith<JsException> { toAwait.await() }
         }
-        val throwableResolved = throwable.await()
-        assertEquals(true, throwableResolved.message?.contains("Rejected"), "${throwableResolved.message}")
+        val thrownValue = throwable.await().thrownValue
+        assertEquals(true, thrownValue.toString().contains("Rejected"), "$thrownValue")
         null
     }
 
@@ -126,7 +126,19 @@ class PromiseTestWeb : TestBase() {
         assertEquals("Rejected", throwable.await().message)
         null
     }
+
+    @Test
+    fun testAwaitPromiseRejectedWithNonKotlinException() = GlobalScope.promise {
+        val e = assertFailsWith<JsException> {
+            jsPromiseRejectedWithJsException().await()
+        }
+        assertTrue(e.message?.contains("Rejected") ?: false)
+        null
+    }
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun jsPromiseRejectedWithString(): Promise<JsBigInt> = js("Promise.reject(\"Rejected\")")
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun jsPromiseRejectedWithJsException(): Promise<JsBigInt> = js("Promise.reject(new Error(\"Rejected\"))")

--- a/kotlinx-coroutines-core/web/test/PromiseTest.kt
+++ b/kotlinx-coroutines-core/web/test/PromiseTest.kt
@@ -103,13 +103,13 @@ class PromiseTestWeb : TestBase() {
     }
 
     @Test
-    fun testAwaitPromiseRejectedWithNonKotlinException() = GlobalScope.promise {
+    fun testAwaitPromiseRejectedWithNonThrowableException() = GlobalScope.promise {
         val toAwait = jsPromiseRejectedWithString()
         val throwable = async(start = CoroutineStart.UNDISPATCHED) {
-            assertFails { toAwait.await() }
+            assertFailsWith<JsException> { toAwait.await() }
         }
-        val throwableResolved = throwable.await()
-        assertEquals(true, throwableResolved.message?.contains("Rejected"), "${throwableResolved.message}")
+        val thrownValue = throwable.await().thrownValue
+        assertTrue(thrownValue.toString().contains("Rejected"), "$thrownValue")
         null
     }
 
@@ -126,7 +126,19 @@ class PromiseTestWeb : TestBase() {
         assertEquals("Rejected", throwable.await().message)
         null
     }
+
+    @Test
+    fun testAwaitPromiseRejectedWithNonKotlinWasmException() = GlobalScope.promise {
+        val e = assertFailsWith<JsException> {
+            jsPromiseRejectedWithJsException().await()
+        }
+        assertTrue(e.message!!.contains("Rejected"))
+        null
+    }
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private fun jsPromiseRejectedWithString(): Promise<JsBigInt> = js("Promise.reject(\"Rejected\")")
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun jsPromiseRejectedWithJsException(): Promise<JsBigInt> = js("Promise.reject(new Error(\"Rejected\"))")


### PR DESCRIPTION
Fixes #4678