### PR TITLE
Fail fast when CoroutineStart.ATOMIC dispatch fails

### DIFF
--- a/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt
@@ -126,7 +126,7 @@ public abstract class AbstractCoroutine<in T>(
      * This function shall be invoked at most once on this coroutine.
      * 
      * - [DEFAULT] uses [startCoroutineCancellable].
-     * - [ATOMIC] uses [startCoroutine].
+     * - [ATOMIC] uses [startCoroutineAtomic].
      * - [UNDISPATCHED] uses [startCoroutineUndispatched].
      * - [LAZY] does nothing.
      */

--- a/kotlinx-coroutines-core/common/src/CoroutineStart.kt
+++ b/kotlinx-coroutines-core/common/src/CoroutineStart.kt
@@ -346,7 +346,7 @@ public enum class CoroutineStart {
      * Starts the corresponding block with receiver as a coroutine with this coroutine start strategy.
      *
      * - [DEFAULT] uses [startCoroutineCancellable].
-     * - [ATOMIC] uses [startCoroutine].
+     * - [ATOMIC] uses [startCoroutineAtomic].
      * - [UNDISPATCHED] uses [startCoroutineUndispatched].
      * - [LAZY] does nothing.
      *
@@ -356,7 +356,7 @@ public enum class CoroutineStart {
     public operator fun <R, T> invoke(block: suspend R.() -> T, receiver: R, completion: Continuation<T>): Unit =
         when (this) {
             DEFAULT -> block.startCoroutineCancellable(receiver, completion)
-            ATOMIC -> block.startCoroutine(receiver, completion)
+            ATOMIC -> block.startCoroutineAtomic(receiver, completion)
             UNDISPATCHED -> block.startCoroutineUndispatched(receiver, completion)
             LAZY -> Unit // will start lazily
         }

--- a/kotlinx-coroutines-core/common/src/intrinsics/Cancellable.kt
+++ b/kotlinx-coroutines-core/common/src/intrinsics/Cancellable.kt
@@ -26,6 +26,12 @@ internal fun <R, T> (suspend (R) -> T).startCoroutineCancellable(
     createCoroutineUnintercepted(receiver, completion).intercepted().resumeCancellableWithInternal(Result.success(Unit))
 }
 
+internal fun <R, T> (suspend (R) -> T).startCoroutineAtomic(
+    receiver: R, completion: Continuation<T>,
+) = runSafely(completion) {
+    createCoroutineUnintercepted(receiver, completion).intercepted().resume(Unit)
+}
+
 /**
  * Similar to [startCoroutineCancellable], but for already created coroutine.
  * [fatalCompletion] is used only when interception machinery throws an exception

--- a/kotlinx-coroutines-core/common/src/intrinsics/Cancellable.kt
+++ b/kotlinx-coroutines-core/common/src/intrinsics/Cancellable.kt
@@ -43,9 +43,9 @@ internal fun Continuation<Unit>.startCoroutineCancellable(fatalCompletion: Conti
 
 /**
  * Runs given block and completes completion with its exception if it occurs.
- * Rationale: [startCoroutineCancellable] is invoked when we are about to run coroutine asynchronously in its own dispatcher.
- * Thus if dispatcher throws an exception during coroutine start, coroutine never completes, so we should treat dispatcher exception
- * as its cause and resume completion.
+ * Rationale: [startCoroutineCancellable] and [startCoroutineAtomic] are invoked when we are about to run coroutine
+ * asynchronously in its own dispatcher. Thus if dispatcher throws an exception during coroutine start, coroutine never completes,
+ * so we should treat dispatcher exception as its cause and resume completion.
  */
 private inline fun runSafely(completion: Continuation<*>, block: () -> Unit) {
     try {

--- a/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
@@ -11,6 +11,7 @@ import org.junit.*
 import org.junit.Test
 import org.junit.rules.*
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.startCoroutine
 import kotlin.test.*
@@ -21,14 +22,20 @@ class FailFastOnStartTest : TestBase() {
     @JvmField
     val timeout: Timeout = Timeout.seconds(5)
 
+    private object ThrowingDispatcher : CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            throw TestException()
+        }
+    }
+
     @Test
     fun testLaunch() = runTest(expected = ::mainException) {
         launch(Dispatchers.Main) {}
     }
 
     @Test
-    fun testLaunchAtomic() = runTest(expected = ::mainException) {
-        launch(Dispatchers.Main, start = CoroutineStart.ATOMIC) {}
+    fun testLaunchAtomic() = runTest(expected = { it is TestException }) {
+        launch(ThrowingDispatcher, start = CoroutineStart.ATOMIC) {}
     }
 
     @Test

--- a/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/FailFastOnStartTest.kt
@@ -27,6 +27,11 @@ class FailFastOnStartTest : TestBase() {
     }
 
     @Test
+    fun testLaunchAtomic() = runTest(expected = ::mainException) {
+        launch(Dispatchers.Main, start = CoroutineStart.ATOMIC) {}
+    }
+
+    @Test
     fun testLaunchLazy() = runTest(expected = ::mainException) {
         val job = launch(Dispatchers.Main, start = CoroutineStart.LAZY) { fail() }
         job.join()


### PR DESCRIPTION
Fixes #4698.

`CoroutineStart.ATOMIC` currently uses `startCoroutine`. If the initial dispatch throws, the exception can bypass the fail-fast handling and leave the coroutine incomplete.

This change wraps the atomic start in `runSafely` while preserving its non-cancellable start semantics. It also adds a regression test for a dispatcher that throws during initial dispatch.

Tested with:

- `./gradlew :kotlinx-coroutines-core:jvmTest`
- `./gradlew :kotlinx-coroutines-core:checkKotlinAbi`