### PR TITLE
Make JS iteration over ReceiveChannel cancel iteration on early exits

### DIFF
--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.klib.api
@@ -196,6 +196,38 @@ abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ChannelIter
     open suspend fun next0(): #A // kotlinx.coroutines.channels/ChannelIterator.next0|next0(){}[0]
 }
 
+abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ReceiveChannel { // kotlinx.coroutines.channels/ReceiveChannel|null[0]
+    abstract val isClosedForReceive // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive|{}isClosedForReceive[0]
+        abstract fun <get-isClosedForReceive>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive.<get-isClosedForReceive>|<get-isClosedForReceive>(){}[0]
+    abstract val isEmpty // kotlinx.coroutines.channels/ReceiveChannel.isEmpty|{}isEmpty[0]
+        abstract fun <get-isEmpty>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isEmpty.<get-isEmpty>|<get-isEmpty>(){}[0]
+    abstract val onReceive // kotlinx.coroutines.channels/ReceiveChannel.onReceive|{}onReceive[0]
+        abstract fun <get-onReceive>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines.channels/ReceiveChannel.onReceive.<get-onReceive>|<get-onReceive>(){}[0]
+    abstract val onReceiveCatching // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching|{}onReceiveCatching[0]
+        abstract fun <get-onReceiveCatching>(): kotlinx.coroutines.selects/SelectClause1<kotlinx.coroutines.channels/ChannelResult<#A>> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching.<get-onReceiveCatching>|<get-onReceiveCatching>(){}[0]
+    open val onReceiveOrNull // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull|{}onReceiveOrNull[0]
+        open fun <get-onReceiveOrNull>(): kotlinx.coroutines.selects/SelectClause1<#A?> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull.<get-onReceiveOrNull>|<get-onReceiveOrNull>(){}[0]
+
+    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
+    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.Throwable?){}[0]
+    abstract fun iterator(): kotlinx.coroutines.channels/ChannelIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.iterator|iterator(){}[0]
+    abstract fun tryReceive(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.tryReceive|tryReceive(){}[0]
+    abstract suspend fun receive(): #A // kotlinx.coroutines.channels/ReceiveChannel.receive|receive(){}[0]
+    abstract suspend fun receiveCatching(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.receiveCatching|receiveCatching(){}[0]
+    open fun cancel() // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(){}[0]
+    open fun poll(): #A? // kotlinx.coroutines.channels/ReceiveChannel.poll|poll(){}[0]
+    open suspend fun receiveOrNull(): #A? // kotlinx.coroutines.channels/ReceiveChannel.receiveOrNull|receiveOrNull(){}[0]
+
+    // Targets: [js]
+    open fun asyncIterator(): kotlinx.coroutines.channels/JsAsyncIterableIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.asyncIterator|asyncIterator(){}[0]
+
+    // Targets: [js]
+    open fun asyncIterator(kotlin/Boolean = ...): kotlinx.coroutines.channels/JsAsyncIterableIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.asyncIterator|asyncIterator(kotlin.Boolean){}[0]
+
+    // Targets: [js]
+    open fun asyncIterator(kotlinx.coroutines.channels/ChannelIteratorOptions? = ...): kotlinx.coroutines.channels/JsAsyncIterableIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.asyncIterator|asyncIterator(kotlinx.coroutines.channels.ChannelIteratorOptions?){}[0]
+}
+
 abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.flow/Flow { // kotlinx.coroutines.flow/Flow|null[0]
     abstract suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // kotlinx.coroutines.flow/Flow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
 }
@@ -1158,30 +1190,6 @@ final suspend inline fun <#A: kotlin/Any?> kotlinx.coroutines/suspendCancellable
 final suspend inline fun kotlinx.coroutines.selects/whileSelect(crossinline kotlin/Function1<kotlinx.coroutines.selects/SelectBuilder<kotlin/Boolean>, kotlin/Unit>) // kotlinx.coroutines.selects/whileSelect|whileSelect(kotlin.Function1<kotlinx.coroutines.selects.SelectBuilder<kotlin.Boolean>,kotlin.Unit>){}[0]
 final suspend inline fun kotlinx.coroutines/currentCoroutineContext(): kotlin.coroutines/CoroutineContext // kotlinx.coroutines/currentCoroutineContext|currentCoroutineContext(){}[0]
 
-// Targets: [native, wasmJs, wasmWasi]
-abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ReceiveChannel { // kotlinx.coroutines.channels/ReceiveChannel|null[0]
-    abstract val isClosedForReceive // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive|{}isClosedForReceive[0]
-        abstract fun <get-isClosedForReceive>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive.<get-isClosedForReceive>|<get-isClosedForReceive>(){}[0]
-    abstract val isEmpty // kotlinx.coroutines.channels/ReceiveChannel.isEmpty|{}isEmpty[0]
-        abstract fun <get-isEmpty>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isEmpty.<get-isEmpty>|<get-isEmpty>(){}[0]
-    abstract val onReceive // kotlinx.coroutines.channels/ReceiveChannel.onReceive|{}onReceive[0]
-        abstract fun <get-onReceive>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines.channels/ReceiveChannel.onReceive.<get-onReceive>|<get-onReceive>(){}[0]
-    abstract val onReceiveCatching // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching|{}onReceiveCatching[0]
-        abstract fun <get-onReceiveCatching>(): kotlinx.coroutines.selects/SelectClause1<kotlinx.coroutines.channels/ChannelResult<#A>> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching.<get-onReceiveCatching>|<get-onReceiveCatching>(){}[0]
-    open val onReceiveOrNull // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull|{}onReceiveOrNull[0]
-        open fun <get-onReceiveOrNull>(): kotlinx.coroutines.selects/SelectClause1<#A?> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull.<get-onReceiveOrNull>|<get-onReceiveOrNull>(){}[0]
-
-    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.Throwable?){}[0]
-    abstract fun iterator(): kotlinx.coroutines.channels/ChannelIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.iterator|iterator(){}[0]
-    abstract fun tryReceive(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.tryReceive|tryReceive(){}[0]
-    abstract suspend fun receive(): #A // kotlinx.coroutines.channels/ReceiveChannel.receive|receive(){}[0]
-    abstract suspend fun receiveCatching(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.receiveCatching|receiveCatching(){}[0]
-    open fun cancel() // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(){}[0]
-    open fun poll(): #A? // kotlinx.coroutines.channels/ReceiveChannel.poll|poll(){}[0]
-    open suspend fun receiveOrNull(): #A? // kotlinx.coroutines.channels/ReceiveChannel.receiveOrNull|receiveOrNull(){}[0]
-}
-
 // Targets: [native]
 open class <#A: kotlin/Comparable<#A> & kotlinx.coroutines.internal/ThreadSafeHeapNode> kotlinx.coroutines.internal/ThreadSafeHeap : kotlinx.atomicfu.locks/SynchronizedObject { // kotlinx.coroutines.internal/ThreadSafeHeap|null[0]
     constructor <init>() // kotlinx.coroutines.internal/ThreadSafeHeap.<init>|<init>(){}[0]
@@ -1263,28 +1271,9 @@ final inline fun <#A: kotlin/Any?> kotlinx.coroutines.internal/synchronized(kotl
 final inline fun <#A: kotlin/Any?> kotlinx.coroutines.internal/synchronizedImpl(kotlinx.coroutines.internal/SynchronizedObject, kotlin/Function0<#A>): #A // kotlinx.coroutines.internal/synchronizedImpl|synchronizedImpl(kotlinx.coroutines.internal.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 
 // Targets: [js]
-abstract interface <#A: out kotlin/Any?> kotlinx.coroutines.channels/ReceiveChannel : kotlinx.coroutines.channels/JsAsyncIterable<#A> { // kotlinx.coroutines.channels/ReceiveChannel|null[0]
-    abstract val isClosedForReceive // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive|{}isClosedForReceive[0]
-        abstract fun <get-isClosedForReceive>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isClosedForReceive.<get-isClosedForReceive>|<get-isClosedForReceive>(){}[0]
-    abstract val isEmpty // kotlinx.coroutines.channels/ReceiveChannel.isEmpty|{}isEmpty[0]
-        abstract fun <get-isEmpty>(): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.isEmpty.<get-isEmpty>|<get-isEmpty>(){}[0]
-    abstract val onReceive // kotlinx.coroutines.channels/ReceiveChannel.onReceive|{}onReceive[0]
-        abstract fun <get-onReceive>(): kotlinx.coroutines.selects/SelectClause1<#A> // kotlinx.coroutines.channels/ReceiveChannel.onReceive.<get-onReceive>|<get-onReceive>(){}[0]
-    abstract val onReceiveCatching // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching|{}onReceiveCatching[0]
-        abstract fun <get-onReceiveCatching>(): kotlinx.coroutines.selects/SelectClause1<kotlinx.coroutines.channels/ChannelResult<#A>> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveCatching.<get-onReceiveCatching>|<get-onReceiveCatching>(){}[0]
-    open val onReceiveOrNull // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull|{}onReceiveOrNull[0]
-        open fun <get-onReceiveOrNull>(): kotlinx.coroutines.selects/SelectClause1<#A?> // kotlinx.coroutines.channels/ReceiveChannel.onReceiveOrNull.<get-onReceiveOrNull>|<get-onReceiveOrNull>(){}[0]
-
-    abstract fun cancel(kotlin.coroutines.cancellation/CancellationException? = ...) // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.coroutines.cancellation.CancellationException?){}[0]
-    abstract fun cancel(kotlin/Throwable? = ...): kotlin/Boolean // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(kotlin.Throwable?){}[0]
-    abstract fun iterator(): kotlinx.coroutines.channels/ChannelIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.iterator|iterator(){}[0]
-    abstract fun tryReceive(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.tryReceive|tryReceive(){}[0]
-    abstract suspend fun receive(): #A // kotlinx.coroutines.channels/ReceiveChannel.receive|receive(){}[0]
-    abstract suspend fun receiveCatching(): kotlinx.coroutines.channels/ChannelResult<#A> // kotlinx.coroutines.channels/ReceiveChannel.receiveCatching|receiveCatching(){}[0]
-    open fun asyncIterator(): kotlinx.coroutines.channels/JsAsyncIterator<#A> // kotlinx.coroutines.channels/ReceiveChannel.asyncIterator|asyncIterator(){}[0]
-    open fun cancel() // kotlinx.coroutines.channels/ReceiveChannel.cancel|cancel(){}[0]
-    open fun poll(): #A? // kotlinx.coroutines.channels/ReceiveChannel.poll|poll(){}[0]
-    open suspend fun receiveOrNull(): #A? // kotlinx.coroutines.channels/ReceiveChannel.receiveOrNull|receiveOrNull(){}[0]
+abstract interface kotlinx.coroutines.channels/ChannelIteratorOptions { // kotlinx.coroutines.channels/ChannelIteratorOptions|null[0]
+    abstract val preventCancel // kotlinx.coroutines.channels/ChannelIteratorOptions.preventCancel|{}preventCancel[0]
+        abstract fun <get-preventCancel>(): kotlin/Boolean? // kotlinx.coroutines.channels/ChannelIteratorOptions.preventCancel.<get-preventCancel>|<get-preventCancel>(){}[0]
 }
 
 // Targets: [js]
@@ -1301,6 +1290,12 @@ final fun <#A: kotlin/Any?> (kotlinx.coroutines/CoroutineScope).kotlinx.coroutin
 
 // Targets: [js]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines/Deferred<#A>).kotlinx.coroutines/asPromise(): kotlin.js/Promise<#A> // kotlinx.coroutines/asPromise|asPromise@kotlinx.coroutines.Deferred<0:0>(){0§<kotlin.Any?>}[0]
+
+// Targets: [js]
+final inline fun <#A: out kotlin/Any?> kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_copy_1tks5(noinline kotlinx.coroutines.channels/JsAsyncIterableIterator<#A>, noinline kotlin/Function0<kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ..., noinline kotlin/Function1<#A?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ..., noinline kotlin/Function1<kotlin/Any?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ...): kotlinx.coroutines.channels/JsAsyncIterableIterator<#A> // kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_copy_1tks5|kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_copy_1tks5(kotlinx.coroutines.channels.JsAsyncIterableIterator<0:0>;kotlin.Function0<kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<0:0?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<kotlin.Any?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>){0§<kotlin.Any?>}[0]
+
+// Targets: [js]
+final inline fun <#A: out kotlin/Any?> kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_invoke_jkqnwo(noinline kotlin/Function0<kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>>, noinline kotlin/Function1<#A?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>>, noinline kotlin/Function1<kotlin/Any?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>>): kotlinx.coroutines.channels/JsAsyncIterableIterator<#A> // kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_invoke_jkqnwo|kotlinx_coroutines_channels_JsAsyncIterableIterator_Companion_xrml8x_invoke_jkqnwo(kotlin.Function0<kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<0:0?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<kotlin.Any?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>){0§<kotlin.Any?>}[0]
 
 // Targets: [js]
 final inline fun <#A: out kotlin/Any?> kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterator_Companion_btfdib_copy_1tks5(noinline kotlinx.coroutines.channels/JsAsyncIterator<#A>, noinline kotlin/Function0<kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ..., noinline kotlin/Function1<#A?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ..., noinline kotlin/Function1<kotlin/Any?, kotlin.js/Promise<kotlinx.coroutines.channels/JsIteratorResult<#A>>> = ...): kotlinx.coroutines.channels/JsAsyncIterator<#A> // kotlinx.coroutines.channels/kotlinx_coroutines_channels_JsAsyncIterator_Companion_btfdib_copy_1tks5|kotlinx_coroutines_channels_JsAsyncIterator_Companion_btfdib_copy_1tks5(kotlinx.coroutines.channels.JsAsyncIterator<0:0>;kotlin.Function0<kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<0:0?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>;kotlin.Function1<kotlin.Any?,kotlin.js.Promise<kotlinx.coroutines.channels.JsIteratorResult<0:0>>>){0§<kotlin.Any?>}[0]

--- a/kotlinx-coroutines-core/js/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/js/src/channels/Channel.kt
@@ -23,7 +23,7 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
      * Returns a JavaScript `AsyncIterator` for this channel.
      *
      * This method is used to implement the JavaScript async-iteration protocol, so that a
-     * `ReceiveChannel` exported to JavaScript can be consumed with `for await ... of`.
+     * `ReceiveChannel` exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
      *
      * Each call to the iterator's `next` method receives at most one element from this channel:
      *
@@ -35,15 +35,18 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
      *   cause.
      *
      * Calling the iterator's `return` method finishes this iterator instance and returns a fulfilled
-     * `Promise` with `done` set to `true`. It does not cancel the underlying channel.
+     * `Promise` with `done` set to `true`. It [cancels][ReceiveChannel.cancel] the channel without a `cause`.
      *
      * Calling the iterator's `throw` method finishes this iterator instance and returns a rejected
-     * `Promise` with the supplied error. It does not cancel the underlying channel.
+     * `Promise` with the supplied error. It [cancels][ReceiveChannel.cancel] the channel
+     * with the `cause` of the [CancellationException] being set to the exception provided to `throw`.
      *
      * The coroutines backing calls to `next` are started in [GlobalScope].
      * In particular, they are not children of any caller-provided coroutine
      * scope and therefore are not bound to the lifetime of any structured-concurrency scope.
      */
+    @OptIn(ExperimentalWasmJsInterop::class)
+    @ExperimentalCoroutinesApi
     override fun asyncIterator(): JsAsyncIterator<E> {
         var wasEarlyFinished = false
         return JsAsyncIterator(
@@ -65,10 +68,16 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#description
             `return` = { value: E? ->
                 wasEarlyFinished = true
+                cancel()
                 Promise.resolve(JsIteratorResult(value = value, done = true))
             },
             `throw` = { err: dynamic ->
                 wasEarlyFinished = true
+                val cause = err.unsafeCast<JsPromiseError>().toThrowableOrNull()
+                /** Adapted from [ReceiveChannel.cancelConsumed] */
+                cancel(cause?.let {
+                    it as? CancellationException ?: CancellationException("Channel was closed via AsyncIterator#throw method", it)
+                })
                 Promise.reject(err)
             }
         )

--- a/kotlinx-coroutines-core/js/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/js/src/channels/Channel.kt
@@ -1,5 +1,5 @@
 @file:OptIn(ExperimentalJsExport::class, ExperimentalStdlibApi::class)
-@file:Suppress("EXPOSED_FUNCTION_RETURN_TYPE", "INVISIBLE_REFERENCE", "EXPOSED_SUPER_INTERFACE")
+@file:Suppress("EXPOSED_FUNCTION_RETURN_TYPE", "INVISIBLE_REFERENCE", "EXPOSED_SUPER_INTERFACE", "EXPOSED_PARAMETER_TYPE")
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
@@ -20,10 +20,53 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
     public actual fun cancel(cause: CancellationException?)
 
     /**
-     * Returns a JavaScript `AsyncIterator` for this channel.
+     * Returns an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) view of this channel.
      *
-     * This method is used to implement the JavaScript async-iteration protocol, so that a
-     * `ReceiveChannel` exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
+     * Each iteration request ([`[Symbol.asyncIterator]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)) creates a new [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) backed by this
+     * channel. The resulting iterable can be consumed with JavaScript `for await ... of` and with APIs
+     * that expect the async-iterable protocol.
+     *
+     * When iteration exits early (for example via loop `break`/`return`/`throw`, or by calling iterator methods `return`/`throw` directly),
+     * the channel is canceled by default.
+     *
+     * @param cancelOnEarlyExit if `true` (default), early iterator completion cancels the channel;
+     * if `false`, early iterator completion does not cancel the channel.
+     */
+    @JsExport.Ignore
+    @ExperimentalCoroutinesApi
+    public fun asAsyncIterable(cancelOnEarlyExit: Boolean = true): JsAsyncIterable<E> {
+        // We don't use Kotlin object to not have logic around lazy initialization
+        val jsObject = js("{}")
+        val asyncIteratorFunction: () -> JsAsyncIterator<E> = { asyncIterator(cancelOnEarlyExit) }
+        jsObject[js("Symbol.asyncIterator")] = asyncIteratorFunction
+        return jsObject
+    }
+
+    /**
+     * Returns an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) view of this channel.
+     *
+     * Each iteration request ([`[Symbol.asyncIterator]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)) creates a new [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) backed by this
+     * channel. The resulting iterable can be consumed with JavaScript `for await ... of` and with APIs
+     * that expect [the async-iterable protocol]((https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols).
+     *
+     * When iteration exits early (for example via loop `break`/`return`/`throw`, or by calling iterator methods `return`/`throw` directly),
+     * the channel is canceled by default.
+     *
+     * @param options iteration behavior options:
+     * - `preventCancel = true`: early iterator completion does not cancel the channel;
+     * - `preventCancel = false` or omitted: early iterator completion cancels the channel.
+     */
+    @ExperimentalCoroutinesApi
+    // We can't use DeprecationLevel.HIDDEN, because the generated declaration will also be deprecated in .d.ts
+    @LowPriorityInOverloadResolution
+    public fun asAsyncIterable(options: ChannelIteratorOptions): JsAsyncIterable<E> =
+        asAsyncIterable(cancelOnEarlyExit = options.preventCancel != true)
+
+    /**
+     * Returns an [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     *
+     * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
+     * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
      *
      * Each call to the iterator's `next` method receives at most one element from this channel:
      *
@@ -35,19 +78,93 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
      *   cause.
      *
      * Calling the iterator's `return` method finishes this iterator instance and returns a fulfilled
-     * `Promise` with `done` set to `true`. It [cancels][ReceiveChannel.cancel] the channel without a `cause`.
+     * `Promise` with `done` set to `true`. By default, it [cancels][ReceiveChannel.cancel] the channel without a `cause`.
      *
      * Calling the iterator's `throw` method finishes this iterator instance and returns a rejected
-     * `Promise` with the supplied error. It [cancels][ReceiveChannel.cancel] the channel
+     * `Promise` with the supplied error. By default, it [cancels][ReceiveChannel.cancel] the channel
      * with the `cause` of the [CancellationException] being set to the exception provided to `throw`.
+     *
+     * To change the default cancallation behavior, use [values] method with `{ preventCancel: false }` (in JavaScript/TypeScript)
+     * or `asyncIterator(cancelOnEarlyExit = false)` (in Kotlin) instead.
      *
      * The coroutines backing calls to `next` are started in [GlobalScope].
      * In particular, they are not children of any caller-provided coroutine
      * scope and therefore are not bound to the lifetime of any structured-concurrency scope.
      */
-    @OptIn(ExperimentalWasmJsInterop::class)
     @ExperimentalCoroutinesApi
-    override fun asyncIterator(): JsAsyncIterator<E> {
+    override fun asyncIterator(): JsAsyncIterator<E> =
+        asyncIterator(cancelOnEarlyExit = true)
+
+    /**
+     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     *
+     * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
+     * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
+     *
+     * Each call to the iterator's `next` method receives at most one element from this channel:
+     *
+     * - if an element is available, the returned `Promise` is fulfilled with an iterator result
+     *   whose `value` is the received element and whose `done` is `false`;
+     * - if the channel is closed normally, or is cancelled with a [CancellationException], the
+     *   returned `Promise` is fulfilled with an iterator result whose `done` is `true`;
+     * - if the channel is closed with another cause, the returned `Promise` is rejected with that
+     *   cause.
+     *
+     * Calling the iterator's `return` method finishes this iterator instance and returns a fulfilled
+     * `Promise` with `done` set to `true`. By default, it [cancels][ReceiveChannel.cancel] the channel without a `cause`.
+     *
+     * Calling the iterator's `throw` method finishes this iterator instance and returns a rejected
+     * `Promise` with the supplied error. By default, it [cancels][ReceiveChannel.cancel] the channel
+     * with the `cause` of the [CancellationException] being set to the exception provided to `throw`.
+     *
+     * The coroutines backing calls to `next` are started in [GlobalScope].
+     * In particular, they are not children of any caller-provided coroutine
+     * scope and therefore are not bound to the lifetime of any structured-concurrency scope.
+     *
+     * @param options iteration behavior options:
+     * - `preventCancel = true`: early iterator completion does not cancel the channel;
+     * - `preventCancel = false` or omitted: early iterator completion cancels the channel.
+     */
+    @ExperimentalCoroutinesApi
+    // We can't use DeprecationLevel.HIDDEN, because the generated declaration will also be deprecated in .d.ts
+    @LowPriorityInOverloadResolution
+    @JsName("values") // We use "values" here to mimic the ReadableStream API: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+    public fun asyncIterator(options: ChannelIteratorOptions): JsAsyncIterator<E> =
+        asyncIterator(options.preventCancel != true)
+
+    /**
+     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     *
+     * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
+     * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
+     *
+     * Each call to the iterator's `next` method receives at most one element from this channel:
+     *
+     * - if an element is available, the returned `Promise` is fulfilled with an iterator result
+     *   whose `value` is the received element and whose `done` is `false`;
+     * - if the channel is closed normally, or is cancelled with a [CancellationException], the
+     *   returned `Promise` is fulfilled with an iterator result whose `done` is `true`;
+     * - if the channel is closed with another cause, the returned `Promise` is rejected with that
+     *   cause.
+     *
+     * Calling the iterator's `return` method finishes this iterator instance and returns a fulfilled
+     * `Promise` with `done` set to `true`. By default, it [cancels][ReceiveChannel.cancel] the channel without a `cause`.
+     *
+     * Calling the iterator's `throw` method finishes this iterator instance and returns a rejected
+     * `Promise` with the supplied error. By default, it [cancels][ReceiveChannel.cancel] the channel
+     * with the `cause` of the [CancellationException] being set to the exception provided to `throw`.
+     *
+     * The coroutines backing calls to `next` are started in [GlobalScope].
+     * In particular, they are not children of any caller-provided coroutine
+     * scope and therefore are not bound to the lifetime of any structured-concurrency scope.
+     *
+     * @param cancelOnEarlyExit if `true` (default), calling iterator `return`/`throw` cancels the channel;
+     * if `false`, early iterator completion does not cancel the channel.
+     */
+    @JsExport.Ignore
+    @ExperimentalCoroutinesApi
+    @OptIn(ExperimentalWasmJsInterop::class)
+    public fun asyncIterator(cancelOnEarlyExit: Boolean = true): JsAsyncIterator<E> {
         var wasEarlyFinished = false
         return JsAsyncIterator(
             next = {
@@ -68,16 +185,18 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#description
             `return` = { value: E? ->
                 wasEarlyFinished = true
-                cancel()
+                if (cancelOnEarlyExit) cancel()
                 Promise.resolve(JsIteratorResult(value = value, done = true))
             },
             `throw` = { err: dynamic ->
                 wasEarlyFinished = true
                 val cause = err.unsafeCast<JsPromiseError>().toThrowableOrNull()
-                /** Adapted from [ReceiveChannel.cancelConsumed] */
-                cancel(cause?.let {
-                    it as? CancellationException ?: CancellationException("Channel was closed via AsyncIterator#throw method", it)
-                })
+                if (cancelOnEarlyExit) {
+                    /** Adapted from [ReceiveChannel.cancelConsumed] */
+                    cancel(cause?.let {
+                        it as? CancellationException ?: CancellationException("Channel was closed via AsyncIterator#throw method", it)
+                    })
+                }
                 Promise.reject(err)
             }
         )
@@ -155,6 +274,24 @@ internal external interface JsAsyncIterator<out T> {
     // `return` and `throw` must be able to accept either zero arguments or a single one
     public val `return`: (value: @UnsafeVariance T?) -> Promise<JsIteratorResult<T>>
     public val `throw`: (value: Any?) -> Promise<JsIteratorResult<T>>
+}
+
+/**
+ * Options for customizing channel async-iteration behavior.
+ */
+@JsImplicitExport(couldBeConvertedToExplicitExport = true)
+@JsPlainObject
+internal external interface ChannelIteratorOptions {
+    /**
+     * Controls whether the channel is canceled when iteration completes early.
+     *
+     * Equivalent TypeScript shape: `preventCancel?: boolean`.
+     * Default is `false` when omitted.
+     *
+     * - `true`: do not cancel the channel on early iterator completion.
+     * - `false` or omitted: cancel the channel on early iterator completion.
+     */
+    val preventCancel: Boolean?
 }
 
 @JsPlainObject

--- a/kotlinx-coroutines-core/js/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/js/src/channels/Channel.kt
@@ -88,6 +88,7 @@ public actual interface ReceiveChannel<out E> {
      */
     @JsName("values") // We use "values" here to mimic the ReadableStream API: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
     @Deprecated(message = "", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION_ERROR")
     public fun asyncIterator(options: ChannelIteratorOptions? = null): JsAsyncIterableIterator<E> =
         asyncIterator(options?.preventCancel != true)
 
@@ -243,7 +244,7 @@ internal external interface JsAsyncIterator<out T> {
  * Options for customizing channel async-iteration behavior.
  */
 @JsExport
-@JsPlainObject
+@Deprecated(message = "", level = DeprecationLevel.HIDDEN)
 public external interface ChannelIteratorOptions {
     /**
      * Controls whether the channel is canceled when iteration completes early.

--- a/kotlinx-coroutines-core/js/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/js/src/channels/Channel.kt
@@ -10,60 +10,17 @@ import kotlin.internal.*
 import kotlin.js.Promise
 
 @JsImplicitExport(couldBeConvertedToExplicitExport = true)
-public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
+public actual interface ReceiveChannel<out E> {
     @DelicateCoroutinesApi
     public actual val isClosedForReceive: Boolean
     @ExperimentalCoroutinesApi
     public actual val isEmpty: Boolean
 
-    public actual suspend fun receive(): E
     public actual fun cancel(cause: CancellationException?)
 
     /**
-     * Returns an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) view of this channel.
-     *
-     * Each iteration request ([`[Symbol.asyncIterator]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)) creates a new [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) backed by this
-     * channel. The resulting iterable can be consumed with JavaScript `for await ... of` and with APIs
-     * that expect the async-iterable protocol.
-     *
-     * When iteration exits early (for example via loop `break`/`return`/`throw`, or by calling iterator methods `return`/`throw` directly),
-     * the channel is canceled by default.
-     *
-     * @param cancelOnEarlyExit if `true` (default), early iterator completion cancels the channel;
-     * if `false`, early iterator completion does not cancel the channel.
-     */
-    @JsExport.Ignore
-    @ExperimentalCoroutinesApi
-    public fun asAsyncIterable(cancelOnEarlyExit: Boolean = true): JsAsyncIterable<E> {
-        // We don't use Kotlin object to not have logic around lazy initialization
-        val jsObject = js("{}")
-        val asyncIteratorFunction: () -> JsAsyncIterator<E> = { asyncIterator(cancelOnEarlyExit) }
-        jsObject[js("Symbol.asyncIterator")] = asyncIteratorFunction
-        return jsObject
-    }
-
-    /**
-     * Returns an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) view of this channel.
-     *
-     * Each iteration request ([`[Symbol.asyncIterator]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)) creates a new [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) backed by this
-     * channel. The resulting iterable can be consumed with JavaScript `for await ... of` and with APIs
-     * that expect [the async-iterable protocol]((https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols).
-     *
-     * When iteration exits early (for example via loop `break`/`return`/`throw`, or by calling iterator methods `return`/`throw` directly),
-     * the channel is canceled by default.
-     *
-     * @param options iteration behavior options:
-     * - `preventCancel = true`: early iterator completion does not cancel the channel;
-     * - `preventCancel = false` or omitted: early iterator completion cancels the channel.
-     */
-    @ExperimentalCoroutinesApi
-    // We can't use DeprecationLevel.HIDDEN, because the generated declaration will also be deprecated in .d.ts
-    @LowPriorityInOverloadResolution
-    public fun asAsyncIterable(options: ChannelIteratorOptions): JsAsyncIterable<E> =
-        asAsyncIterable(cancelOnEarlyExit = options.preventCancel != true)
-
-    /**
-     * Returns an [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+     * (which is also `AsyncIterable`, see [AsyncIterableIterator](https://github.com/microsoft/TypeScript/blob/6ef3b2ce767ed0d93557c745b896e2b10178c4f5/tsc/internal/bundled/libs/lib.es2018.asynciterable.d.ts#L42)) for this channel.
      *
      * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
      * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
@@ -92,11 +49,13 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
      * scope and therefore are not bound to the lifetime of any structured-concurrency scope.
      */
     @ExperimentalCoroutinesApi
-    override fun asyncIterator(): JsAsyncIterator<E> =
+    @JsSymbol("asyncIterator")
+    public fun asyncIterator(): JsAsyncIterableIterator<E> =
         asyncIterator(cancelOnEarlyExit = true)
 
     /**
-     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+     * (which is also `AsyncIterable`, see [AsyncIterableIterator](https://github.com/microsoft/TypeScript/blob/6ef3b2ce767ed0d93557c745b896e2b10178c4f5/tsc/internal/bundled/libs/lib.es2018.asynciterable.d.ts#L42)) for this channel.
      *
      * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
      * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
@@ -124,16 +83,17 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
      * @param options iteration behavior options:
      * - `preventCancel = true`: early iterator completion does not cancel the channel;
      * - `preventCancel = false` or omitted: early iterator completion cancels the channel.
+     *
+     * @suppress
      */
-    @ExperimentalCoroutinesApi
-    // We can't use DeprecationLevel.HIDDEN, because the generated declaration will also be deprecated in .d.ts
-    @LowPriorityInOverloadResolution
     @JsName("values") // We use "values" here to mimic the ReadableStream API: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
-    public fun asyncIterator(options: ChannelIteratorOptions): JsAsyncIterator<E> =
-        asyncIterator(options.preventCancel != true)
+    @Deprecated(message = "", level = DeprecationLevel.HIDDEN)
+    public fun asyncIterator(options: ChannelIteratorOptions? = null): JsAsyncIterableIterator<E> =
+        asyncIterator(options?.preventCancel != true)
 
     /**
-     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) for this channel.
+     * Returns a JavaScript [`AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+     * (which is also `AsyncIterable`, see [AsyncIterableIterator](https://github.com/microsoft/TypeScript/blob/6ef3b2ce767ed0d93557c745b896e2b10178c4f5/tsc/internal/bundled/libs/lib.es2018.asynciterable.d.ts#L42)) for this channel.
      *
      * This method is used to implement the JavaScript async-iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), so that the
      * channel exported to JavaScript can be [consumed][Channel.consume] with `for await ... of`.
@@ -164,9 +124,9 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
     @JsExport.Ignore
     @ExperimentalCoroutinesApi
     @OptIn(ExperimentalWasmJsInterop::class)
-    public fun asyncIterator(cancelOnEarlyExit: Boolean = true): JsAsyncIterator<E> {
+    public fun asyncIterator(cancelOnEarlyExit: Boolean = true): JsAsyncIterableIterator<E> {
         var wasEarlyFinished = false
-        return JsAsyncIterator(
+        val iterator = JsAsyncIterator(
             next = {
                 GlobalScope.promise {
                     if (wasEarlyFinished) return@promise JsIteratorResult(done = true)
@@ -200,6 +160,8 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
                 Promise.reject(err)
             }
         )
+        iterator.asDynamic()[js("Symbol.asyncIterator")] = { iterator }
+        return iterator.unsafeCast<JsAsyncIterableIterator<E>>()
     }
 
     @JsExport.Ignore // Is replaced by AsyncIterable implementation
@@ -207,6 +169,9 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
 
     @JsExport.Ignore // Can't be exported until the compiler supports exporting of value classes
     public actual fun tryReceive(): ChannelResult<E>
+
+    @JsExport.Ignore // Exporting a suspend function by JsImplicitExport is a bit broken till 2.5.0
+    public actual suspend fun receive(): E
 
     @JsExport.Ignore // Can't be exported until the compiler supports exporting of value classes
     public actual suspend fun receiveCatching(): ChannelResult<E>
@@ -260,11 +225,9 @@ public actual interface ReceiveChannel<out E> : JsAsyncIterable<E> {
     public actual val onReceiveOrNull: SelectClause1<E?> get() = (this as BufferedChannel<E>).onReceiveOrNull
 }
 
-@JsName("AsyncIterable")
-internal external interface JsAsyncIterable<out T> {
-    @JsSymbol("asyncIterator")
-    public fun asyncIterator(): JsAsyncIterator<T>
-}
+@JsPlainObject
+@JsName("AsyncIterableIterator")
+internal external interface JsAsyncIterableIterator<out T> : JsAsyncIterator<T>
 
 @JsPlainObject
 @JsName("AsyncIterator")
@@ -279,9 +242,9 @@ internal external interface JsAsyncIterator<out T> {
 /**
  * Options for customizing channel async-iteration behavior.
  */
-@JsImplicitExport(couldBeConvertedToExplicitExport = true)
+@JsExport
 @JsPlainObject
-internal external interface ChannelIteratorOptions {
+public external interface ChannelIteratorOptions {
     /**
      * Controls whether the channel is canceled when iteration completes early.
      *
@@ -291,7 +254,7 @@ internal external interface ChannelIteratorOptions {
      * - `true`: do not cancel the channel on early iterator completion.
      * - `false` or omitted: cancel the channel on early iterator completion.
      */
-    val preventCancel: Boolean?
+    public val preventCancel: Boolean?
 }
 
 @JsPlainObject

--- a/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
+++ b/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
@@ -50,37 +50,41 @@ class ChannelInteropTest : TestBase() {
         val iterator: JsAsyncIterator<Int> = channel.asDynamic()[js("Symbol.asyncIterator")]()
         launch {
             channel.send(1)
-            channel.send(2)
+            assertFailsWith<CancellationException>{
+                channel.send(2)
+            }.apply {
+                assertNull(cause)
+            }
         }
         assertNextStepToBe(iterator, value = 1, done = false)
         // Call return() to stop iteration early
         val returnResult = iterator.asDynamic().`return`().unsafeCast<Promise<JsIteratorResult<Int>>>().await()
         assertEquals(true, returnResult.done)
-        // Channel should not be cancelled
-        assertFalse(channel.isClosedForReceive)
+        // Channel should be cancelled
+        assertTrue(channel.isClosedForReceive)
         assertNextStepToBe(iterator, done = true)
-        assertEquals(2, channel.receive())
     }
 
     @Test
     fun testChannelToAsyncIteratorThrow() = runTest {
         val channel = Channel<Int>()
         val iterator: JsAsyncIterator<Int> = channel.asDynamic()[js("Symbol.asyncIterator")]()
+        val error = js("new Error('test error')")
         launch {
             channel.send(1)
-            channel.send(2)
-            channel.send(3)
+            assertFailsWith<CancellationException> {
+                channel.send(2)
+            }.apply {
+                assertSame(error, cause)
+            }
         }
         assertNextStepToBe(iterator, value = 1, done = false)
         // Call throw() to cancel the iterator
-        val error = js("new Error('test error')")
         assertFailsWith<Throwable> { iterator.`throw`(error).await() }
             .apply { assertEquals("test error", message) }
         // Channel should not be cancelled
-        assertFalse(channel.isClosedForReceive)
+        assertTrue(channel.isClosedForReceive)
         assertNextStepToBe(iterator, done = true)
-        assertEquals(2, channel.receive())
-        assertEquals(3, channel.receive())
     }
 
     @Test
@@ -165,16 +169,19 @@ class ChannelInteropTest : TestBase() {
         val iterator: JsAsyncIterator<Int> = channel.asDynamic()[js("Symbol.asyncIterator")]()
         launch {
             channel.send(1)
-            channel.send(2)
+            assertFailsWith<CancellationException> {
+                channel.send(2)
+            }.apply {
+                assertNull(cause)
+            }
         }
         assertNextStepToBe(iterator, value = 1, done = false)
         // Call throw() with no argument to cancel the iterator
         assertFailsWith<Throwable> { iterator.asDynamic().`throw`().unsafeCast<Promise<JsIteratorResult<Int>>>().await() }
             .apply { assertEquals("Promise rejected with a non-Throwable exception", message) }
         // Channel should not be cancelled
-        assertFalse(channel.isClosedForReceive)
+        assertTrue(channel.isClosedForReceive)
         assertNextStepToBe(iterator, done = true)
-        assertEquals( 2, channel.receive())
     }
 
     @Test
@@ -183,7 +190,11 @@ class ChannelInteropTest : TestBase() {
         val iterator: JsAsyncIterator<Int> = channel.asDynamic()[js("Symbol.asyncIterator")]()
         launch {
             channel.send(1)
-            channel.send(2)
+            assertFailsWith<CancellationException> {
+                channel.send(2)
+            }.apply {
+                assertNull(cause)
+            }
         }
         assertNextStepToBe(iterator, value = 1, done = false)
         // Call return(value) to stop iteration early, passing a return value
@@ -191,9 +202,8 @@ class ChannelInteropTest : TestBase() {
         assertEquals(true, returnResult.done)
         assertEquals(42, returnResult.value)
         // Channel should not be cancelled
-        assertFalse(channel.isClosedForReceive)
+        assertTrue(channel.isClosedForReceive)
         assertNextStepToBe(iterator, done = true)
-        assertEquals(2, channel.receive())
     }
 
     private suspend fun <T> assertNextStepToBe(

--- a/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
+++ b/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
@@ -206,6 +206,110 @@ class ChannelInteropTest : TestBase() {
         assertNextStepToBe(iterator, done = true)
     }
 
+    @Test
+    fun testChannelToAsyncIteratorNoCancelOnEarlyReturn() = runTest {
+        val channel = Channel<Int>(capacity = 1)
+        val iterator = channel.asyncIterator(cancelOnEarlyExit = false)
+        launch {
+            channel.send(1)
+            channel.send(2)
+            channel.close()
+        }
+        assertNextStepToBe(iterator, value = 1, done = false)
+        val returnResult = iterator.asDynamic().`return`().unsafeCast<Promise<JsIteratorResult<Int>>>().await()
+        assertEquals(true, returnResult.done)
+        assertFalse(channel.isClosedForReceive)
+        assertEquals(2, channel.receive())
+        assertTrue(channel.isClosedForReceive)
+        assertNextStepToBe(iterator, done = true)
+    }
+
+    @Test
+    fun testAsAsyncIterableOptionsPreventCancelTrue() = runTest {
+        val channel = Channel<Int>(capacity = 1)
+        val iterator: JsAsyncIterator<Int> = channel
+            .asAsyncIterable(ChannelIteratorOptions(preventCancel = true))
+            .asDynamic()[js("Symbol.asyncIterator")]()
+        launch {
+            channel.send(1)
+            channel.send(2)
+            channel.close()
+        }
+        assertNextStepToBe(iterator, value = 1, done = false)
+        val returnResult = iterator.asDynamic().`return`().unsafeCast<Promise<JsIteratorResult<Int>>>().await()
+        assertEquals(true, returnResult.done)
+        assertFalse(channel.isClosedForReceive)
+        assertEquals(2, channel.receive())
+        assertTrue(channel.isClosedForReceive)
+        assertNextStepToBe(iterator, done = true)
+    }
+
+    @Test
+    fun testAsAsyncIterableOptionsPreventCancelFalse() = runTest {
+        val channel = Channel<Int>()
+        val iterator: JsAsyncIterator<Int> = channel
+            .asAsyncIterable(ChannelIteratorOptions(preventCancel = false))
+            .asDynamic()[js("Symbol.asyncIterator")]()
+        launch {
+            channel.send(1)
+            assertFailsWith<CancellationException> {
+                channel.send(2)
+            }.apply {
+                assertNull(cause)
+            }
+        }
+        assertNextStepToBe(iterator, value = 1, done = false)
+        val returnResult = iterator.asDynamic().`return`().unsafeCast<Promise<JsIteratorResult<Int>>>().await()
+        assertEquals(true, returnResult.done)
+        assertTrue(channel.isClosedForReceive)
+        assertNextStepToBe(iterator, done = true)
+    }
+
+    @Test
+    fun testValuesOptionsPreventCancelTrue() = runTest {
+        val channel = Channel<Int>(capacity = 1)
+        val iterator: JsAsyncIterator<Int> = channel
+            .asDynamic()
+            .values(ChannelIteratorOptions(preventCancel = true))
+            .unsafeCast<JsAsyncIterator<Int>>()
+        val error = js("new Error('test error')")
+        launch {
+            channel.send(1)
+            channel.send(2)
+            channel.close()
+        }
+        assertNextStepToBe(iterator, value = 1, done = false)
+        assertFailsWith<Throwable> { iterator.`throw`(error).await() }
+            .apply { assertEquals("test error", message) }
+        assertFalse(channel.isClosedForReceive)
+        assertEquals(2, channel.receive())
+        assertTrue(channel.isClosedForReceive)
+        assertNextStepToBe(iterator, done = true)
+    }
+
+    @Test
+    fun testValuesOptionsPreventCancelFalseByDefault() = runTest {
+        val channel = Channel<Int>()
+        val iterator: JsAsyncIterator<Int> = channel
+            .asDynamic()
+            .values(ChannelIteratorOptions(preventCancel = null))
+            .unsafeCast<JsAsyncIterator<Int>>()
+        val error = js("new Error('test error')")
+        launch {
+            channel.send(1)
+            assertFailsWith<CancellationException> {
+                channel.send(2)
+            }.apply {
+                assertSame(error, cause)
+            }
+        }
+        assertNextStepToBe(iterator, value = 1, done = false)
+        assertFailsWith<Throwable> { iterator.`throw`(error).await() }
+            .apply { assertEquals("test error", message) }
+        assertTrue(channel.isClosedForReceive)
+        assertNextStepToBe(iterator, done = true)
+    }
+
     private suspend fun <T> assertNextStepToBe(
         iterator: JsAsyncIterator<T>,
         value: T? = js("undefined"),

--- a/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
+++ b/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
@@ -228,8 +228,8 @@ class ChannelInteropTest : TestBase() {
     fun testAsAsyncIterableOptionsPreventCancelTrue() = runTest {
         val channel = Channel<Int>(capacity = 1)
         val iterator: JsAsyncIterator<Int> = channel
-            .asAsyncIterable(ChannelIteratorOptions(preventCancel = true))
-            .asDynamic()[js("Symbol.asyncIterator")]()
+            .asDynamic()
+            .values(ChannelIteratorOptions(preventCancel = true))[js("Symbol.asyncIterator")]()
         launch {
             channel.send(1)
             channel.send(2)
@@ -248,8 +248,8 @@ class ChannelInteropTest : TestBase() {
     fun testAsAsyncIterableOptionsPreventCancelFalse() = runTest {
         val channel = Channel<Int>()
         val iterator: JsAsyncIterator<Int> = channel
-            .asAsyncIterable(ChannelIteratorOptions(preventCancel = false))
-            .asDynamic()[js("Symbol.asyncIterator")]()
+            .asDynamic()
+            .values(ChannelIteratorOptions(preventCancel = false))[js("Symbol.asyncIterator")]()
         launch {
             channel.send(1)
             assertFailsWith<CancellationException> {

--- a/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
+++ b/kotlinx-coroutines-core/js/test/ChannelInteropTest.kt
@@ -227,9 +227,7 @@ class ChannelInteropTest : TestBase() {
     @Test
     fun testAsAsyncIterableOptionsPreventCancelTrue() = runTest {
         val channel = Channel<Int>(capacity = 1)
-        val iterator: JsAsyncIterator<Int> = channel
-            .asDynamic()
-            .values(ChannelIteratorOptions(preventCancel = true))[js("Symbol.asyncIterator")]()
+        val iterator: JsAsyncIterator<Int> = js("channel.values({ preventCancel: true })[Symbol.asyncIterator]()")
         launch {
             channel.send(1)
             channel.send(2)
@@ -247,9 +245,8 @@ class ChannelInteropTest : TestBase() {
     @Test
     fun testAsAsyncIterableOptionsPreventCancelFalse() = runTest {
         val channel = Channel<Int>()
-        val iterator: JsAsyncIterator<Int> = channel
-            .asDynamic()
-            .values(ChannelIteratorOptions(preventCancel = false))[js("Symbol.asyncIterator")]()
+        val iterator: JsAsyncIterator<Int> =
+            js("channel.values({ preventCancel: false })[Symbol.asyncIterator]()")
         launch {
             channel.send(1)
             assertFailsWith<CancellationException> {
@@ -268,10 +265,7 @@ class ChannelInteropTest : TestBase() {
     @Test
     fun testValuesOptionsPreventCancelTrue() = runTest {
         val channel = Channel<Int>(capacity = 1)
-        val iterator: JsAsyncIterator<Int> = channel
-            .asDynamic()
-            .values(ChannelIteratorOptions(preventCancel = true))
-            .unsafeCast<JsAsyncIterator<Int>>()
+        val iterator: JsAsyncIterator<Int> = js("channel.values({ preventCancel: true })[Symbol.asyncIterator]()")
         val error = js("new Error('test error')")
         launch {
             channel.send(1)
@@ -290,10 +284,7 @@ class ChannelInteropTest : TestBase() {
     @Test
     fun testValuesOptionsPreventCancelFalseByDefault() = runTest {
         val channel = Channel<Int>()
-        val iterator: JsAsyncIterator<Int> = channel
-            .asDynamic()
-            .values(ChannelIteratorOptions(preventCancel = null))
-            .unsafeCast<JsAsyncIterator<Int>>()
+        val iterator: JsAsyncIterator<Int> = js("channel.values()[Symbol.asyncIterator]()")
         val error = js("new Error('test error')")
         launch {
             channel.send(1)


### PR DESCRIPTION
Also, mark `asyncIterator` as `ExperimentalCoroutinesApi`.