### PR TITLE
Restore the removed atomicfu workaround

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -347,7 +347,7 @@ internal open class BufferedChannel<E>(
         }
     }
 
-    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of this issue: KT-65554. 
+    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of these issues: KT-81416, KT-86264. 
     // For now, an inline function, which invokes atomic operations, may only be called within a parent class.
     protected fun trySendDropOldest(element: E): ChannelResult<Unit> =
         sendImpl( // <-- this is an inline function

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -238,7 +238,7 @@ internal open class BufferedChannel<E>(
     /**
      * Abstract send implementation.
      */
-    protected inline fun <R> sendImpl(
+    private inline fun <R> sendImpl(
         /* The element to be sent. */
         element: E,
         /* The waiter to be stored in case of suspension,
@@ -346,6 +346,29 @@ internal open class BufferedChannel<E>(
             }
         }
     }
+
+    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of this issue: KT-65554. 
+    // For now, an inline function, which invokes atomic operations, may only be called within a parent class.
+    protected fun trySendDropOldest(element: E): ChannelResult<Unit> =
+        sendImpl( // <-- this is an inline function
+            element = element,
+            // Put the element into the logical buffer even
+            // if this channel is already full, the `onSuspend`
+            // callback below extract the first (oldest) element.
+            waiter = BUFFERED,
+            // Finish successfully when a rendezvous has happened
+            // or the element has been buffered.
+            onRendezvousOrBuffered = { return success(Unit) },
+            // In case the algorithm decided to suspend, the element
+            // was added to the buffer. However, as the buffer is now
+            // overflowed, the first (oldest) element has to be extracted.
+            onSuspend = { segm, i ->
+                dropFirstElementUntilTheSpecifiedCellIsInTheBuffer(segm.id * SEGMENT_SIZE + i)
+                return success(Unit)
+            },
+            // If the channel is closed, return the corresponding result.
+            onClosed = { return closed(sendException) }
+        )
 
     private inline fun sendImplOnNoWaiter(
         /* The working cell is specified by

--- a/kotlinx-coroutines-core/common/src/channels/ConflatedBufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ConflatedBufferedChannel.kt
@@ -69,27 +69,6 @@ internal open class ConflatedBufferedChannel<E>(
         return success(Unit)
     }
 
-    private fun trySendDropOldest(element: E): ChannelResult<Unit> =
-        sendImpl( // <-- this is an inline function
-            element = element,
-            // Put the element into the logical buffer even
-            // if this channel is already full, the `onSuspend`
-            // callback below extract the first (oldest) element.
-            waiter = BUFFERED,
-            // Finish successfully when a rendezvous has happened
-            // or the element has been buffered.
-            onRendezvousOrBuffered = { return success(Unit) },
-            // In case the algorithm decided to suspend, the element
-            // was added to the buffer. However, as the buffer is now
-            // overflowed, the first (oldest) element has to be extracted.
-            onSuspend = { segm, i ->
-                dropFirstElementUntilTheSpecifiedCellIsInTheBuffer(segm.id * SEGMENT_SIZE + i)
-                return success(Unit)
-            },
-            // If the channel is closed, return the corresponding result.
-            onClosed = { return closed(sendException) }
-        )
-
     @Suppress("UNCHECKED_CAST")
     override fun registerSelectForSend(select: SelectInstance<*>, element: Any?) {
         // The plain `send(..)` operation never suspends. Thus, either this


### PR DESCRIPTION
Already introduced once, then reverted in https://github.com/Kotlin/kotlinx.coroutines/pull/4663, which led to new issues.