### PR TITLE
Upgrade kotlinx.benchmarks to 0.4.16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ kotlin_version=2.3.21
 atomicfu_version=0.32.1
 
 # Dependencies
-benchmarks_version=0.4.13
+benchmarks_version=0.4.16
 benchmarks_jmh_version=1.37
 junit_version=4.12
 junit5_version=5.7.0


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-80897 removes a Kotlin Gradle plugin API that was used by kotlinx.benchmark prior to version 0.4.15, so once kotlinx.coroutines upgrades to KGP 2.5.x it'll run in binary compatibility issues. This change prevents that by upgrading to a safe kotlinx.benchmarks version.