### PR TITLE
Avoid costly stacktrace element initialization on the DebugProbes hot path

### DIFF
--- a/benchmarks/src/jmh/kotlin/benchmarks/debug/RedundantMaterializationOnResumeBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/debug/RedundantMaterializationOnResumeBenchmark.kt
@@ -1,0 +1,60 @@
+package benchmarks.debug
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.*
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.annotations.State
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+
+// IJPL-251805, KT-57634
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+open class RedundantMaterializationOnResumeBenchmark {
+
+    @Volatile
+    private var sink = 42 // prevent TCO
+
+    @Param("1", "10", "50")
+    private var depth: Int = 1
+
+    @Param("true", "false")
+    var withDebugger = false
+
+    @Setup
+    fun setup() {
+        DebugProbes.sanitizeStackTraces = false
+        DebugProbes.enableCreationStackTraces = false
+        if (withDebugger) {
+            DebugProbes.install()
+        }
+    }
+
+    @Benchmark
+    fun suspendFewTimes() = runBlocking {
+        repeat(100) {
+            recursion(depth)
+            sink = 239
+        }
+    }
+
+
+    suspend fun recursion(depth: Int) {
+        if (depth - 1 == 0) {
+            stateMachine()
+            sink = 42
+            return
+        }
+        recursion(depth - 1)
+        sink = 42
+    }
+
+    private suspend fun stateMachine() {
+        yield()
+        sink = 42
+    }
+}

--- a/benchmarks/src/jmh/kotlin/benchmarks/debug/RedundantMaterializationOnResumeBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/benchmarks/debug/RedundantMaterializationOnResumeBenchmark.kt
@@ -42,8 +42,7 @@ open class RedundantMaterializationOnResumeBenchmark {
         }
     }
 
-
-    suspend fun recursion(depth: Int) {
+    private suspend fun recursion(depth: Int) {
         if (depth - 1 == 0) {
             stateMachine()
             sink = 42

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -473,7 +473,9 @@ internal object DebugProbesImpl {
          * which tends to be unreasonably slow (KT-57634) because of reflection overhead. We don't need the line number
          * here or even a stacktrace element, we need only the marker it exists.
          * By its contract, BaseContinuationImpl always has one, so it's much (~x2) cheaper to check for the type
-         * rather than materializing StackTraceElement
+         * rather than materializing StackTraceElement.
+         *
+         * Can be removed when KT-43395 is implemented and widely adopted.
          */
         @Suppress("INVISIBLE_REFERENCE")
         return if (caller is BaseContinuationImpl || caller.getStackTraceElement() != null) caller else caller.realCaller()

--- a/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
+++ b/kotlinx-coroutines-core/jvm/src/debug/internal/DebugProbesImpl.kt
@@ -12,6 +12,7 @@ import kotlin.concurrent.*
 import kotlin.coroutines.*
 import kotlin.coroutines.jvm.internal.CoroutineStackFrame
 import kotlin.synchronized
+import kotlin.coroutines.jvm.internal.*
 import _COROUTINE.ArtificialStackFrames
 
 @PublishedApi
@@ -466,7 +467,16 @@ internal object DebugProbesImpl {
 
     private tailrec fun CoroutineStackFrame.realCaller(): CoroutineStackFrame? {
         val caller = callerFrame ?: return null
-        return if (caller.getStackTraceElement() != null) caller else caller.realCaller()
+        /*
+         * Kludge: suppress visibility for effectively public and stable stdlib API.
+         * getStackTraceElement() reflectively reads `label` from the compiler-generated continuation
+         * which tends to be unreasonably slow (KT-57634) because of reflection overhead. We don't need the line number
+         * here or even a stacktrace element, we need only the marker it exists.
+         * By its contract, BaseContinuationImpl always has one, so it's much (~x2) cheaper to check for the type
+         * rather than materializing StackTraceElement
+         */
+        @Suppress("INVISIBLE_REFERENCE")
+        return if (caller is BaseContinuationImpl || caller.getStackTraceElement() != null) caller else caller.realCaller()
     }
 
     private fun updateState(owner: CoroutineOwner<*>, frame: Continuation<*>, state: String) {


### PR DESCRIPTION
Use a hack to detect the type of the underlying continuation instead. It yields twice the performance and avoids reflective lookup to 'label' Field in DebugMetadataKt (KT-57634)