### PR TITLE
Upgrade kotlinx.benchmark to 0.4.17

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -68,7 +68,12 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-benchmark-plugin:${version("benchmarks")}")
+    // kotlinx-benchmark-plugin may depend on a newer version of kotlin-stlib than the one bundled by Gradle,
+    // leading to Gradle complaining about an incompatible version of Kotlin. Exclude the kotlin-stdlib
+    // dependency to default to the one bundled by Gradle.
+    implementation("org.jetbrains.kotlinx:kotlinx-benchmark-plugin:${version("benchmarks")}") {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    }
     implementation("org.jetbrains.kotlinx:kotlinx-knit:${version("knit")}")
     implementation("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${version("atomicfu")}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ kotlin_version=2.2.20
 atomicfu_version=0.32.1
 
 # Dependencies
-benchmarks_version=0.4.13
+benchmarks_version=0.4.17
 benchmarks_jmh_version=1.37
 junit_version=4.12
 junit5_version=5.7.0


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-80897 removes a Kotlin Gradle plugin API that was used by kotlinx.benchmark prior to version 0.4.15, so once kotlinx.coroutines upgrades to KGP 2.5.x it'll run in binary compatibility issues. This change prevents that by upgrading to a safe kotlinx.benchmarks version.