### PR TITLE
Clarify debugging capabilities are JVM-only

### DIFF
--- a/docs/topics/debugging.md
+++ b/docs/topics/debugging.md
@@ -16,6 +16,7 @@
 Debugging asynchronous programs is challenging, because multiple concurrent coroutines are typically working at the same time.
 To help with that, `kotlinx.coroutines` comes with additional features for debugging: debug mode, stacktrace recovery 
 and debug agent.
+These debugging capabilities are available only on JVM platforms.
 
 ## Debug mode
 


### PR DESCRIPTION
Clarifies that the debugging capabilities described in docs/topics/debugging.md are available only on JVM platforms.

Fixes #4339