### PR TITLE
Clarify docs on flow completion with exception and catch operator

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -17,7 +17,7 @@ import kotlin.coroutines.*
  * or [launchIn] operator that starts collection of the flow in the given scope.
  * They are applied to the upstream flow and trigger execution of all operations.
  * Execution of the flow is also called _collecting the flow_  and is always performed in a suspending manner
- * without actual blocking. Terminal operators complete normally or exceptionally depending on successful or failed
+ * without actual blocking. Terminal operators complete normally or with an exception depending on successful or failed
  * execution of all the flow operations in the upstream. The most basic terminal operator is [collect], for example:
  *
  * ```
@@ -33,6 +33,10 @@ import kotlin.coroutines.*
  * By default, flows are _sequential_ and all flow operations are executed sequentially in the same coroutine,
  * with an exception for a few operations specifically designed to introduce concurrency into flow
  * execution such as [buffer] and [flatMapMerge]. See their documentation for details.
+ *
+ * A flow completes normally when the upstream emitter finishes execution.
+ * A flow completes with an exception when an exception is thrown by any of the flow operations.
+ * In this case, the upstream flow completes immediately and does not emit any more values.
  *
  * The `Flow` interface does not carry information whether a flow is a _cold_ stream that can be collected repeatedly and
  * triggers execution of the same code every time it is collected, or if it is a _hot_ stream that emits different
@@ -130,9 +134,10 @@ import kotlin.coroutines.*
  * When `emit` or `emitAll` throws, the Flow implementations must immediately stop emitting new values and finish with an exception.
  * For diagnostics or application-specific purposes, the exception may be different from the one thrown by the emit operation,
  * suppressing the original exception as discussed below.
- * If there is a need to emit values after the downstream failed, please use the [catch][Flow.catch] operator.
+ * If there is a need to emit fallback values after an upstream flow completes with an  exception, please use the
+ * [catch][Flow.catch] operator downstream of the failing operation in the flow chain.
  *
- * The [catch][Flow.catch] operator only catches upstream exceptions, but passes
+ * The [catch][Flow.catch] operator catches only the exception that the upstream flow completed with, but passes
  * all downstream exceptions. Similarly, terminal operators like [collect][Flow.collect]
  * throw any unhandled exceptions that occur in their code or in upstream flows, for example:
  *

--- a/kotlinx-coroutines-core/common/src/flow/Flow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Flow.kt
@@ -34,10 +34,6 @@ import kotlin.coroutines.*
  * with an exception for a few operations specifically designed to introduce concurrency into flow
  * execution such as [buffer] and [flatMapMerge]. See their documentation for details.
  *
- * A flow completes normally when the upstream emitter finishes execution.
- * A flow completes with an exception when an exception is thrown by any of the flow operations.
- * In this case, the upstream flow completes immediately and does not emit any more values.
- *
  * The `Flow` interface does not carry information whether a flow is a _cold_ stream that can be collected repeatedly and
  * triggers execution of the same code every time it is collected, or if it is a _hot_ stream that emits different
  * values from the same running source on each collection. Usually flows represent _cold_ streams, but
@@ -131,13 +127,13 @@ import kotlin.coroutines.*
  *
  * ### Exception transparency
  *
- * When `emit` or `emitAll` throws, the Flow implementations must immediately stop emitting new values and finish with an exception.
+ * When `emit` or `emitAll` throws, the Flow implementations must immediately stop emitting new values and complete with an exception.
  * For diagnostics or application-specific purposes, the exception may be different from the one thrown by the emit operation,
  * suppressing the original exception as discussed below.
- * If there is a need to emit fallback values after an upstream flow completes with an  exception, please use the
- * [catch][Flow.catch] operator downstream of the failing operation in the flow chain.
+ * If there is a need to emit fallback values after the flow completed with an exception, use the
+ * [catch][Flow.catch] operator and emit them from its [action][Flow.catch] block.
  *
- * The [catch][Flow.catch] operator catches only the exception that the upstream flow completed with, but passes
+ * The [catch][Flow.catch] operator only catches upstream exceptions, but passes
  * all downstream exceptions. Similarly, terminal operators like [collect][Flow.collect]
  * throw any unhandled exceptions that occur in their code or in upstream flows, for example:
  *

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -10,8 +10,10 @@ import kotlin.jvm.*
 import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
- * Catches exceptions in the flow completion and calls a specified [action] with
- * the caught exception. This operator is *transparent* to exceptions that occur
+ * Catches exceptions in the upstream flow completion.
+ * After the upstream flow has completed with an exception, the [action] is called with the caught exception
+ * and may emit fallback values downstream.
+ * This operator is *transparent* to exceptions that occur
  * in downstream flow and does not catch exceptions that are thrown to cancel the flow.
  *
  * For example:
@@ -39,7 +41,7 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
  * }
  * ```
  *
