### PR TITLE
Remove unused variable in Flow guide example

### DIFF
--- a/docs/topics/coroutines-flow.md
+++ b/docs/topics/coroutines-flow.md
@@ -1589,7 +1589,6 @@ class Chatroom {
 
 //sampleStart
 suspend fun main() {
-    val nUsers = 3
     val chatroom = Chatroom()
     withContext(Dispatchers.Default) {
         // Creates a child scope of the currently running coroutine


### PR DESCRIPTION
Remove unused `nUsers` variable in example in the "Cancel hot flows" section of the Flow guide.