### PR TITLE
fix: use unsafeCast instead of `as` for the no runtime interfaces

### DIFF
--- a/kotlinx-coroutines-core/web/src/Promise.kt
+++ b/kotlinx-coroutines-core/web/src/Promise.kt
@@ -62,8 +62,7 @@ public fun <T: JsAny?> Deferred<T>.asPromise(): Promise<T> {
  */
 @OptIn(ExperimentalWasmJsInterop::class)
 public fun <T: JsAny?> Promise<T>.asDeferred(): Deferred<T> {
-    @Suppress("UNCHECKED_CAST", "UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    val deferred = promiseGetDeferred(this) as? JsReference<Deferred<T>>
+    val deferred = promiseGetDeferred(this)?.unsafeCast<JsReference<Deferred<T>>>()
     return deferred?.get() ?: GlobalScope.async(start = CoroutineStart.UNDISPATCHED) { await() }
 }
 


### PR DESCRIPTION
The commit is fixing a compilation error appearing during metadata compilation