### PR TITLE
Simplify the Native multithreaded dispatchers

### DIFF
--- a/kotlinx-coroutines-core/native/src/MultithreadedDispatchers.kt
+++ b/kotlinx-coroutines-core/native/src/MultithreadedDispatchers.kt
@@ -87,9 +87,18 @@ private class MultiWorkerDispatcher(
     }
 
     /**
-     * `number of tasks - number of workers`
+     * `number of tasks - number of workers`.
+     *
+     * Used only to determine if we need to allocate a new worker when a new task arrives: if there are idling workers,
+     * we can reuse them.
+     *
+     * It is safe for this variable to overflow.
+     * For [tasksMinusWorkers] to exceed [Int.MAX_VALUE], we need to have at least [Int.MAX_VALUE] tasks enqueued,
+     * each of which requested a worker allocation.
+     * Even in the (practically impossible) race with [workersCount] being [Int.MAX_VALUE],
+     * we will correctly allocate every worker.
      */
-    private val tasksMinusWorkers = atomic(0L)
+    private val tasksMinusWorkers = atomic(0)
 
     private fun workerRunLoop() = runBlocking {
         while (true) {
@@ -101,10 +110,6 @@ private class MultiWorkerDispatcher(
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        if (tasksQueue.isClosedForSend) {
-            // a fast path to avoid touching `tasksMinusWorkers` unnecessarily
-            throw IllegalStateException("Dispatcher $name was closed, attempted to schedule: $block")
-        }
         val previousTasksMinusWorkers = tasksMinusWorkers.getAndAdd(1)
         if (previousTasksMinusWorkers >= 0) {
             // no workers are available, we must allocate a new one

--- a/kotlinx-coroutines-core/native/src/MultithreadedDispatchers.kt
+++ b/kotlinx-coroutines-core/native/src/MultithreadedDispatchers.kt
@@ -80,7 +80,6 @@ private class MultiWorkerDispatcher(
     private val workersCount: Int
 ) : CloseableCoroutineDispatcher() {
     private val tasksQueue = Channel<Runnable>(Channel.UNLIMITED)
-    private val availableWorkers = Channel<CancellableContinuation<Runnable>>(Channel.UNLIMITED)
     private val workerPool = OnDemandAllocatingPool(workersCount) {
         Worker.start(name = "$name-$it").apply {
             executeAfter { workerRunLoop() }
@@ -88,59 +87,34 @@ private class MultiWorkerDispatcher(
     }
 
     /**
-     * (number of tasks - number of workers) * 2 + (1 if closed)
+     * `number of tasks - number of workers`
      */
-    private val tasksAndWorkersCounter = atomic(0L)
-
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun Long.isClosed() = this and 1L == 1L
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun Long.hasTasks() = this >= 2
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun Long.hasWorkers() = this < 0
+    private val tasksMinusWorkers = atomic(0L)
 
     private fun workerRunLoop() = runBlocking {
         while (true) {
-            val state = tasksAndWorkersCounter.getAndUpdate {
-                if (it.isClosed() && !it.hasTasks()) return@runBlocking
-                it - 2
-            }
-            if (state.hasTasks()) {
-                // we promised to process a task, and there are some
-                tasksQueue.receive().run()
-            } else {
-                try {
-                    suspendCancellableCoroutine {
-                        val result = availableWorkers.trySend(it)
-                        checkChannelResult(result)
-                    }.run()
-                } catch (e: CancellationException) {
-                    /** we are cancelled from [close] and thus will never get back to this branch of code,
-                    but there may still be pending work, so we can't just exit here. */
-                }
-            }
+            tasksMinusWorkers.getAndAdd(-1)
+            tasksQueue.receiveCatching()
+                .onSuccess { it.run() }
+                .onClosed { return@runBlocking }
         }
     }
 
-    // a worker that promised to be here and should actually arrive, so we wait for it in a blocking manner.
-    private fun obtainWorker(): CancellableContinuation<Runnable> =
-        availableWorkers.tryReceive().getOrNull() ?: runBlocking { availableWorkers.receive() }
-
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        val state = tasksAndWorkersCounter.getAndUpdate {
-            if (it.isClosed())
-                throw IllegalStateException("Dispatcher $name was closed, attempted to schedule: $block")
-            it + 2
+        if (tasksQueue.isClosedForSend) {
+            // a fast path to avoid touching `tasksMinusWorkers` unnecessarily
+            throw IllegalStateException("Dispatcher $name was closed, attempted to schedule: $block")
         }
-        if (state.hasWorkers()) {
-            // there are workers that have nothing to do, let's grab one of them
-            obtainWorker().resume(block)
-        } else {
+        val previousTasksMinusWorkers = tasksMinusWorkers.getAndAdd(1)
+        if (previousTasksMinusWorkers >= 0) {
+            // no workers are available, we must allocate a new one
             workerPool.allocate()
-            // no workers are available, we must queue the task
-            val result = tasksQueue.trySend(block)
-            checkChannelResult(result)
         }
+        tasksQueue.trySend(block)
+            .onClosed {
+                tasksMinusWorkers.getAndAdd(-1) // remove the task we failed to send
+                throw IllegalStateException("Dispatcher $name was closed, attempted to schedule: $block")
+            }
     }
 
     override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
@@ -152,30 +126,14 @@ private class MultiWorkerDispatcher(
     }
 
     override fun close() {
-        tasksAndWorkersCounter.getAndUpdate { if (it.isClosed()) it else it or 1L }
+        // the order is important: we don't want to end up with a non-empty channel because there are no workers
+        tasksQueue.close()
         val workers = workerPool.close() // no new workers will be created
-        while (true) {
-            // check if there are workers that await tasks in their personal channels, we need to wake them up
-            val state = tasksAndWorkersCounter.getAndUpdate {
-                if (it.hasWorkers()) it + 2 else it
-            }
-            if (!state.hasWorkers())
-                break
-            obtainWorker().cancel()
-        }
         /*
          * Here we cannot avoid waiting on `.result`, otherwise it will lead
          * to a native memory leak, including a pthread handle.
          */
         val requests = workers.map { it.requestTermination() }
-        requests.map { it.result }
-    }
-
-    private fun checkChannelResult(result: ChannelResult<*>) {
-        if (!result.isSuccess)
-            throw IllegalStateException(
-                "Internal invariants of $this were violated, please file a bug to kotlinx.coroutines",
-                result.exceptionOrNull()
-            )
+        requests.forEach { it.result }
     }
 }


### PR DESCRIPTION
Before, we used to duplicate the functionality of a `Channel` on top of using a `Channel`.
The algorithm is now simplified, stripping away that layer. Most notably, we no longer need to block the thread in a call to `dispatch` while waiting for a preempted worker thread to start its job. This improves liveness and saves us from the spooky action at a distance in sensitive parts of the codebase (#4215).