### PR TITLE
Replace AtomicFU atomic arrays with stdlib types

### DIFF
--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -2817,7 +2817,7 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     // ########################################
 
     internal fun storeElement(index: Int, element: E) {
-        setElement(index, element)
+        setElementLazy(index, element)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -2826,11 +2826,11 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     internal fun retrieveElement(index: Int): E = getElement(index).also { cleanElement(index) }
 
     internal fun cleanElement(index: Int) {
-        setElement(index, null)
+        setElementLazy(index, null)
     }
 
-    private fun setElement(index: Int, value: Any?) {
-        data.storeAt(index * 2, value)
+    private fun setElementLazy(index: Int, value: Any?) {
+        data.storeLazyAt(index * 2, value)
     }
 
     // ######################################

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -2817,7 +2817,7 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     // ########################################
 
     internal fun storeElement(index: Int, element: E) {
-        setElementLazy(index, element)
+        setElement(index, element)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -2826,10 +2826,10 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     internal fun retrieveElement(index: Int): E = getElement(index).also { cleanElement(index) }
 
     internal fun cleanElement(index: Int) {
-        setElementLazy(index, null)
+        setElement(index, null)
     }
 
-    private fun setElementLazy(index: Int, value: Any?) {
+    private fun setElement(index: Int, value: Any?) {
         data.storeAt(index * 2, value)
     }
 

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -2,7 +2,11 @@
 
 package kotlinx.coroutines.channels
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
+import kotlinx.atomicfu.loop
+import kotlinx.atomicfu.update
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ChannelResult.Companion.closed
 import kotlinx.coroutines.channels.ChannelResult.Companion.failure
@@ -10,6 +14,8 @@ import kotlinx.coroutines.channels.ChannelResult.Companion.success
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.*
 import kotlinx.coroutines.selects.TrySelectDetailedResult.*
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.atomicArrayOfNulls
 import kotlin.coroutines.*
 import kotlin.js.*
 import kotlin.jvm.*
@@ -347,7 +353,7 @@ internal open class BufferedChannel<E>(
         }
     }
 
-    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of these issues: KT-81416, KT-86264. 
+    // Note: this function is temporarily moved from ConflatedBufferedChannel to BufferedChannel class, because of these issues: KT-81416, KT-86264.
     // For now, an inline function, which invokes atomic operations, may only be called within a parent class.
     protected fun trySendDropOldest(element: E): ChannelResult<Unit> =
         sendImpl( // <-- this is an inline function
@@ -2798,6 +2804,7 @@ internal open class BufferedChannel<E>(
  * to update [BufferedChannel.sendSegment], [BufferedChannel.receiveSegment],
  * and [BufferedChannel.bufferEndSegment] correctly.
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: BufferedChannel<E>?, pointers: Int) : Segment<ChannelSegment<E>>(id, prev, pointers) {
     private val _channel: BufferedChannel<E>? = channel
     val channel get() = _channel!! // always non-null except for `NULL_SEGMENT`
@@ -2814,7 +2821,7 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     }
 
     @Suppress("UNCHECKED_CAST")
-    internal fun getElement(index: Int) = data[index * 2].value as E
+    internal fun getElement(index: Int) = data.loadAt(index * 2) as E
 
     internal fun retrieveElement(index: Int): E = getElement(index).also { cleanElement(index) }
 
@@ -2823,22 +2830,22 @@ internal class ChannelSegment<E>(id: Long, prev: ChannelSegment<E>?, channel: Bu
     }
 
     private fun setElementLazy(index: Int, value: Any?) {
-        data[index * 2].lazySet(value)
+        data.storeAt(index * 2, value)
     }
 
     // ######################################
     // # Manipulation with the State Fields #
     // ######################################
 
-    internal fun getState(index: Int): Any? = data[index * 2 + 1].value
+    internal fun getState(index: Int): Any? = data.loadAt(index * 2 + 1)
 
     internal fun setState(index: Int, value: Any?) {
-        data[index * 2 + 1].value = value
+        data.storeAt(index * 2 + 1, value)
     }
 
-    internal fun casState(index: Int, from: Any?, to: Any?) = data[index * 2 + 1].compareAndSet(from, to)
+    internal fun casState(index: Int, from: Any?, to: Any?) = data.compareAndSetAt(index * 2 + 1, from, to)
 
-    internal fun getAndSetState(index: Int, update: Any?) = data[index * 2 + 1].getAndSet(update)
+    internal fun getAndSetState(index: Int, update: Any?) = data.exchangeAt(index * 2 + 1, update)
 
 
     // ########################

--- a/kotlinx-coroutines-core/common/src/internal/LazyAtomicOperations.kt
+++ b/kotlinx-coroutines-core/common/src/internal/LazyAtomicOperations.kt
@@ -1,0 +1,7 @@
+package kotlinx.coroutines.internal
+
+import kotlin.concurrent.atomics.AtomicArray
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+@ExperimentalAtomicApi
+internal expect inline fun <T> AtomicArray<T>.storeLazyAt(index: Int, value: T)

--- a/kotlinx-coroutines-core/common/src/internal/LockFreeTaskQueue.kt
+++ b/kotlinx-coroutines-core/common/src/internal/LockFreeTaskQueue.kt
@@ -1,7 +1,12 @@
 package kotlinx.coroutines.internal
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.loop
+import kotlinx.atomicfu.update
+import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.*
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.atomicArrayOfNulls
 import kotlin.jvm.*
 
 private typealias Core<E> = LockFreeTaskQueueCore<E>
@@ -69,6 +74,7 @@ internal open class LockFreeTaskQueue<E : Any>(
  * Lock-free Multiply-Producer xxx-Consumer Queue core.
  * @see LockFreeTaskQueue
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class LockFreeTaskQueueCore<E : Any>(
     private val capacity: Int,
     private val singleConsumer: Boolean // true when there is only a single consumer (slightly faster)
@@ -107,7 +113,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
                 if ((tail + 2) and mask == head and mask) return ADD_FROZEN // overfull, so do freeze & copy
                 // If queue is Multi-Consumer then the consumer could still have not cleared element
                 // despite the above check for one free slot.
-                if (!singleConsumer && array[tail and mask].value != null) {
+                if (!singleConsumer && array.loadAt(tail and mask) != null) {
                     // There are two options in this situation
                     // 1. Spin-wait until consumer clears the slot
                     // 2. Freeze & resize to avoid spinning
@@ -122,7 +128,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
                 val newTail = (tail + 1) and MAX_CAPACITY_MASK
                 if (_state.compareAndSet(state, state.updateTail(newTail))) {
                     // successfully added
-                    array[tail and mask].value = element
+                    array.storeAt(tail and mask, element)
                     // could have been frozen & copied before this item was set -- correct it by filling placeholder
                     var cur = this
                     while(true) {
@@ -136,7 +142,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
     }
 
     private fun fillPlaceholder(index: Int, element: E): Core<E>? {
-        val old = array[index and mask].value
+        val old = array.loadAt(index and mask)
         /*
          * addLast actions:
          * 1) Commit tail slot
@@ -148,7 +154,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
          * perform *unique* check that current placeholder is our to avoid overwriting another producer placeholder
          */
         if (old is Placeholder && old.index == index) {
-            array[index and mask].value = element
+            array.storeAt(index and mask, element)
             // we've corrected missing element, should check if that propagated to further copies, just in case
             return this
         }
@@ -162,7 +168,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
             if (state and FROZEN_MASK != 0L) return REMOVE_FROZEN // frozen -- cannot modify
             state.withState { head, tail ->
                 if ((tail and mask) == (head and mask)) return null // empty
-                val element = array[head and mask].value
+                val element = array.loadAt(head and mask)
                 if (element == null) {
                     // If queue is Single-Consumer, then element == null only when add has not finished yet
                     if (singleConsumer) return null // consider it not added yet
@@ -176,7 +182,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
                 if (_state.compareAndSet(state, state.updateHead(newHead))) {
                     // Array could have been copied by another thread and it is perfectly fine, since only elements
                     // between head and tail were copied and there are no extra steps we should take here
-                    array[head and mask].value = null // now can safely put null (state was updated)
+                    array.storeAt(head and mask, null) // now can safely put null (state was updated)
                     return element // successfully removed in fast-path
                 }
                 // Multi-Consumer queue must retry this loop on CAS failure (another consumer might have removed element)
@@ -200,7 +206,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
                     return next() // continue to correct head in next
                 }
                 if (_state.compareAndSet(state, state.updateHead(newHead))) {
-                    array[head and mask].value = null // now can safely put null (state was updated)
+                    array.storeAt(head and mask, null) // now can safely put null (state was updated)
                     return null
                 }
             }
@@ -228,8 +234,8 @@ internal class LockFreeTaskQueueCore<E : Any>(
             var index = head
             while (index and mask != tail and mask) {
                 // replace nulls with placeholders on copy
-                val value = array[index and mask].value ?: Placeholder(index)
-                next.array[index and next.mask].value = value
+                val value = array.loadAt(index and mask) ?: Placeholder(index)
+                next.array.storeAt(index and next.mask, value)
                 index++
             }
             next._state.value = state wo FROZEN_MASK
@@ -244,7 +250,7 @@ internal class LockFreeTaskQueueCore<E : Any>(
             var index = head
             while (index and mask != tail and mask) {
                 // replace nulls with placeholders on copy
-                val element = array[index and mask].value
+                val element = array.loadAt(index and mask)
                 @Suppress("UNCHECKED_CAST")
                 if (element != null && element !is Placeholder) res.add(transform(element as E))
                 index++

--- a/kotlinx-coroutines-core/common/src/sync/Semaphore.kt
+++ b/kotlinx-coroutines-core/common/src/sync/Semaphore.kt
@@ -1,9 +1,12 @@
 package kotlinx.coroutines.sync
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.*
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.atomicArrayOfNulls
 import kotlin.contracts.*
 import kotlin.coroutines.*
 import kotlin.js.*
@@ -358,23 +361,24 @@ private class SemaphoreImpl(
 
 private fun createSegment(id: Long, prev: SemaphoreSegment?) = SemaphoreSegment(id, prev, 0)
 
+@OptIn(ExperimentalAtomicApi::class)
 private class SemaphoreSegment(id: Long, prev: SemaphoreSegment?, pointers: Int) : Segment<SemaphoreSegment>(id, prev, pointers) {
     val acquirers = atomicArrayOfNulls<Any?>(SEGMENT_SIZE)
     override val numberOfSlots: Int get() = SEGMENT_SIZE
 
     @Suppress("NOTHING_TO_INLINE")
-    inline fun get(index: Int): Any? = acquirers[index].value
+    inline fun get(index: Int): Any? = acquirers.loadAt(index)
 
     @Suppress("NOTHING_TO_INLINE")
     inline fun set(index: Int, value: Any?) {
-        acquirers[index].value = value
+        acquirers.storeAt(index, value)
     }
 
     @Suppress("NOTHING_TO_INLINE")
-    inline fun cas(index: Int, expected: Any?, value: Any?): Boolean = acquirers[index].compareAndSet(expected, value)
+    inline fun cas(index: Int, expected: Any?, value: Any?): Boolean = acquirers.compareAndSetAt(index, expected, value)
 
     @Suppress("NOTHING_TO_INLINE")
-    inline fun getAndSet(index: Int, value: Any?) = acquirers[index].getAndSet(value)
+    inline fun getAndSet(index: Int, value: Any?) = acquirers.exchangeAt(index, value)
 
     // Cleans the acquirer slot located by the specified index
     // and removes this segment physically if all slots are cleaned.

--- a/kotlinx-coroutines-core/concurrent/src/internal/OnDemandAllocatingPool.kt
+++ b/kotlinx-coroutines-core/concurrent/src/internal/OnDemandAllocatingPool.kt
@@ -1,6 +1,10 @@
 package kotlinx.coroutines.internal
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.loop
+import kotlin.concurrent.atomics.AtomicArray
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.atomicArrayOfNulls
 
 /**
  * A thread-safe resource pool.
@@ -11,6 +15,7 @@ import kotlinx.atomicfu.*
  * This is only used in the Native implementation,
  * but is part of the `concurrent` source set in order to test it on the JVM.
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class OnDemandAllocatingPool<T>(
     private val maxCapacity: Int,
     private val create: (Int) -> T
@@ -20,7 +25,8 @@ internal class OnDemandAllocatingPool<T>(
      * Once the flag is set, the value is guaranteed not to change anymore.
      */
     private val controlState = atomic(0)
-    private val elements = atomicArrayOfNulls<T>(maxCapacity)
+    @Suppress("UNCHECKED_CAST")
+    private val elements = atomicArrayOfNulls<Any>(maxCapacity) as AtomicArray<T?>
 
     /**
      * Returns the number of elements that need to be cleaned up due to the pool being closed.
@@ -50,7 +56,7 @@ internal class OnDemandAllocatingPool<T>(
             if (ctl.isClosed()) return false
             if (ctl >= maxCapacity) return true
             if (controlState.compareAndSet(ctl, ctl + 1)) {
-                elements[ctl].value = create(ctl)
+                elements.storeAt(ctl, create(ctl))
                 return true
             }
         }
@@ -73,7 +79,7 @@ internal class OnDemandAllocatingPool<T>(
         return (0 until elementsExisting).map { i ->
             // we wait for the element to be created, because we know that eventually it is going to be there
             loop {
-                val element = elements[i].getAndSet(null)
+                val element = elements.exchangeAt(i, null)
                 if (element != null) {
                     return@map element
                 }
@@ -84,7 +90,7 @@ internal class OnDemandAllocatingPool<T>(
     // for tests
     internal fun stateRepresentation(): String {
         val ctl = controlState.value
-        val elementsStr = (0 until (ctl and IS_CLOSED_MASK.inv())).map { elements[it].value }.toString()
+        val elementsStr = (0 until (ctl and IS_CLOSED_MASK.inv())).map { elements.loadAt(it) }.toString()
         val closedStr = if (ctl.isClosed()) "[closed]" else ""
         return elementsStr + closedStr
     }

--- a/kotlinx-coroutines-core/jsAndWasmShared/src/internal/LazyAtomicOperations.kt
+++ b/kotlinx-coroutines-core/jsAndWasmShared/src/internal/LazyAtomicOperations.kt
@@ -1,0 +1,8 @@
+package kotlinx.coroutines.internal
+
+import kotlin.concurrent.atomics.AtomicArray
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+@ExperimentalAtomicApi
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T> AtomicArray<T>.storeLazyAt(index: Int, value: T) = storeAt(index, value)

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/ConcurrentWeakMap.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/ConcurrentWeakMap.kt
@@ -1,9 +1,12 @@
 package kotlinx.coroutines.debug.internal
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import kotlinx.coroutines.internal.*
 import java.lang.ref.*
 import java.util.AbstractMap
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.atomicArrayOfNulls
 
 // This is very limited implementation, not suitable as a generic map replacement.
 // It has lock-free get and put with synchronized rehash for simplicity (and better CPU usage on contention)
@@ -78,6 +81,7 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
         core.value.cleanWeakRef(w)
     }
 
+    @OptIn(ExperimentalAtomicApi::class)
     @Suppress("UNCHECKED_CAST")
     private inner class Core(private val allocated: Int) {
         private val shift = allocated.countLeadingZeroBits() + 1
@@ -92,10 +96,10 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
         fun getImpl(key: K): V? {
             var index = index(key.hashCode())
             while (true) {
-                val w = keys[index].value ?: return null // not found
+                val w = keys.loadAt(index) ?: return null // not found
                 val k = w.get()
                 if (key == k) {
-                    val value = values[index].value
+                    val value = values.loadAt(index)
                     return (if (value is Marked) value.ref else value) as V?
                 }
                 if (k == null) removeCleanedAt(index) // weak ref was here, but collected
@@ -106,9 +110,9 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
 
         private fun removeCleanedAt(index: Int) {
             while (true) {
-                val oldValue = values[index].value ?: return // return when already removed
+                val oldValue = values.loadAt(index) ?: return // return when already removed
                 if (oldValue is Marked) return // cannot remove marked (rehash is working on it, will not copy)
-                if (values[index].compareAndSet(oldValue, null)) { // removed
+                if (values.compareAndSetAt(index, oldValue, null)) { // removed
                     decrementSize()
                     return
                 }
@@ -121,7 +125,7 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
             var loadIncremented = false
             var weakKey: HashedWeakRef<K>? = weakKey0
             while (true) {
-                val w = keys[index].value
+                val w = keys.loadAt(index)
                 if (w == null) { // slot empty => not found => try reserving slot
                     if (value == null) return null // removing missing value, nothing to do here
                     if (!loadIncremented) {
@@ -133,7 +137,7 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
                         loadIncremented = true
                     }
                     if (weakKey == null) weakKey = HashedWeakRef(key, weakRefQueue)
-                    if (keys[index].compareAndSet(null, weakKey)) break // slot reserved !!!
+                    if (keys.compareAndSetAt(index, null, weakKey)) break // slot reserved !!!
                     continue // retry at this slot on CAS failure (somebody already reserved this slot)
                 }
                 val k = w.get()
@@ -148,9 +152,9 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
             // update value
             var oldValue: Any?
             while (true) {
-                oldValue = values[index].value
+                oldValue = values.loadAt(index)
                 if (oldValue is Marked) return REHASH // rehash started, cannot work here
-                if (values[index].compareAndSet(oldValue, value)) break
+                if (values.compareAndSetAt(index, oldValue, value)) break
             }
             return oldValue as V?
         }
@@ -164,19 +168,19 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
                 val newCore = Core(newCapacity)
                 for (index in 0 until allocated) {
                     // load the key
-                    val w = keys[index].value
+                    val w = keys.loadAt(index)
                     val k = w?.get()
                     if (w != null && k == null) removeCleanedAt(index) // weak ref was here, but collected
                     // mark value so that it cannot be changed while we rehash to new core
                     var value: Any?
                     while (true) {
-                        value = values[index].value
+                        value = values.loadAt(index)
                         if (value is Marked) { // already marked -- good
                             value = value.ref
                             break
                         }
                         // try mark
-                        if (values[index].compareAndSet(value, value.mark())) break
+                        if (values.compareAndSetAt(index, value, value.mark())) break
                     }
                     if (k != null && value != null) {
                         val oldValue = newCore.putImpl(k, value as V, w)
@@ -191,7 +195,7 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
         fun cleanWeakRef(weakRef: HashedWeakRef<*>) {
             var index = index(weakRef.hash)
             while (true) {
-                val w = keys[index].value ?: return // return when slots are over
+                val w = keys.loadAt(index) ?: return // return when slots are over
                 if (w === weakRef) { // found
                     removeCleanedAt(index)
                     return
@@ -212,8 +216,8 @@ internal class ConcurrentWeakMap<K : Any, V: Any>(
 
             private fun findNext() {
                 while (++index < allocated) {
-                    key = keys[index].value?.get() ?: continue
-                    var value = values[index].value
+                    key = keys.loadAt(index)?.get() ?: continue
+                    var value = values.loadAt(index)
                     if (value is Marked) value = value.ref
                     if (value != null) {
                         this.value = value as V

--- a/kotlinx-coroutines-core/jvm/src/internal/LazyAtomicOperations.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/LazyAtomicOperations.kt
@@ -1,0 +1,13 @@
+package kotlinx.coroutines.internal
+
+import kotlin.concurrent.atomics.AtomicArray
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+@ExperimentalAtomicApi
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T> AtomicArray<T>.storeLazyAt(index: Int, value: T) {
+    @Suppress("UNCHECKED_CAST", "CAST_NEVER_SUCCEEDS")
+    // can't use asJavaAtomicArray due to a bug in older lincheck versions
+    this as java.util.concurrent.atomic.AtomicReferenceArray<T>
+    lazySet(index, value)
+}

--- a/kotlinx-coroutines-core/native/src/internal/LazyAtomicOperations.kt
+++ b/kotlinx-coroutines-core/native/src/internal/LazyAtomicOperations.kt
@@ -1,0 +1,8 @@
+package kotlinx.coroutines.internal
+
+import kotlin.concurrent.atomics.AtomicArray
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+@ExperimentalAtomicApi
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun <T> AtomicArray<T>.storeLazyAt(index: Int, value: T) = storeAt(index, value)

--- a/test-utils/concurrent/src/Barrier.kt
+++ b/test-utils/concurrent/src/Barrier.kt
@@ -2,8 +2,10 @@
 
 package kotlinx.coroutines.testing
 
-import kotlinx.atomicfu.*
+import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.*
+import kotlin.concurrent.atomics.atomicArrayOfNulls
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.*
 
 /**
@@ -12,6 +14,7 @@ import kotlin.time.*
  * Adapted from kotlinx-atomicfu
  * https://github.com/Kotlin/kotlinx-atomicfu/blob/d09c2b07cd16b0b273bd94edaa4929acd2ec42bc/atomicfu/src/concurrentTest/kotlin/kotlinx/atomicfu/locks/BarrierTest.kt#L60
  */
+@OptIn(ExperimentalAtomicApi::class)
 class Barrier(private val parties: Int) {
     init {
         require(parties > 1)
@@ -32,9 +35,9 @@ class Barrier(private val parties: Int) {
         // else myIndex < parties - 1, enqueue and park
         val currentThread = ParkingSupport.currentThreadHandle()
         while (true) {
-            val waiter = waiters[myIndex].value
+            val waiter = waiters.loadAt(myIndex)
             when {
-                waiter === null -> waiters[myIndex].compareAndSet(waiter, currentThread)
+                waiter === null -> waiters.compareAndSetAt(myIndex, waiter, currentThread)
                 waiter is ParkingHandle -> ParkingSupport.park(Duration.INFINITE)
                 waiter === FINISHED -> return
                 else -> error("Unreachable")
@@ -44,7 +47,7 @@ class Barrier(private val parties: Int) {
 
     fun checkTriggeredAndAllWokenUp() {
         for (i in 0..<parties - 1) {
-            val waiter = waiters[i].value
+            val waiter = waiters.loadAt(i)
             check(waiter === FINISHED) { "Thread #$i either never awaited or is still awaiting" }
         }
     }
@@ -52,8 +55,8 @@ class Barrier(private val parties: Int) {
     private fun wakeUpEveryone() {
         for (i in 0..<parties - 1) {
             while (true) {
-                val waiter = waiters[i].value
-                if (waiters[i].compareAndSet(waiter, FINISHED)) {
+                val waiter = waiters.loadAt(i)
+                if (waiters.compareAndSetAt(i, waiter, FINISHED)) {
                     if (waiter is ParkingHandle) {
                         ParkingSupport.unpark(waiter)
                     } else {


### PR DESCRIPTION
AtomicFU's array types are deprecated and barely supported by the compiler plugin. These types could be safely replaced with atomic array types from the stdlib.