### PR TITLE
Fix a crash caused by renaming a live worker thread from another thread

### DIFF
--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -608,8 +608,17 @@ internal class CoroutineScheduler(
         @Volatile // volatile for push/pop operation into parkedWorkersStack
         var indexInArray = 0
             set(index) {
-                name = "$schedulerName-worker-${if (index == 0) "TERMINATED" else index.toString()}"
                 field = index
+                // Renaming a live thread from another thread can require the runtime to
+                // suspend it first (see #2234), which can time out and crash the process
+                // if that thread doesn't reach a safepoint quickly enough. Only rename
+                // synchronously here if it's safe to do so: either this thread hasn't
+                // started yet (no live peer to suspend), or we ARE this thread. Otherwise,
+                // defer to runWorker()'s self-heal check, which is always a same-thread
+                // (and therefore always safe) rename.
+                if (!isAlive || Thread.currentThread() === this) {
+                    name = "$schedulerName-worker-${if (index == 0) "TERMINATED" else index.toString()}"
+                }
             }
 
         constructor(index: Int) : this() {
@@ -706,9 +715,18 @@ internal class CoroutineScheduler(
         @JvmField
         var mayHaveLocalTasks = false
 
+        // Tracks the index this worker's name was last set to by itself, so a rename
+        // deferred by indexInArray's setter (because it was requested by another
+        // thread) gets applied here instead, on this worker's own thread.
+        private var appliedNameIndex = indexInArray
+
         private fun runWorker() {
             var rescanned = false
             while (!isTerminated && state != WorkerState.TERMINATED) {
+                if (appliedNameIndex != indexInArray) {
+                    appliedNameIndex = indexInArray
+                    name = "$schedulerName-worker-${if (appliedNameIndex == 0) "TERMINATED" else appliedNameIndex.toString()}"
+                }
                 val task = findTask(mayHaveLocalTasks)
                 // Task found. Execute and repeat
                 if (task != null) {

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -36,18 +36,8 @@ abstract class SchedulerTestBase : TestBase() {
         }
 
         private fun maxSequenceNumber(): Int? {
-            return Thread.getAllStackTraces().keys.asSequence().filter { it is CoroutineScheduler.Worker }
-                .map { sequenceNumber(it.name) }.maxOrNull()
-        }
-
-        private fun sequenceNumber(threadName: String): Int {
-            val suffix = threadName.substring(threadName.lastIndexOf("-") + 1)
-            val separatorIndex = suffix.indexOf(' ')
-            if (separatorIndex == -1) {
-                return suffix.toInt()
-            }
-
-            return suffix.substring(0, separatorIndex).toInt()
+            return Thread.getAllStackTraces().keys.asSequence()
+                .filterIsInstance<CoroutineScheduler.Worker>().maxOfOrNull { it.indexInArray }
         }
 
         suspend fun Iterable<Job>.joinAll() = forEach { it.join() }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/WorkerRenameTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/WorkerRenameTest.kt
@@ -1,0 +1,71 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.testing.*
+import org.junit.Test
+import java.lang.Runnable
+import java.util.concurrent.*
+import java.util.concurrent.atomic.*
+import kotlin.test.*
+
+/**
+ * Regression test for #2234: renaming a live worker thread from a different
+ * thread can require the runtime to suspend it first, which can time out and
+ * crash the process (see CoroutineScheduler.Worker.indexInArray). Verifies
+ * that a cross-thread indexInArray change never renames the thread directly,
+ * and that the worker corrects its own name once it next runs.
+ */
+class WorkerRenameTest : TestBase() {
+
+    @Test
+    fun testCrossThreadIndexChangeDoesNotRenameLiveWorker() {
+        CoroutineScheduler(1, 2, schedulerName = "WorkerRenameTest").use { scheduler ->
+            val workerRef = AtomicReference<CoroutineScheduler.Worker>()
+            val started = CountDownLatch(1)
+            val release = CountDownLatch(1)
+
+            scheduler.dispatch(Runnable {
+                workerRef.set(Thread.currentThread() as CoroutineScheduler.Worker)
+                started.countDown()
+                release.await()
+            })
+            started.await()
+            val worker = workerRef.get()
+
+            try {
+                val nameBefore = worker.name
+                val otherIndex = worker.indexInArray + 1000
+                worker.indexInArray = otherIndex // cross-thread: this is the test thread, not `worker`
+                assertEquals(nameBefore, worker.name, "cross-thread rename must not happen synchronously")
+            } finally {
+                release.countDown()
+            }
+
+            val expectedName = "WorkerRenameTest-worker-${worker.indexInArray}"
+            val deadline = System.currentTimeMillis() + 5_000
+            while (worker.name != expectedName && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10)
+            }
+            assertEquals(expectedName, worker.name, "worker should self-heal its own name once it runs again")
+        }
+    }
+
+    @Test
+    fun testSelfRenameHappensSynchronously() {
+        CoroutineScheduler(1, 2, schedulerName = "WorkerRenameTest").use { scheduler ->
+            val done = CountDownLatch(1)
+            var expectedName: String? = null
+            var nameAfterSelfRename: String? = null
+
+            scheduler.dispatch(Runnable {
+                val self = Thread.currentThread() as CoroutineScheduler.Worker
+                self.indexInArray = self.indexInArray + 1000 // same-thread: self-rename
+                expectedName = "WorkerRenameTest-worker-${self.indexInArray}"
+                nameAfterSelfRename = self.name // must already reflect the change, synchronously
+                done.countDown()
+            })
+
+            done.await()
+            assertEquals(expectedName, nameAfterSelfRename, "self-rename must apply synchronously, not deferred")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`CoroutineScheduler.Worker.indexInArray`'s setter unconditionally renames the underlying `Thread` on every assignment:

```kotlin
var indexInArray = 0
    set(index) {
        name = "$schedulerName-worker-${if (index == 0) "TERMINATED" else index.toString()}"
        field = index
    }
```

Two of its three call sites are safe: renaming a `Worker` before `start()` (no live peer yet), and a worker renaming itself during self-termination. The third, in `tryTerminateWorker()`, renames a **different, live** worker as part of keeping the workers array dense after a pool shrink:

```kotlin
val lastWorker = workers[lastIndex]!!
workers.setSynchronized(oldIndex, lastWorker)
lastWorker.indexInArray = oldIndex // <- cross-thread rename of a live thread
```

On Android, renaming a live thread you don't own requires the ART runtime to suspend it first (`Thread.setName` → `Thread_setNativeName` → `SuspendThreadByPeer`). If that thread doesn't reach a safepoint quickly enough — under GC pressure, device load, or anything else that delays it — the suspend attempt times out and ART aborts the whole process with `SIGABRT`. This matches the crash reports in #2234 exactly, including the `CoroutineScheduler$Worker.tryTerminateWorker`/`setIndexInArray` frames in the native backtrace.

I confirmed this is exploitable on-demand: forcing worker-pool churn while deliberately starving one worker (CPU priority + core-affinity pinning + blocking I/O + GC pressure) reproduces the exact crash reliably on an emulator, with the abort backtrace showing this precise call chain.

## Fix

Only rename the thread synchronously when it's safe to do so — the thread hasn't started yet, or the calling thread *is* the thread being renamed:

```kotlin
var indexInArray = 0
    set(index) {
        field = index
        if (!isAlive || Thread.currentThread() === this) {
            name = "$schedulerName-worker-${if (index == 0) "TERMINATED" else index.toString()}"
        }
    }
```

When neither holds (the cross-thread case), the rename is deferred to the worker's own next loop iteration in `runWorker()`, which is always a same-thread — and therefore always safe — rename:

```kotlin
private var appliedNameIndex = indexInArray

private fun runWorker() {
    var rescanned = false
    while (!isTerminated && state != WorkerState.TERMINATED) {
        if (appliedNameIndex != indexInArray) {
            appliedNameIndex = indexInArray
            name = "$schedulerName-worker-${if (appliedNameIndex == 0) "TERMINATED" else appliedNameIndex.toString()}"
        }
        ...
```

The numeric `indexInArray` field still updates immediately and unconditionally in all cases, so scheduling/parking/work-stealing correctness is unaffected — only the *display name* can lag briefly after a pool shrink, until the affected worker next runs.

Also updated `SchedulerTestBase.maxSequenceNumber()` to read `indexInArray` directly instead of parsing it out of `Thread.name`, since the name can now be briefly stale right after a shrink event.

## Drawbacks/trade-offs

- **Worker names can be briefly stale after a pool shrink.** When a cross-thread rename is deferred, the affected worker keeps showing its old index in `Thread.getName()` — visible in thread dumps, `jstack`, Android Studio's profiler, ANR reports, or any logging that tags by thread name — until that worker next loops around in `runWorker()`. In practice, this window is bounded by whatever the worker is currently doing (its current task, or until it wakes from parking), so it's on the order of the same task-scheduling latency that's already normal for this pool, not an unbounded delay. This is a real, if minor, change in observability: previously, the name was always immediately accurate; now it's eventually accurate.

- **The crash itself isn't reproducible in a JVM unit test.** The bug only manifests through ART's native thread-suspension machinery on Android, which doesn't exist in a plain JVM test environment — confirmed directly while working on this fix, since neither a JNI critical section nor CPU/IO starvation could force the equivalent failure outside of a real Android runtime. The added tests verify the actual safety property this fix relies on (a live thread is never renamed except by itself), not the crash/abort itself. If a future change reintroduces a similar cross-thread rename somewhere else in the scheduler, these tests won't catch it unless it goes through this exact code path.

## Testing

- Added `WorkerRenameTest` covering both live-thread branches: a cross-thread `indexInArray` change never renames synchronously (and the worker self-heals its name on its next run), and a worker renaming itself is applied synchronously.
- Full existing `scheduling` test suite passes with no regressions.
- Verified against the real crash: built a reproduction harness that reliably crashes on the unpatched code within a handful of attempts under the conditions described above, and confirmed 20/20 clean runs (repeated across multiple full passes) against this fix with no `SIGABRT`.

Fixes:
https://github.com/Kotlin/kotlinx.coroutines/issues/2234