### PR TITLE
Fix TSan data race in `CoroutineDispatcherTest`.

### DIFF
--- a/kotlinx-coroutines-core/jvm/test/scheduling/CoroutineDispatcherTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CoroutineDispatcherTest.kt
@@ -9,11 +9,6 @@ import kotlin.test.*
 
 class CoroutineDispatcherTest : SchedulerTestBase() {
 
-    @After
-    fun tearDown() {
-        schedulerTimeSource = NanoTimeSource
-    }
-
     @Test
     fun testSingleThread() = runBlocking {
         corePoolSize = 1


### PR DESCRIPTION
Remove redundant `tearDown()` resetting `schedulerTimeSource` in `CoroutineDispatcherTest`. None of the tests in `CoroutineDispatcherTest` mutate `schedulerTimeSource`, and resetting it in `@After tearDown()` races with active worker threads before `SchedulerTestBase.after()` closes the dispatcher.

```
==================
WARNING: ThreadSanitizer: data race (pid=2223)
  Write of size 4 at 0x00008f6e2cb4 by thread T29:
    #0 kotlinx.coroutines.scheduling.CoroutineDispatcherTest.tearDown()V CoroutineDispatcherTest.kt:14

  Previous read of size 4 at 0x00008f6e2cb4 by thread T67:
    #0 kotlinx.coroutines.scheduling.WorkQueue.tryStealLastScheduled(ILkotlin/jvm/internal/Ref$ObjectRef;)J WorkQueue.kt:201
    #1 kotlinx.coroutines.scheduling.WorkQueue.trySteal(ILkotlin/jvm/internal/Ref$ObjectRef;)J WorkQueue.kt:130
    #2 kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.trySteal(I)Lkotlinx/coroutines/scheduling/Task; CoroutineScheduler.kt:954
    #3 kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.findAnyTask(Z)Lkotlinx/coroutines/scheduling/Task; CoroutineScheduler.kt:927
    #4 kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.findTask(Z)Lkotlinx/coroutines/scheduling/Task; CoroutineScheduler.kt:899
    #5 kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker()V CoroutineScheduler.kt:712
    #6 kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run()V CoroutineScheduler.kt:704

SUMMARY: ThreadSanitizer: data race CoroutineDispatcherTest.kt:14 in kotlinx.coroutines.scheduling.CoroutineDispatcherTest.tearDown()V
==================
```