### PR TITLE
Fix inaccurate description of cancellation vs. failure in Supervision docs

### DIFF
--- a/docs/topics/exception-handling.md
+++ b/docs/topics/exception-handling.md
@@ -338,8 +338,8 @@ CoroutineExceptionHandler got java.io.IOException
 
 ## Supervision
 
-As we have studied before, cancellation is a bidirectional relationship propagating through the whole
-hierarchy of coroutines. Let us take a look at the case when unidirectional cancellation is required. 
+As we have studied before, a failure of a coroutine is a bidirectional relationship propagating through the whole
+hierarchy of coroutines. Let us take a look at the case when unidirectional failure propagation is required. 
 
 A good example of such a requirement is a UI component with the job defined in its scope. If any of the UI's child tasks
 have failed, it is not always necessary to cancel (effectively kill) the whole UI component,
@@ -351,8 +351,8 @@ their execution, tracking their failures and only restarting the failed ones.
 ### Supervision job
 
 The [SupervisorJob][SupervisorJob()] can be used for these purposes. 
-It is similar to a regular [Job][Job()] with the only exception that cancellation is propagated
-only downwards. This can easily be demonstrated using the following example:
+It is similar to a regular [Job][Job()] with the only exception that a failure or cancellation of a child
+does not propagate to the supervisor job or its other children. This can easily be demonstrated using the following example:
 
 ```kotlin
 import kotlinx.coroutines.*


### PR DESCRIPTION
Fixes #4004.

The "Supervision" section of `docs/topics/exception-handling.md` describes cancellation as the bidirectional relationship that propagates through the whole coroutine hierarchy, and describes `SupervisorJob` as blocking cancellation propagation "only downwards."

This is inaccurate: explicit cancellation is already unidirectional by default (a parent cancels its children, not the other way around). It's a *failure* (an uncaught exception in a child) that propagates bidirectionally up to the parent and across siblings. `SupervisorJob`'s actual role — per its own KDoc and `SupervisorJobImpl.childCancelled` (`kotlinx-coroutines-core/common/src/Supervisor.kt`) — is to stop a child's failure or cancellation from propagating to the supervisor job or to its other children, not to make cancellation "unidirectional."

This PR corrects both mentions in the "Supervision" section to describe failure propagation accurately, consistent with the `SupervisorJob` KDoc.

## Changes
- `docs/topics/exception-handling.md`: two prose corrections, no line-count change, no code samples or references touched.

## Verification
- Cross-checked the corrected wording against `SupervisorJob`'s own KDoc and `SupervisorJobImpl`/`SupervisorCoroutine.childCancelled` in `Supervisor.kt`, and against the document's own earlier "Cancellation and exceptions" section, which already describes failure (not cancellation) as bidirectional.
- Per `CONTRIBUTING.md`, I attempted to run `./gradlew knit` to regenerate any derived docs output. I was not able to complete this locally: the build requires downloading a Kotlin/Native toolchain dependency from `download.jetbrains.com`, which was unreachable from my environment (DNS resolution failure) even after resolving unrelated JDK toolchain setup issues. Since this change is pure prose with no code samples, no reference links, and no line-count shift, I don't expect Knit to produce any diff, but I was not able to confirm this directly — flagging it in case a maintainer wants to double check.

---
This PR was prepared with the assistance of Claude Code (Anthropic's CLI-based coding agent). The root-cause analysis, wording, and verification steps above were reviewed and confirmed by me before submitting.