### PR TITLE
Make kotlinx.coroutines.debug timeout tests deterministic

### DIFF
--- a/kotlinx-coroutines-debug/src/junit/CoroutinesTimeoutImpl.kt
+++ b/kotlinx-coroutines-debug/src/junit/CoroutinesTimeoutImpl.kt
@@ -134,24 +134,21 @@ internal class FakeDelayEventQueue {
 
     fun processEventQueueAndAwaitCompletion(testTimeoutMs: Long) {
         while (true) {
-            val (timeMs, tasks) = synchronized(this@FakeDelayEventQueue) {
+            val tasks = synchronized(this@FakeDelayEventQueue) {
                 val currentEvents = events ?: return
-                currentEvents.eventPriorityQueue.pollFirstEntry().also {
-                    if (it == null) {
+                val (timeMs, tasks) = currentEvents.eventPriorityQueue.pollFirstEntry()
+                    ?: run {
                         (this@FakeDelayEventQueue as Object).wait()
                         continue
                     }
+                if (timeMs >= testTimeoutMs) {
+                    throw TimeoutException()
                 }
-            }
-            if (timeMs > testTimeoutMs) {
-                throw TimeoutException()
+                currentEvents.currentTime = timeMs
+                tasks
             }
             for (task in tasks) {
                 task.resumeWith(Result.success(Unit))
-            }
-            synchronized(this@FakeDelayEventQueue) {
-                val currentEvents = events ?: continue
-                currentEvents.currentTime = maxOf(currentEvents.currentTime, timeMs)
             }
         }
     }

--- a/kotlinx-coroutines-debug/src/junit/CoroutinesTimeoutImpl.kt
+++ b/kotlinx-coroutines-debug/src/junit/CoroutinesTimeoutImpl.kt
@@ -1,6 +1,12 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package kotlinx.coroutines.debug
 
+import kotlinx.coroutines.*
+import java.util.TreeMap
 import java.util.concurrent.*
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Run [invocation] in a separate thread with the given timeout in ms, after which the coroutines info is dumped and, if
@@ -8,7 +14,7 @@ import java.util.concurrent.*
  *
  * Assumes that [DebugProbes] are installed. Does not deinstall them.
  */
-internal inline fun <T : Any?> runWithTimeoutDumpingCoroutines(
+internal inline fun <T> runWithTimeoutDumpingCoroutines(
     methodName: String,
     testTimeoutMs: Long,
     cancelOnTimeout: Boolean,
@@ -16,9 +22,20 @@ internal inline fun <T : Any?> runWithTimeoutDumpingCoroutines(
     crossinline invocation: () -> T
 ): T {
     val testStartedLatch = CountDownLatch(1)
+    val fakeDelayEventQueue = if (fakeDelaysRequestsFromTests.load() != 0) {
+        fakeDelayEventQueue.also {
+            it.signalStart()
+        }
+    } else {
+        null
+    }
     val testResult = FutureTask {
         testStartedLatch.countDown()
-        invocation()
+        try {
+            invocation()
+        } finally {
+            fakeDelayEventQueue?.signalCompletion()
+        }
     }
     /*
      * We are using hand-rolled thread instead of single thread executor
@@ -29,8 +46,13 @@ internal inline fun <T : Any?> runWithTimeoutDumpingCoroutines(
         testThread.start()
         // Await until test is started to take only test execution time into account
         testStartedLatch.await()
-        return testResult.get(testTimeoutMs, TimeUnit.MILLISECONDS)
-    } catch (e: TimeoutException) {
+        return if (fakeDelayEventQueue != null) {
+            fakeDelayEventQueue.processEventQueueAndAwaitCompletion(testTimeoutMs)
+            testResult.get()
+        } else {
+            testResult.get(testTimeoutMs, TimeUnit.MILLISECONDS)
+        }
+    } catch (_: TimeoutException) {
         handleTimeout(testThread, methodName, testTimeoutMs, cancelOnTimeout, initCancellationException())
     } catch (e: ExecutionException) {
         throw e.cause ?: e
@@ -74,4 +96,97 @@ private fun cancelIfNecessary(cancelOnTimeout: Boolean) {
 private fun Throwable.attachStacktraceFrom(thread: Thread) {
     val stackTrace = thread.stackTrace
     this.stackTrace = stackTrace
+}
+
+// Testing facilities /////////////////////////////////////////////////////////
+
+/**
+ * Tests should be wrapped in this if they intend to use [fakeDelay].
+ */
+internal fun <T> withFakeDelayForTesting(block: () -> T): T {
+    fakeDelaysRequestsFromTests.fetchAndAdd(1)
+    try {
+        return block()
+    } finally {
+        fakeDelaysRequestsFromTests.fetchAndAdd(-1)
+    }
+}
+
+/**
+ * Similar to [delay], but works with virtual time.
+ *
+ * Only call this if a [withFakeDelayForTesting] call is running.
+ */
+internal suspend fun fakeDelay(timeMillis: Long) {
+    fakeDelayEventQueue.delay(timeMillis)
+}
+
+private val fakeDelayEventQueue by lazy {
+    FakeDelayEventQueue()
+}
+
+private val fakeDelaysRequestsFromTests = AtomicInt(0)
+
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") // to access wait/notifyAll
+internal class FakeDelayEventQueue {
+    // methodName -> resumptionTime -> continuation to resume
+    private var events: VirtualTimeState? = null
+
+    fun processEventQueueAndAwaitCompletion(testTimeoutMs: Long) {
+        while (true) {
+            val (timeMs, tasks) = synchronized(this@FakeDelayEventQueue) {
+                val currentEvents = events ?: return
+                currentEvents.eventPriorityQueue.pollFirstEntry().also {
+                    if (it == null) {
+                        (this@FakeDelayEventQueue as Object).wait()
+                        continue
+                    }
+                }
+            }
+            if (timeMs > testTimeoutMs) {
+                throw TimeoutException()
+            }
+            for (task in tasks) {
+                task.resumeWith(Result.success(Unit))
+            }
+            synchronized(this@FakeDelayEventQueue) {
+                val currentEvents = events ?: continue
+                currentEvents.currentTime = maxOf(currentEvents.currentTime, timeMs)
+            }
+        }
+    }
+
+    fun signalStart() {
+        synchronized(this@FakeDelayEventQueue) {
+            while (events != null) {
+                (this@FakeDelayEventQueue as Object).wait()
+            }
+            events = VirtualTimeState(0, TreeMap())
+        }
+    }
+
+    fun signalCompletion() {
+        synchronized(this@FakeDelayEventQueue) {
+            events = null
+            (this@FakeDelayEventQueue as Object).notifyAll()
+        }
+    }
+
+    suspend fun delay(timeMillis: Long): Unit = suspendCancellableCoroutine { cont ->
+        synchronized(this@FakeDelayEventQueue) {
+            val currentEvents = events ?: throw IllegalStateException(
+                "Use 'withFakeDelayForTests' to allow calling the 'fakeDelay' method " +
+                "and make sure a timeout is installed"
+            )
+            currentEvents.eventPriorityQueue.getOrPut(
+                currentEvents.currentTime + timeMillis
+            ) { mutableListOf() }.add(cont)
+            (this@FakeDelayEventQueue as Object).notifyAll()
+        }
+    }
+
+    private class VirtualTimeState(
+        var currentTime: Long,
+        val eventPriorityQueue: TreeMap<Long, MutableList<CancellableContinuation<Unit>>>,
+    )
 }

--- a/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutInheritanceTest.kt
+++ b/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutInheritanceTest.kt
@@ -2,6 +2,7 @@ package kotlinx.coroutines.debug.junit5
 
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.fakeDelay
 import org.junit.jupiter.api.*
 
 /**
@@ -20,21 +21,21 @@ class CoroutinesTimeoutInheritanceTest {
         @Test
         @Order(1)
         fun usesBaseClassTimeout() = runBlocking {
-            delay(1000)
+            fakeDelay(1000)
         }
 
         @CoroutinesTimeout(300)
         @Test
         @Order(2)
         fun methodOverridesBaseClassTimeoutWithGreaterTimeout() = runBlocking {
-            delay(200)
+            fakeDelay(200)
         }
 
         @CoroutinesTimeout(10)
         @Test
         @Order(3)
         fun methodOverridesBaseClassTimeoutWithLesserTimeout() = runBlocking {
-            delay(50)
+            fakeDelay(50)
         }
 
     }
@@ -44,12 +45,12 @@ class CoroutinesTimeoutInheritanceTest {
 
         @Test
         fun classOverridesBaseClassTimeout1() = runBlocking {
-            delay(200)
+            fakeDelay(200)
         }
 
         @Test
         fun classOverridesBaseClassTimeout2() = runBlocking {
-            delay(400)
+            fakeDelay(400)
         }
 
     }

--- a/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutMethodTest.kt
+++ b/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutMethodTest.kt
@@ -1,6 +1,7 @@
 package kotlinx.coroutines.debug.junit5
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.fakeDelay
 import org.junit.jupiter.api.*
 
 /**
@@ -24,7 +25,7 @@ class CoroutinesTimeoutMethodTest {
     @Order(2)
     fun usesMethodTimeoutWithNoClassTimeout() {
         runBlocking {
-            delay(1000)
+            fakeDelay(1000)
         }
     }
 
@@ -33,7 +34,7 @@ class CoroutinesTimeoutMethodTest {
     @Order(3)
     fun fitsInMethodTimeout() {
         runBlocking {
-            delay(10)
+            fakeDelay(10)
         }
     }
 

--- a/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutNestedTest.kt
+++ b/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutNestedTest.kt
@@ -1,6 +1,7 @@
 package kotlinx.coroutines.debug.junit5
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.fakeDelay
 import org.junit.jupiter.api.*
 
 /**
@@ -14,12 +15,12 @@ class CoroutinesTimeoutNestedTest {
     inner class NestedInInherited {
         @Test
         fun usesOuterClassTimeout() = runBlocking {
-            delay(1000)
+            fakeDelay(1000)
         }
 
         @Test
         fun fitsInOuterClassTimeout() = runBlocking {
-            delay(10)
+            fakeDelay(10)
         }
     }
 }

--- a/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutSimpleTest.kt
+++ b/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutSimpleTest.kt
@@ -1,6 +1,7 @@
 package kotlinx.coroutines.debug.junit5
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.debug.fakeDelay
 import org.junit.jupiter.api.*
 
 /**
@@ -16,7 +17,7 @@ class CoroutinesTimeoutSimpleTest {
     @Order(1)
     fun usesClassTimeout1() {
         runBlocking {
-            delay(150)
+            fakeDelay(150)
         }
     }
 
@@ -25,7 +26,7 @@ class CoroutinesTimeoutSimpleTest {
     @Order(2)
     fun ignoresClassTimeout() {
         runBlocking {
-            delay(150)
+            fakeDelay(150)
         }
     }
 
@@ -34,7 +35,7 @@ class CoroutinesTimeoutSimpleTest {
     @Order(3)
     fun usesMethodTimeout() {
         runBlocking {
-            delay(300)
+            fakeDelay(300)
         }
     }
 
@@ -42,7 +43,7 @@ class CoroutinesTimeoutSimpleTest {
     @Order(4)
     fun fitsInClassTimeout() {
         runBlocking {
-            delay(50)
+            fakeDelay(50)
         }
     }
 
@@ -50,7 +51,7 @@ class CoroutinesTimeoutSimpleTest {
     @Order(5)
     fun usesClassTimeout2() {
         runBlocking {
-            delay(150)
+            fakeDelay(150)
         }
     }
 

--- a/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutTest.kt
+++ b/kotlinx-coroutines-debug/test/junit5/CoroutinesTimeoutTest.kt
@@ -1,5 +1,6 @@
 package kotlinx.coroutines.debug.junit5
 
+import kotlinx.coroutines.debug.withFakeDelayForTesting
 import org.assertj.core.api.*
 import org.junit.Ignore
 import org.junit.Assert.*
@@ -23,7 +24,7 @@ class CoroutinesTimeoutTest {
     }
 
     @Test
-    fun testCoroutinesTimeoutSimple() {
+    fun testCoroutinesTimeoutSimple() = withFakeDelayForTesting {
         val capturedOut = ByteArrayOutputStream()
         eventsForSelector(selectClass(CoroutinesTimeoutSimpleTest::class.java), capturedOut)
             .testFinishedSuccessfully("ignoresClassTimeout")
@@ -35,7 +36,7 @@ class CoroutinesTimeoutTest {
     }
 
     @Test
-    fun testCoroutinesTimeoutMethod() {
+    fun testCoroutinesTimeoutMethod() = withFakeDelayForTesting {
         val capturedOut = ByteArrayOutputStream()
         eventsForSelector(selectClass(CoroutinesTimeoutMethodTest::class.java), capturedOut)
             .testFinishedSuccessfully("fitsInMethodTimeout")
@@ -45,7 +46,7 @@ class CoroutinesTimeoutTest {
     }
 
     @Test
-    fun testCoroutinesTimeoutNested() {
+    fun testCoroutinesTimeoutNested() = withFakeDelayForTesting {
         val capturedOut = ByteArrayOutputStream()
         eventsForSelector(selectClass(CoroutinesTimeoutNestedTest::class.java), capturedOut)
             .testFinishedSuccessfully("fitsInOuterClassTimeout")
@@ -54,7 +55,7 @@ class CoroutinesTimeoutTest {
     }
 
     @Test
-    fun testCoroutinesTimeoutInheritanceWithNoTimeoutInDerived() {
+    fun testCoroutinesTimeoutInheritanceWithNoTimeoutInDerived() = withFakeDelayForTesting {
         val capturedOut = ByteArrayOutputStream()
         eventsForSelector(selectClass(CoroutinesTimeoutInheritanceTest.InheritedWithNoTimeout::class.java), capturedOut)
             .testFinishedSuccessfully("methodOverridesBaseClassTimeoutWithGreaterTimeout")
@@ -64,7 +65,7 @@ class CoroutinesTimeoutTest {
     }
 
     @Test
-    fun testCoroutinesTimeoutInheritanceWithGreaterTimeoutInDerived() {
+    fun testCoroutinesTimeoutInheritanceWithGreaterTimeoutInDerived() = withFakeDelayForTesting {
         val capturedOut = ByteArrayOutputStream()
         eventsForSelector(
             selectClass(CoroutinesTimeoutInheritanceTest.InheritedWithGreaterTimeout::class.java),


### PR DESCRIPTION
Introduced a simple lightweight alternative to VirtualTimeSource or TestCoroutineScheduler specifically for testing the JUnit 4/5 extensions for dumping coroutine state on a timeout.

We could not easily reuse TestCoroutineScheduler because the code awaiting the timeout isn't (and shouldn't be!) running in a coroutine.
That would mean polluting the coroutine dumps,
which we are checking.

VirtualTimeSource could have been used, allowing us to write `delay` instead of `fakeDelay`. However, that would have required either sending tasks to the `DefaultExecutor` or writing our own copy of that based on `parkNanos`/`nanoTime` and co.

1. Using `DefaultExecutor` for tracking high-level test timeouts in production isn't ideal, because a timeout indicates that the system is in a weird state, making everything suspect. `DefaultExecutor` could have been flooded with tasks. Using a separate thread like we do now is appropriate in this scenario.
2. Writing a copy of `DefaultExecutor` is trickier than the current implementation.
3. A combined approach is possible: use `DefaultExecutor` + `VirtualTimeSource` only for tests, use a separate thread + real time in production. That was attempted, but looked very convoluted.