### PR TITLE
Remove dead Android sample project link from UI coroutines guide

### DIFF
--- a/ui/coroutines-guide-ui.md
+++ b/ui/coroutines-guide-ui.md
@@ -113,11 +113,6 @@ Add dependencies on `kotlinx-coroutines-android` module to the `dependencies { .
 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0"
 ```
 
-You can clone [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) project from GitHub onto your 
-workstation. The resulting template project for Android resides in 
-[`ui/kotlinx-coroutines-android/example-app`](kotlinx-coroutines-android/example-app) directory. 
-You can load it in Android Studio to follow this guide on Android.
-
 ## Basic UI coroutines
 
 This section shows basic usage of coroutines in UI applications.


### PR DESCRIPTION
Fixes #4243

The `ui/kotlinx-coroutines-android/example-app` directory referenced in `ui/coroutines-guide-ui.md` was removed in #2418 ("Remove outdated Android examples") back in 2020, but the doc paragraph pointing to it as a clonable Android Studio sample was never cleaned up.

No replacement sample project exists elsewhere in the repository (checked `ui/` and other module trees), so this PR removes the dead paragraph rather than redirecting it. The guide's Android section still stands on its own via the existing step-by-step instructions and inline code snippets earlier/later in the same section.

### Changes
- Removed the paragraph in `ui/coroutines-guide-ui.md` that linked to the nonexistent `ui/kotlinx-coroutines-android/example-app` directory.

### Test plan
- [x] Confirmed the directory does not exist in current `master`.
- [x] Confirmed via `git log --path` that it was intentionally deleted in #2418, not moved.
- [x] Searched the repo for any other reference to `example-app` — none found.
- [x] Verified the surrounding guide text still reads coherently after removal.