### PR TITLE
Join backgroundScope after cancel in runTest

### DIFF
--- a/kotlinx-coroutines-test/common/src/TestBuilders.kt
+++ b/kotlinx-coroutines-test/common/src/TestBuilders.kt
@@ -368,6 +368,7 @@ public fun TestScope.runTest(
         } finally {
             backgroundScope.cancel()
             testScheduler.advanceUntilIdleOr { false }
+            backgroundScope.coroutineContext[Job]?.join()
             val uncaughtExceptions = scope.leave()
             throwAll(timeoutError ?: scope.getCompletionExceptionOrNull(), uncaughtExceptions)
         }
@@ -400,6 +401,7 @@ public fun TestScope.runTest(
         runTestCoroutineLegacy(it, dispatchTimeoutMs.milliseconds, TestScopeImpl::tryGetCompletionCause, testBody) {
             backgroundScope.cancel()
             testScheduler.advanceUntilIdleOr { false }
+            backgroundScope.coroutineContext[Job]?.join()
             it.legacyLeave()
         }
     }

--- a/kotlinx-coroutines-test/common/test/TestScopeTest.kt
+++ b/kotlinx-coroutines-test/common/test/TestScopeTest.kt
@@ -547,6 +547,27 @@ class TestScopeTest {
         })
     }
 
+    /**
+     * A NonCancellable background job on [Dispatchers.Default] must be joined
+     * before the next [runTest], or it leaks as [UncaughtExceptionsBeforeTest].
+     */
+    @Test
+    fun testBackgroundNonCancellableDoesNotLeakToNextTest(): TestResult = testResultChain({ _ ->
+        runCatching {
+            runTest {
+                backgroundScope.launch(Dispatchers.Default) {
+                    withContext(NonCancellable) {
+                        delay(30)
+                        throw TestException("hmm")
+                    }
+                }
+                delay(5)
+            }
+        }
+    }, {
+        runTest { }
+    })
+
     companion object {
         internal val invalidContexts = listOf(
             Dispatchers.Default, // not a [TestDispatcher]


### PR DESCRIPTION
cancel() plus advanceUntilIdle does not wait for NonCancellable work on Dispatchers.Default. That job then finishes after the test and the next runTest throws UncaughtExceptionsBeforeTest.

I join the background job after draining the test scheduler, so real-dispatcher leftovers are collected in the same test.

Fixes #4685