### PR TITLE
chore: change order of documents in the guide

### DIFF
--- a/docs/kc.tree
+++ b/docs/kc.tree
@@ -9,12 +9,12 @@
             <toc-element accepts-web-file-names="flow.html" toc-title="Overview" topic="coroutines-flow.md"/>
             <toc-element topic="coroutines-flow-operators.md"/>
         </toc-element>
+        <toc-element topic="coroutines-and-channels.md"/>
 		<toc-element topic="composing-suspending-functions.md"/>
 		<toc-element topic="coroutine-context-and-dispatchers.md"/>
 		<toc-element topic="channels.md"/>
 		<toc-element topic="exception-handling.md"/>
 		<toc-element topic="shared-mutable-state-and-concurrency.md"/>
-        <toc-element topic="coroutines-and-channels.md"/>
 		<toc-element topic="select-expression.md"/>
 		<toc-element topic="debug-coroutines-with-idea.md"/>
 		<toc-element topic="debug-flow-with-idea.md"/>

--- a/docs/kc.tree
+++ b/docs/kc.tree
@@ -4,17 +4,17 @@
 	<snippet id="coroutines">
 		<toc-element topic="coroutines-guide.md"/>
 		<toc-element accepts-web-file-names="basics.html,coroutines-basic-jvm.html" topic="coroutines-basics.md"/>
-		<toc-element topic="coroutines-and-channels.md"/>
 		<toc-element accepts-web-file-names="cancellation-and-timeouts.html" topic="coroutines-cancellation.md" toc-title="Cancellation"/>
+        <toc-element toc-title="Flows">
+            <toc-element accepts-web-file-names="flow.html" toc-title="Overview" topic="coroutines-flow.md"/>
+            <toc-element topic="coroutines-flow-operators.md"/>
+        </toc-element>
 		<toc-element topic="composing-suspending-functions.md"/>
 		<toc-element topic="coroutine-context-and-dispatchers.md"/>
-		<toc-element toc-title="Flows">
-			<toc-element accepts-web-file-names="flow.html" toc-title="Overview" topic="coroutines-flow.md"/>
-			<toc-element topic="coroutines-flow-operators.md"/>
-		</toc-element>
 		<toc-element topic="channels.md"/>
 		<toc-element topic="exception-handling.md"/>
 		<toc-element topic="shared-mutable-state-and-concurrency.md"/>
+        <toc-element topic="coroutines-and-channels.md"/>
 		<toc-element topic="select-expression.md"/>
 		<toc-element topic="debug-coroutines-with-idea.md"/>
 		<toc-element topic="debug-flow-with-idea.md"/>

--- a/docs/topics/coroutines-guide.md
+++ b/docs/topics/coroutines-guide.md
@@ -20,11 +20,11 @@ In order to use coroutines as well as follow the examples in this guide, you nee
 ## Table of contents
 
 * [Coroutines basics](coroutines-basics.md)
-* [Tutorial: Intro to coroutines and channels](coroutines-and-channels.md)
 * [Cancellation and timeouts](coroutines-cancellation.md)
+* [Flows](coroutines-flow.md)
+* [Tutorial: Intro to coroutines and channels](coroutines-and-channels.md)
 * [Composing suspending functions](composing-suspending-functions.md)
 * [Coroutine context and dispatchers](coroutine-context-and-dispatchers.md)
-* [Flows](coroutines-flow.md)
 * [Channels](channels.md)
 * [Coroutine exceptions handling](exception-handling.md)
 * [Shared mutable state and concurrency](shared-mutable-state-and-concurrency.md)


### PR DESCRIPTION
This PR changes the order of the guides to show the updated guides first, helping users learn about coroutines more easily.