### PR TITLE
Update kotlinx-benchmark to v0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ kotlin_version=2.3.21
 atomicfu_version=0.32.1
 
 # Dependencies
-benchmarks_version=0.4.17
+benchmarks_version=0.5.0
 benchmarks_jmh_version=1.37
 junit_version=4.12
 junit5_version=5.7.0


### PR DESCRIPTION
Rationale: this change is needed for the `kotlin-community/dev` branch mostly, as older `kotlinx-benchmark` versions won't support Kotlin 2.5. At the same time, there are no reasons to use older version when there's a newer one, so instead of updating `kotlin-community/dev`, I would rather update the version for the project in general.