### PR TITLE
Fix typo in jvm SafeCollector#emit docs

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/flow/internal/SafeCollector.kt
+++ b/kotlinx-coroutines-core/jvm/src/flow/internal/SafeCollector.kt
@@ -94,7 +94,7 @@ internal actual class SafeCollector<T> actual constructor(
      * Here we use the following trick:
      * - Perform all the required checks
      * - Having a non-intercepted, non-cancellable caller's `uCont`, we leverage our implementation knowledge
-     *   and invoke `collector.emit(T)` as `collector.emit(value: T, completion: Continuation), passing `this`
+     *   and invoke `collector.emit(T)` as `collector.emit(value: T, completion: Continuation)`, passing `this`
      *   as the completion. We also setup `this` state, so if the `completion.resume` is invoked, we are
      *   invoking `uCont.resume` properly in accordance with `ContinuationImpl`/`BaseContinuationImpl` internal invariants.
      *


### PR DESCRIPTION
Fixes a small missing backtick for markdown code rendering in the SafeCollector#emit in the jvm module