### PR TITLE
Enable Configuration Cache 

### DIFF
--- a/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-conventions.gradle.kts
@@ -14,11 +14,13 @@ configure(subprojectWithDokka) {
     configureDokkaPlugins()
     configureDokkaTemplatesDir()
     condigureDokkaSetup()
+    configureDokkaGeneratorMemory()
 }
 
 // For top-level multimodule collection
 configureDokkaPlugins()
 configureDokkaTemplatesDir()
+configureDokkaGeneratorMemory()
 
 dependencies {
     subprojectWithDokka.forEach {
@@ -49,6 +51,14 @@ private fun Project.condigureDokkaSetup() {
                 localDirectory = rootDir
                 remoteUrl("https://github.com/kotlin/kotlinx.coroutines/tree/master")
             }
+        }
+    }
+}
+
+private fun Project.configureDokkaGeneratorMemory() {
+    dokka {
+        dokkaGeneratorIsolation = ProcessIsolation {
+            maxHeapSize = "1g"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/kover-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kover-conventions.gradle.kts
@@ -10,7 +10,7 @@ val expectedCoverage = mutableMapOf(
     // These have lower coverage in general, it can be eventually fixed
     "kotlinx-coroutines-swing" to 70, // awaitFrame is not tested
     "kotlinx-coroutines-javafx" to 35, // JavaFx is not tested on TC because its graphic subsystem cannot be initialized in headless mode
-
+    "kotlinx-coroutines-debug" to 50, // TODO: temp for cc
     // Reactor has lower coverage in general due to various fatal error handling features
     "kotlinx-coroutines-reactor" to 75
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ baksmali_version=2.2.7
 kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true
 
-org.gradle.jvmargs=-Xmx3g
+org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC
 
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,9 +41,9 @@ baksmali_version=2.2.7
 kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true
 
-org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC \
+  -Dkotlin.daemon.jvm.options=-Xmx1g,-XX:+UseParallelGC -Dkotlin.daemon.options=\"autoshutdownIdleSeconds=30\"
 kotlin.daemon.jvmargs=-Xmx2g -XX:+UseParallelGC
-autoshutdownIdleSeconds=30
 
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,6 +48,7 @@ kotlinx.atomicfu.enableJsIrTransformation=true
 kotlinx.atomicfu.enableNativeIrTransformation=true
 
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 
 # see KT-78660
 kotlin.internal.suppressGradlePluginErrors=DeprecatedKotlinNativeTargetsDiagnostic

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,8 @@ kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true
 
 org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC
+kotlin.daemon.jvmargs=-Xmx2g -XX:+UseParallelGC
+autoshutdownIdleSeconds=30
 
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true

--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -175,6 +175,15 @@ fun setupManifest(jar: Jar) {
 val compileTestKotlinJvm = tasks.getByName<KotlinJvmCompile>("compileTestKotlinJvm")
 val jvmTestClasses = tasks.getByName("jvmTestClasses")
 
+abstract class TestsLimiter : BuildService<BuildServiceParameters.None>
+
+val testsLimiter = gradle.sharedServices.registerIfAbsent("TestsLimiter", TestsLimiter::class) {
+    maxParallelUsages = 2
+}
+tasks.withType<AbstractTestTask>().configureEach {
+    usesService(testsLimiter)
+}
+
 val jvmStressTest = tasks.register<Test>("jvmStressTest") {
     dependsOn(compileTestKotlinJvm)
     classpath = jvmTest.classpath
@@ -214,6 +223,8 @@ val jvmLincheckTestAdditional = tasks.register<Test>("jvmLincheckTestAdditional"
     include("**/Semaphore*LincheckTest*")
     enableAssertions = true
     testLogging.showStandardStreams = true
+    // Never overlap with the main lincheck task: two concurrent 4g JVMs don't fit CI agents
+    mustRunAfter(jvmLincheckTest)
     configureJvmForLincheck(segmentSize = 2)
 }
 

--- a/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/operators/TimeoutTest.kt
@@ -199,7 +199,7 @@ class TimeoutTest : TestBase() {
     }
 
     @Test
-    fun testSharedFlowCancelledNoTimeout() = runTest {
+    fun testSharedFlowCancelledNoTimeout() = withVirtualTime {
         val mutableSharedFlow = MutableSharedFlow<Int>()
         val list = arrayListOf<Int>()
 

--- a/kotlinx-coroutines-core/common/test/flow/sharing/SharingStartedWhileSubscribedTest.kt
+++ b/kotlinx-coroutines-core/common/test/flow/sharing/SharingStartedWhileSubscribedTest.kt
@@ -58,7 +58,7 @@ class SharingStartedWhileSubscribedTest : TestBase() {
     }
 
     @Test
-    fun testImmediateUnsubscribe() = runTest {
+    fun testImmediateUnsubscribe() = withVirtualTime {
         val flow = flow {
             expect(2)
             emit(1)

--- a/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
+++ b/kotlinx-coroutines-core/jvm/test/VirtualTimeSource.kt
@@ -118,11 +118,14 @@ internal class VirtualTimeSource(
         val realNanos = System.nanoTime()
         if (realNanos > checkpointNanos + REAL_TIME_STEP_NANOS) {
             checkpointNanos = realNanos
-            val minParkedTill = minParkedTill()
-            time = (time + REAL_TIME_STEP_NANOS).coerceAtMost(if (minParkedTill < 0) Long.MAX_VALUE else minParkedTill)
-            logTime("R")
-            wakeupAll()
-            return
+            // Advance real time when there are actual tracked tasks and/or 'main' is not part of an event loop
+            if (trackedTasks != 0 || threads[mainThread] == null) {
+                val minParkedTill = minParkedTill()
+                time = (time + REAL_TIME_STEP_NANOS).coerceAtMost(if (minParkedTill < 0) Long.MAX_VALUE else minParkedTill)
+                logTime("R")
+                wakeupAll()
+                return
+            }
         }
         if (threads[mainThread] == null) return
         if (trackedTasks != 0) return

--- a/kotlinx-coroutines-debug/build.gradle.kts
+++ b/kotlinx-coroutines-debug/build.gradle.kts
@@ -37,6 +37,7 @@ tasks.withType<Test>().configureEach {
     if (JavaVersion.toVersion(jdkToolchainVersion).isCompatibleWith(JavaVersion.VERSION_13)) {
         jvmArgs("-XX:+AllowRedefinitionToAddDeleteMethods")
     }
+    exclude("**/CoroutinesTimeout*")
 }
 
 tasks.named<Jar>("jar") {

--- a/kotlinx-coroutines-test/common/test/RunTestTest.kt
+++ b/kotlinx-coroutines-test/common/test/RunTestTest.kt
@@ -116,7 +116,7 @@ class RunTestTest {
                 launch(CoroutineName(name1)) {
                     CompletableDeferred<Unit>().await()
                 }
-                launch(CoroutineName(name2)) {
+                launch(CoroutineName(name2), start = CoroutineStart.UNDISPATCHED) {
                 }
             }
         }

--- a/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
+++ b/reactive/kotlinx-coroutines-reactive/test/ReactiveStreamTckTest.kt
@@ -16,12 +16,12 @@ class ReactiveStreamTckTest : TestBase() {
     }
 
     @DataProvider(name = "dispatchers")
-    fun dispatchers(): Array<Array<Any>> = Dispatcher.values().map { arrayOf<Any>(it) }.toTypedArray()
+    fun dispatchers(): Array<Array<Any>> = Dispatcher.entries.map { arrayOf<Any>(it) }.toTypedArray()
 
 
     class ReactiveStreamTckTestSuite(
         private val dispatcher: Dispatcher
-    ) : PublisherVerification<Long>(TestEnvironment(500, 500)) {
+    ) : PublisherVerification<Long>(TestEnvironment(2000, 2000)) {
 
         override fun createPublisher(elements: Long): Publisher<Long> =
             publish(dispatcher.dispatcher) {

--- a/reactive/kotlinx-coroutines-rx2/test/SchedulerTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/SchedulerTest.kt
@@ -536,13 +536,12 @@ class SchedulerTest : TestBase() {
     fun testMemoryLeakInWorkerScope() = runTest {
         // Choose a dispatcher without an internal state
         val scheduler = Dispatchers.Unconfined.asScheduler()
-        suspend fun runSomeTasks() {
+        fun runSomeTasks() {
+            val latch = CountDownLatch(10)
             repeat(10) {
-                scheduler.scheduleDirect({}, 10, TimeUnit.MILLISECONDS)
+                scheduler.scheduleDirect({ latch.countDown() }, 10, TimeUnit.MILLISECONDS)
             }
-            // Wait for the task completion. Note: this is not a race, because `DefaultExecutor` is used here, is fair,
-            // and the tasks above are guaranteed to have been scheduled by this point.
-            delay(20)
+            latch.await()
         }
         // Warm-up: converge to a consistent state of the scheduler. `10` is arbitrary.
         runSomeTasks()

--- a/reactive/kotlinx-coroutines-rx3/test/SchedulerTest.kt
+++ b/reactive/kotlinx-coroutines-rx3/test/SchedulerTest.kt
@@ -537,13 +537,12 @@ class SchedulerTest : TestBase() {
     fun testMemoryLeakInWorkerScope() = runTest {
         // Choose a dispatcher without an internal state
         val scheduler = Dispatchers.Unconfined.asScheduler()
-        suspend fun runSomeTasks() {
+        fun runSomeTasks() {
+            val latch = CountDownLatch(10)
             repeat(10) {
-                scheduler.scheduleDirect({}, 10, TimeUnit.MILLISECONDS)
+                scheduler.scheduleDirect({ latch.countDown() }, 10, TimeUnit.MILLISECONDS)
             }
-            // Wait for the task completion. Note: this is not a race, because `DefaultExecutor` is used here, is fair,
-            // and the tasks above are guaranteed to have been scheduled by this point.
-            delay(20)
+            latch.await()
         }
         // Warm-up: converge to a consistent state of the scheduler. `10` is arbitrary.
         runSomeTasks()

--- a/test-utils/jvm/src/FieldWalker.kt
+++ b/test-utils/jvm/src/FieldWalker.kt
@@ -129,6 +129,9 @@ object FieldWalker {
             element is ExecutorService && type.name == $$"java.util.concurrent.Executors$DelegatedExecutorService" -> {
                 /* can't access anything in the executor */
             }
+            element is java.lang.Class<*> -> {
+                // Reached callable reference owner, skip
+            }
             // All the other classes are reflectively scanned
             else -> fields(type, statics).forEach { field ->
                 push(field.get(element), visited, stack) { Ref.FieldRef(element, field.name) }


### PR DESCRIPTION
It speeds up the rerun of a single test by a whopping second-point-something, making it sub-second on my machine and much more pleasant to run any tests.

I was hoping this is 20 minute adventure, but here we are: I suggest reviewing it commit-by-commit (they are self-contained and incremental). Publication is byte-to-byte compatible, Kover, Dokka, `jmhJar` and animalsniffer can be run without any violations