### PR TITLE
docs(core): fix duplicated words in internal comments

### DIFF
--- a/kotlinx-coroutines-core/common/src/JobSupport.kt
+++ b/kotlinx-coroutines-core/common/src/JobSupport.kt
@@ -1549,7 +1549,7 @@ private class ResumeAwaitOnCompletion<T>(
         val state = job.state
         assert { state !is Incomplete }
         if (state is CompletedExceptionally) {
-            // Resume with with the corresponding exception to preserve it
+            // Resume with the corresponding exception to preserve it
             continuation.resumeWithException(state.cause)
         } else {
             // Resuming with value in a cancellable way (AwaitContinuation is configured for this mode).

--- a/kotlinx-coroutines-core/common/src/flow/internal/NullSurrogate.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/NullSurrogate.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.internal.*
 import kotlin.jvm.*
 
 /**
- * This value is used a a surrogate `null` value when needed.
+ * This value is used as a surrogate `null` value when needed.
  * It should never leak to the outside world.
  * Its usage typically are paired with [Symbol.unbox] usages.
  */


### PR DESCRIPTION


Fix three duplicated words in internal comments covering job state, the null surrogate, and platform exception handling.

