### PR TITLE
Correctly check version in MavenPublicationMetaInfValidator test

### DIFF
--- a/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
+++ b/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
@@ -27,7 +27,7 @@ class MavenPublicationMetaInfValidator {
         val clazz = Class.forName("kotlinx.coroutines.android.HandlerDispatcher")
         val expectedEntries = buildSet {
             add("MANIFEST.MF")
-            if (kotlin24OrNewer(kotlinVersion)) {
+            if (kotlinVersion >= "2.4") { // TODO: remove the check after updating Kotlin version to 2.4+
                 add("org.jetbrains.kotlinx_kotlinx-coroutines-android.kotlin_module")
             } else {
                 add("kotlinx-coroutines-android.kotlin_module")
@@ -66,13 +66,4 @@ class MavenPublicationMetaInfValidator {
 
     private val kotlinVersion: String
         get() = System.getProperty("kotlin.version.integration")
-
-    private fun kotlin24OrNewer(version: String): Boolean {
-        val majorVersion = version.substringBefore('.').toIntOrNull() ?: return false
-        if (majorVersion > 2) return true
-        if (majorVersion < 2) return false
-
-        val minorVersion = version.substringAfter('.').substringBefore('.').toIntOrNull() ?: return false
-        return minorVersion >= 4
-    }
 }

--- a/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
+++ b/integration-testing/src/mavenTest/kotlin/MavenPublicationMetaInfValidator.kt
@@ -27,7 +27,7 @@ class MavenPublicationMetaInfValidator {
         val clazz = Class.forName("kotlinx.coroutines.android.HandlerDispatcher")
         val expectedEntries = buildSet {
             add("MANIFEST.MF")
-            if (kotlinVersion.startsWith("2.4")) {
+            if (kotlin24OrNewer(kotlinVersion)) {
                 add("org.jetbrains.kotlinx_kotlinx-coroutines-android.kotlin_module")
             } else {
                 add("kotlinx-coroutines-android.kotlin_module")
@@ -66,4 +66,13 @@ class MavenPublicationMetaInfValidator {
 
     private val kotlinVersion: String
         get() = System.getProperty("kotlin.version.integration")
+
+    private fun kotlin24OrNewer(version: String): Boolean {
+        val majorVersion = version.substringBefore('.').toIntOrNull() ?: return false
+        if (majorVersion > 2) return true
+        if (majorVersion < 2) return false
+
+        val minorVersion = version.substringAfter('.').substringBefore('.').toIntOrNull() ?: return false
+        return minorVersion >= 4
+    }
 }


### PR DESCRIPTION
One of the tests behavior varies depending on a Kotlin version, and currently the version check is incorrect. It assumes that there's new compiler behavior for Kotlin 2.4 only, while the module names are different starting from 2.4. As a result, the test fails in Kotlin aggregate builds where it is built and executed w/ Kotlin 2.5.x.