- * The [action] code has [FlowCollector] as a receiver and can [emit][FlowCollector.emit] values downstream.
+ * The [action] code has [FlowCollector] as a receiver and can [emit][FlowCollector.emit] fallback values downstream.
  * For example, caught exception can be replaced with some wrapper value for errors:
  *
  * ```

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -11,8 +11,6 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
  * If the upstream flow completes with an exception, this operator catches that exception and calls the specified [action] with it.
- * After completing with an exception, the flow cannot emit any more values, and fallback values may be emitted
- * downstream from the [action] block instead.
  * This operator is *transparent* to exceptions that occur
  * in downstream flow and does not catch exceptions that are thrown to cancel the flow.
  *
@@ -29,6 +27,9 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
  * Conceptually, the action of `catch` operator is similar to wrapping the code of upstream flows with
  * `try { ... } catch (e: Throwable) { action(e) }`.
  *
+ * After the flow has completed with an exception, it cannot emit any more values, and fallback values may be emitted
+ * downstream from the [action] block instead.
+ *
  * Any exception in the [action] code itself proceeds downstream where it can be
  * caught by further `catch` operators if needed. If a particular exception does not need to be
  * caught it can be rethrown from the action of `catch` operator. For example:
@@ -41,7 +42,7 @@ import kotlinx.coroutines.flow.internal.unsafeFlow as flow
  * }
  * ```
  *
- * The [action] code has [FlowCollector] as a receiver and can [emit][FlowCollector.emit] fallback values downstream.
+ * The [action] code has [FlowCollector] as a receiver and can [emit][FlowCollector.emit] values downstream.
  * For example, caught exception can be replaced with some wrapper value for errors:
  *
  * ```

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -10,8 +10,8 @@ import kotlin.jvm.*
 import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
- * Catches the exception that the upstream flow completes with and calls the specified [action] with the caught exception.
- * After completing with the exception the flow cannot emit any more values, and fallback values may be emitted
+ * Catches the exception if the upstream flow completes with one, and calls the specified [action] with it.
+ * After completing with the exception, the flow cannot emit any more values, and fallback values may be emitted
  * downstream from the [action] block instead.
  * This operator is *transparent* to exceptions that occur
  * in downstream flow and does not catch exceptions that are thrown to cancel the flow.

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -10,9 +10,9 @@ import kotlin.jvm.*
 import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
- * Catches exceptions in the upstream flow completion.
- * After the upstream flow has completed with an exception, the [action] is called with the caught exception
- * and may emit fallback values downstream.
+ * Catches the exception that the upstream flow completes with and calls the specified [action] with the caught exception.
+ * After completing with the exception the flow cannot emit any more values, and fallback values may be emitted
+ * downstream from the [action] block instead.
  * This operator is *transparent* to exceptions that occur
  * in downstream flow and does not catch exceptions that are thrown to cancel the flow.
  *

--- a/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt
@@ -10,8 +10,8 @@ import kotlin.jvm.*
 import kotlinx.coroutines.flow.internal.unsafeFlow as flow
 
 /**
- * Catches the exception if the upstream flow completes with one, and calls the specified [action] with it.
- * After completing with the exception, the flow cannot emit any more values, and fallback values may be emitted
+ * If the upstream flow completes with an exception, this operator catches that exception and calls the specified [action] with it.
+ * After completing with an exception, the flow cannot emit any more values, and fallback values may be emitted
  * downstream from the [action] block instead.
  * This operator is *transparent* to exceptions that occur
  * in downstream flow and does not catch exceptions that are thrown to cancel the flow.


### PR DESCRIPTION
PR highlights that when the upstream flow throws, it completes, and the original flow can no longer produce the values, even if `.catch` is applied

Unified the usage of  'complete with an exception' across both `Flow` and `.catch`.

Addresses the misconception that arose in #3594 