### PR TITLE
Rename the `await` overloads that cancel the source to `consume`

### DIFF
--- a/integration/kotlinx-coroutines-guava/api/kotlinx-coroutines-guava.api
+++ b/integration/kotlinx-coroutines-guava/api/kotlinx-coroutines-guava.api
@@ -2,6 +2,7 @@ public final class kotlinx/coroutines/guava/ListenableFutureKt {
 	public static final fun asDeferred (Lcom/google/common/util/concurrent/ListenableFuture;)Lkotlinx/coroutines/Deferred;
 	public static final fun asListenableFuture (Lkotlinx/coroutines/Deferred;)Lcom/google/common/util/concurrent/ListenableFuture;
 	public static final fun await (Lcom/google/common/util/concurrent/ListenableFuture;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun consume (Lcom/google/common/util/concurrent/ListenableFuture;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun future (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Lcom/google/common/util/concurrent/ListenableFuture;
 	public static final fun future (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/Job;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Lcom/google/common/util/concurrent/ListenableFuture;
 	public static synthetic fun future$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/google/common/util/concurrent/ListenableFuture;

--- a/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
+++ b/integration/kotlinx-coroutines-guava/src/ListenableFuture.kt
@@ -232,18 +232,24 @@ public fun <T> Deferred<T>.asListenableFuture(): ListenableFuture<T> {
 }
 
 /**
- * Awaits completion of `this` [ListenableFuture] without blocking a thread.
+ * Await the result of this [ListenableFuture] without blocking the thread or cancel it if the result is not needed.
  *
- * This suspend function is cancellable.
+ * If the future completes, this function either returns its result [T] or throws the exception thrown by the task,
+ * depending on whether the future was successful.
+ * However, if the call to [consume] is cancelled before the future completes,
+ * the future also gets cancelled.
  *
- * If the [Job] of the current coroutine is cancelled while this suspending function is waiting, this function
- * stops waiting for the future and immediately resumes with [CancellationException][kotlinx.coroutines.CancellationException].
+ * This method is most suitable for cases where only one consumer is expected for the given [ListenableFuture]:
+ * this way, there is no need to explicitly cancel the future to avoid wasting resources.
+ * If cancelling the given future is undesired, use [Futures.nonCancellationPropagating]
+ * or convert the future to a [Deferred] using [asDeferred] and await that.
  *
- * This method is intended to be used with one-shot Futures, so on coroutine cancellation, the Future is cancelled as well.
- * If cancelling the given future is undesired, use [Futures.nonCancellationPropagating] or
- * [kotlinx.coroutines.NonCancellable].
+ * This suspending function is cancellable: if the [Job] of the current coroutine is cancelled while this
+ * suspending function is waiting, this function immediately resumes with [CancellationException].
+ * There is a **prompt cancellation guarantee**: even if this function is ready to return the result, but was cancelled
+ * while suspended, [CancellationException] will be thrown. See [suspendCancellableCoroutine] for low-level details.
  */
-public suspend fun <T> ListenableFuture<T>.await(): T {
+public suspend fun <T> ListenableFuture<T>.consume(): T {
     try {
         if (isDone) return Uninterruptibles.getUninterruptibly(this)
     } catch (e: ExecutionException) {
@@ -522,3 +528,24 @@ private class JobListenableFuture<T>(private val jobToCancel: Job): ListenableFu
  * class and pass it into [SettableFuture.complete]. See implementation of [JobListenableFuture].
  */
 private class Cancelled(@JvmField val exception: CancellationException)
+
+/**
+ * Deprecated synonym for [consume].
+ *
+ * This function is deprecated because it's inconsistent with how in `kotlinx.coroutines`,
+ * on its own cancellation, `await()` typically does not cancel the computation that's being awaited,
+ * whereas this function does.
+ *
+ * [consume] is the new name for this operation.
+ * If the computation has several consumers, [asDeferred] is recommended:
+ * the resulting [Deferred] can be awaited by multiple coroutines whose cancellation will not affect the computation.
+ */
+@Deprecated("The name is misleading: instead of just awaiting this value, " +
+    "the function also cancels the computation if the caller is cancelled. " +
+    "Either use this.consume() to preserve this single-shot semantics " +
+    "or call this.asDeferred().await() to avoid cancellation",
+    ReplaceWith("this.consume()"),
+    DeprecationLevel.WARNING
+)
+// WARNING in 1.12, ERROR in 1.14, HIDDEN in 1.16
+public suspend fun <T> ListenableFuture<T>.await(): T = consume()

--- a/integration/kotlinx-coroutines-guava/test/ListenableFutureExceptionsTest.kt
+++ b/integration/kotlinx-coroutines-guava/test/ListenableFutureExceptionsTest.kt
@@ -12,22 +12,22 @@ import kotlin.test.*
 class ListenableFutureExceptionsTest : TestBase() {
 
     @Test
-    fun testAwait() {
+    fun testConsume() {
         testException(IOException(), { it is IOException })
     }
 
     @Test
-    fun testAwaitChained() {
+    fun testConsumeChained() {
         testException(IOException(), { it is IOException }, { i -> i!! + 1 })
     }
 
     @Test
-    fun testAwaitCompletionException() {
+    fun testConsumeCompletionException() {
         testException(CompletionException("test", IOException()), { it is CompletionException })
     }
 
     @Test
-    fun testAwaitChainedCompletionException() {
+    fun testConsumeChainedCompletionException() {
         testException(
             CompletionException("test", IOException()),
             { it is CompletionException },
@@ -35,12 +35,12 @@ class ListenableFutureExceptionsTest : TestBase() {
     }
 
     @Test
-    fun testAwaitTestException() {
+    fun testConsumeTestException() {
         testException(TestException(), { it is TestException })
     }
 
     @Test
-    fun testAwaitChainedTestException() {
+    fun testConsumeChainedTestException() {
         testException(TestException(), { it is TestException }, { i -> i!! + 1 })
     }
 
@@ -60,7 +60,7 @@ class ListenableFutureExceptionsTest : TestBase() {
             }
             future.setException(exception)
             try {
-                chained.await()
+                chained.consume()
             } catch (e: Throwable) {
                 assertTrue(expected(e))
             }
@@ -79,7 +79,7 @@ class ListenableFutureExceptionsTest : TestBase() {
             }
 
             try {
-                chained.await()
+                chained.consume()
             } catch (e: Throwable) {
                 assertTrue(expected(e))
             }

--- a/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
+++ b/integration/kotlinx-coroutines-guava/test/ListenableFutureTest.kt
@@ -18,22 +18,22 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testSimpleAwait() {
+    fun testSimpleConsume() {
         val service = MoreExecutors.listeningDecorator(ForkJoinPool.commonPool())
         val future = GlobalScope.future {
-            service.submit(Callable<String> {
+            service.submit(Callable {
                 "O"
-            }).await() + "K"
+            }).consume() + "K"
         }
         assertEquals("OK", future.get())
     }
 
     @Test
-    fun testAwaitWithContext() = runTest {
+    fun testConsumeWithContext() = runTest {
         val future = SettableFuture.create<Int>()
         val deferred = async {
             withContext(Dispatchers.Default) {
-                future.await()
+                future.consume()
             }
         }
 
@@ -42,11 +42,11 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testAwaitWithCancellation() = runTest(expected = {it is TestCancellationException}) {
+    fun testConsumeWithCancellation() = runTest(expected = {it is TestCancellationException}) {
         val future = SettableFuture.create<Int>()
         val deferred = async {
             withContext(Dispatchers.Default) {
-                future.await()
+                future.consume()
             }
         }
 
@@ -60,7 +60,7 @@ class ListenableFutureTest : TestBase() {
         val toAwait = SettableFuture.create<String>()
         toAwait.set("O")
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertEquals("OK", future.get())
     }
@@ -69,7 +69,7 @@ class ListenableFutureTest : TestBase() {
     fun testWaitForFuture() {
         val toAwait = SettableFuture.create<String>()
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertFalse(future.isDone)
         toAwait.set("O")
@@ -82,7 +82,7 @@ class ListenableFutureTest : TestBase() {
         toAwait.setException(IllegalArgumentException("O"))
         val future = GlobalScope.future {
             try {
-                toAwait.await()
+                toAwait.consume()
             } catch (e: RuntimeException) {
                 assertIs<IllegalArgumentException>(e)
                 e.message!!
@@ -96,7 +96,7 @@ class ListenableFutureTest : TestBase() {
         val toAwait = SettableFuture.create<String>()
         val future = GlobalScope.future {
             try {
-                toAwait.await()
+                toAwait.consume()
             } catch (e: RuntimeException) {
                 assertIs<IllegalArgumentException>(e)
                 e.message!!
@@ -111,7 +111,7 @@ class ListenableFutureTest : TestBase() {
     fun testExceptionInsideCoroutine() {
         val service = MoreExecutors.listeningDecorator(ForkJoinPool.commonPool())
         val future = GlobalScope.future {
-            if (service.submit(Callable<Boolean> { true }).await()) {
+            if (service.submit(Callable { true }).consume()) {
                 throw IllegalStateException("OK")
             }
             "fail"
@@ -145,12 +145,12 @@ class ListenableFutureTest : TestBase() {
         }
         expect(3)
         val future = deferred.asListenableFuture()
-        assertEquals("OK", future.await())
+        assertEquals("OK", future.consume())
         finish(4)
     }
 
     @Test
-    fun testWaitForDeferredAsListenableFuture() = runBlocking {
+    fun testConsumeDeferredAsListenableFuture() = runBlocking {
         expect(1)
         val deferred = async {
             expect(3) // will complete later
@@ -158,7 +158,7 @@ class ListenableFutureTest : TestBase() {
         }
         expect(2)
         val future = deferred.asListenableFuture()
-        assertEquals("OK", future.await()) // await yields main thread to deferred coroutine
+        assertEquals("OK", future.consume()) // consume yields main thread to deferred coroutine
         finish(4)
     }
 
@@ -178,13 +178,13 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testCancellableAwait() = runBlocking {
+    fun testCancellableConsume() = runBlocking {
         expect(1)
         val toAwait = SettableFuture.create<String>()
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(2)
             try {
-                toAwait.await() // suspends
+                toAwait.consume() // suspends
             } catch (e: CancellationException) {
                 expect(5) // should throw cancellation exception
                 throw e
@@ -199,14 +199,13 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testFutureAwaitCancellationPropagatingToDeferred() = runTest {
-
+    fun testFutureConsumeCancellationPropagatingToDeferred() = runTest {
         val latch = CountDownLatch(1)
         val executor = MoreExecutors.listeningDecorator(ForkJoinPool.commonPool())
         val future = executor.submit(Callable { latch.await(); 42 })
         val deferred = async {
             expect(2)
-            future.await()
+            future.consume()
         }
         expect(1)
         yield()
@@ -221,14 +220,13 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testFutureAwaitCancellationPropagatingToDeferredNoInterruption() = runTest {
-
+    fun testFutureConsumeCancellationPropagatingToDeferredNoInterruption() = runTest {
         val latch = CountDownLatch(1)
         val executor = MoreExecutors.listeningDecorator(ForkJoinPool.commonPool())
         val future = executor.submit(Callable { latch.await(); 42 })
         val deferred = async {
             expect(2)
-            future.await()
+            future.consume()
         }
         expect(1)
         yield()
@@ -249,7 +247,7 @@ class ListenableFutureTest : TestBase() {
         val future = executor.submit(Callable { latch.await(); 42 })
         val deferred = async {
             expect(2)
-            future.await()
+            future.consume()
         }
         val asListenableFuture = deferred.asListenableFuture()
         expect(1)
@@ -272,7 +270,7 @@ class ListenableFutureTest : TestBase() {
         val future = executor.submit(Callable { latch.await(); 42 })
         val deferred = async {
             expect(2)
-            future.await()
+            future.consume()
         }
         val asListenableFuture = deferred.asListenableFuture()
         expect(1)
@@ -295,7 +293,7 @@ class ListenableFutureTest : TestBase() {
         val future = SettableFuture.create<Void>()
         val deferred = async {
             expect(2)
-            future.await()
+            future.consume()
         }
         val asListenableFuture = deferred.asListenableFuture()
         expect(1)
@@ -338,7 +336,7 @@ class ListenableFutureTest : TestBase() {
 
     @Test
     fun testFutureCancellation() = runTest {
-        val future = awaitFutureWithCancel(true)
+        val future = awaitOrConsumeFutureWithCancel(true)
         assertTrue(future.isCancelled)
         assertFailsWith<CancellationException> { future.get() }
         finish(4)
@@ -363,7 +361,7 @@ class ListenableFutureTest : TestBase() {
 
     @Test
     fun testNoFutureCancellation() = runTest {
-        val future = awaitFutureWithCancel(false)
+        val future = awaitOrConsumeFutureWithCancel(false)
         assertFalse(future.isCancelled)
         @Suppress("BlockingMethodInNonBlockingContext")
         assertEquals(42, future.get())
@@ -371,14 +369,14 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Test
-    fun testCancelledDeferredAsListenableFutureAwaitThrowsCancellation() = runTest {
+    fun testCancelledDeferredAsListenableFutureConsumeThrowsCancellation() = runTest {
         val future = Futures.immediateCancelledFuture<Int>()
         val asDeferred = future.asDeferred()
         val asDeferredAsFuture = asDeferred.asListenableFuture()
 
         assertTrue(asDeferredAsFuture.isCancelled)
         assertFailsWith<CancellationException> {
-            asDeferredAsFuture.await()
+            asDeferredAsFuture.consume()
         }
     }
 
@@ -711,13 +709,13 @@ class ListenableFutureTest : TestBase() {
     }
 
     @Suppress("SuspendFunctionOnCoroutineScope")
-    private suspend fun CoroutineScope.awaitFutureWithCancel(cancellable: Boolean): ListenableFuture<Int> {
+    private suspend fun CoroutineScope.awaitOrConsumeFutureWithCancel(doConsume: Boolean): ListenableFuture<Int> {
         val latch = CountDownLatch(1)
         val executor = MoreExecutors.listeningDecorator(ForkJoinPool.commonPool())
         val future = executor.submit(Callable { latch.await(); 42 })
         val deferred = async {
             expect(2)
-            if (cancellable) future.await()
+            if (doConsume) future.consume()
             else future.asDeferred().await()
         }
         expect(1)
@@ -784,8 +782,7 @@ class ListenableFutureTest : TestBase() {
         repeat(1000) {
             supervisorScope { // Don't propagate failures in children to parent and other children.
                 val innerFuture = SettableFuture.create<Unit>()
-                val outerFuture = async { innerFuture.await() }
-
+                val outerFuture = async { innerFuture.consume() }
                 withContext(Dispatchers.Default) {
                     launch { innerFuture.setException(TestException("can be lost")) }
                     launch { outerFuture.cancel() }

--- a/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
+++ b/integration/kotlinx-coroutines-play-services/api/kotlinx-coroutines-play-services.api
@@ -4,5 +4,6 @@ public final class kotlinx/coroutines/tasks/TasksKt {
 	public static final fun asTask (Lkotlinx/coroutines/Deferred;)Lcom/google/android/gms/tasks/Task;
 	public static final fun await (Lcom/google/android/gms/tasks/Task;Lcom/google/android/gms/tasks/CancellationTokenSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun await (Lcom/google/android/gms/tasks/Task;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun consume (Lcom/google/android/gms/tasks/Task;Lcom/google/android/gms/tasks/CancellationTokenSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/integration/kotlinx-coroutines-play-services/src/Tasks.kt
+++ b/integration/kotlinx-coroutines-play-services/src/Tasks.kt
@@ -98,14 +98,15 @@ private fun <T> Task<T>.asDeferredImpl(cancellationTokenSource: CancellationToke
  * If the [Job] of the current coroutine is cancelled while this suspending function is waiting, this function
  * stops waiting for the completion stage and immediately resumes with [CancellationException].
  *
- * For bi-directional cancellation, an overload that accepts [CancellationTokenSource] can be used.
+ * [consume] can be used for single-shot tasks whose results are not needed if the coroutine awaiting them is cancelled.
  */
 public suspend fun <T> Task<T>.await(): T = awaitImpl(null)
 
 /**
- * Awaits the completion of the task that is linked to the given [CancellationTokenSource] to control cancellation.
+ * Awaits the completion of the [Task] without blocking the thread, using the given [CancellationTokenSource] to cancel
+ * the task if the result is not needed.
  *
- * This suspending function is cancellable and cancellation is bi-directional:
+ * This suspending function is cancellable, and cancellation is bi-directional:
  * - If the [Job] of the current coroutine is cancelled while this suspending function is waiting, this function
  * cancels the [cancellationTokenSource] and throws a [CancellationException].
  * - If the task is cancelled, then this function will throw a [CancellationException].
@@ -113,9 +114,30 @@ public suspend fun <T> Task<T>.await(): T = awaitImpl(null)
  * Providing a [CancellationTokenSource] that is unrelated to the receiving [Task] is not supported and
  * leads to an unspecified behaviour.
  */
-@ExperimentalCoroutinesApi // Since 1.5.1, tentatively until 1.6.0
-public suspend fun <T> Task<T>.await(cancellationTokenSource: CancellationTokenSource): T =
+public suspend fun <T> Task<T>.consume(cancellationTokenSource: CancellationTokenSource): T =
     awaitImpl(cancellationTokenSource)
+
+/**
+ * Deprecated synonym for [consume].
+ *
+ * This function is deprecated because it's inconsistent with how in `kotlinx.coroutines`,
+ * on its own cancellation, `await()` typically does not cancel the computation that's being awaited,
+ * whereas this function does.
+ *
+ * [consume] is the new name for this operation.
+ * If the computation has several consumers, [asDeferred] is recommended:
+ * the resulting [Deferred] can be awaited by multiple coroutines whose cancellation will not affect the computation.
+ */
+@Deprecated("The name is misleading: instead of just awaiting this value, " +
+    "the function also cancels the computation if the caller is cancelled. " +
+    "Either use this.consume(cancellationTokenSource) to preserve this single-shot semantics " +
+    "or call this.asDeferred().await() to avoid cancellation",
+    ReplaceWith("this.consume(cancellationTokenSource)"),
+    DeprecationLevel.WARNING
+)
+// WARNING in 1.12, ERROR in 1.14, removed in 1.16 (was experimental)
+public suspend fun <T> Task<T>.await(cancellationTokenSource: CancellationTokenSource): T =
+    consume(cancellationTokenSource)
 
 private suspend fun <T> Task<T>.awaitImpl(cancellationTokenSource: CancellationTokenSource?): T {
     // fast path

--- a/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
+++ b/integration/kotlinx-coroutines-play-services/test/TaskTest.kt
@@ -278,7 +278,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>(cancellationTokenSource.token)
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -294,7 +294,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>(cancellationTokenSource.token)
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -309,7 +309,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>(cancellationTokenSource.token)
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -332,7 +332,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>(cancellationTokenSource.token)
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -356,7 +356,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>()
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.LAZY) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -377,7 +377,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>()
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.UNDISPATCHED) {
-            taskCompletionSource.task.await(cancellationTokenSource)
+            taskCompletionSource.task.consume(cancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)
@@ -399,7 +399,7 @@ class TaskTest : TestBase() {
         val taskCompletionSource = TaskCompletionSource<Int>(firstCancellationTokenSource.token)
 
         val deferred: Deferred<Int> = async(start = CoroutineStart.LAZY) {
-            taskCompletionSource.task.await(secondCancellationTokenSource)
+            taskCompletionSource.task.consume(secondCancellationTokenSource)
         }
 
         assertFalse(deferred.isCompleted)

--- a/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
+++ b/kotlinx-coroutines-core/api/kotlinx-coroutines-core.api
@@ -1312,6 +1312,7 @@ public final class kotlinx/coroutines/future/FutureKt {
 	public static final fun asCompletableFuture (Lkotlinx/coroutines/Job;)Ljava/util/concurrent/CompletableFuture;
 	public static final fun asDeferred (Ljava/util/concurrent/CompletionStage;)Lkotlinx/coroutines/Deferred;
 	public static final fun await (Ljava/util/concurrent/CompletionStage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun consume (Ljava/util/concurrent/CompletionStage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun future (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Ljava/util/concurrent/CompletableFuture;
 	public static final fun future (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/Job;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun future$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;

--- a/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
+++ b/kotlinx-coroutines-core/common/src/CancellableContinuation.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.intrinsics.*
  * from a callback or an external source of values that optionally supports cancellation:
  *
  * ```
- * suspend fun <T> CompletableFuture<T>.await(): T = suspendCancellableCoroutine { c ->
+ * suspend fun <T> CompletableFuture<T>.consume(): T = suspendCancellableCoroutine { c ->
  *     val future = this
  *     future.whenComplete { result, throwable ->
  *         if (throwable != null) {
@@ -35,7 +35,7 @@ import kotlin.coroutines.intrinsics.*
  *             c.resume(result)
  *         }
  *     }
- *     // Cancel the computation if the continuation itself was cancelled because a caller of 'await' is cancelled
+ *     // Cancel the computation if the continuation itself was cancelled because a caller of 'consume' is cancelled
  *     c.invokeOnCancellation { future.cancel(true) }
  * }
  * ```

--- a/kotlinx-coroutines-core/jvm/src/future/Future.kt
+++ b/kotlinx-coroutines-core/jvm/src/future/Future.kt
@@ -183,7 +183,7 @@ public fun <T> CompletionStage<T>.asDeferred(): Deferred<T> {
 }
 
 /**
- * Awaits for completion of [CompletionStage] without blocking a thread.
+ * Await the result of this [CompletionStage] without blocking the thread or cancel it if the result is not needed.
  *
  * This suspending function is cancellable.
  * If the [Job] of the current coroutine is cancelled while this suspending function is waiting, this function
@@ -193,7 +193,7 @@ public fun <T> CompletionStage<T>.asDeferred(): Deferred<T> {
  * corresponds to this [CompletionStage] (see [CompletionStage.toCompletableFuture])
  * is cancelled. If cancelling the given stage is undesired, `stage.asDeferred().await()` should be used instead.
  */
-public suspend fun <T> CompletionStage<T>.await(): T {
+public suspend fun <T> CompletionStage<T>.consume(): T {
     val future = toCompletableFuture() // retrieve the future
     // fast path when CompletableFuture is already done (does not suspend)
     if (future.isDone) {
@@ -238,10 +238,31 @@ private class CancelFutureOnCompletion(
 
     override fun invoke(cause: Throwable?) {
         // Don't interrupt when cancelling future on completion, because no one is going to reset this
-        // interruption flag and it will cause spurious failures elsewhere.
+        // interruption flag, and it will cause spurious failures elsewhere.
         // We do not cancel the future if it's already completed in some way,
         // because `cancel` on a completed future won't change the state but is not guaranteed to behave well
         // on reentrancy. See https://github.com/Kotlin/kotlinx.coroutines/issues/4156
         if (cause != null && !future.isDone) future.cancel(false)
     }
 }
+
+/**
+ * Deprecated synonym for [consume].
+ *
+ * This function is deprecated because it's inconsistent with how in `kotlinx.coroutines`,
+ * on its own cancellation, `await()` typically does not cancel the computation that's being awaited,
+ * whereas this function does.
+ *
+ * [consume] is the new name for this operation.
+ * If the computation has several consumers, [asDeferred] is recommended:
+ * the resulting [Deferred] can be awaited by multiple coroutines whose cancellation will not affect the computation.
+ */
+@Deprecated("The name is misleading: instead of just awaiting this value, " +
+    "the function also cancels the computation if the caller is cancelled. " +
+    "Either use this.consume() to preserve this single-shot semantics " +
+    "or call this.asDeferred().await() to avoid cancellation",
+    ReplaceWith("this.consume()"),
+    DeprecationLevel.WARNING
+)
+// WARNING in 1.12, ERROR in 1.14, HIDDEN in 1.16
+public suspend fun <T> CompletionStage<T>.await(): T = consume()

--- a/kotlinx-coroutines-core/jvm/test/CancellableContinuationJvmTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/CancellableContinuationJvmTest.kt
@@ -31,7 +31,7 @@ class CancellableContinuationJvmTest : TestBase() {
     fun testBlockingIntegration() = runTest {
         val source = BlockingSource()
         val job = launch(Dispatchers.Default) {
-            source.await()
+            source.consume()
         }
         source.cancelAndJoin(job)
     }
@@ -41,7 +41,7 @@ class CancellableContinuationJvmTest : TestBase() {
         val source = BlockingSource()
         val job = launch(Dispatchers.Default) {
             cancel()
-            source.await()
+            source.consume()
         }
         source.cancelAndJoin(job)
     }
@@ -53,7 +53,7 @@ class CancellableContinuationJvmTest : TestBase() {
         job.cancelAndJoin()
     }
 
-    private suspend fun BlockingSource.await() = suspendCancellableCoroutine<Unit> {
+    private suspend fun BlockingSource.consume() = suspendCancellableCoroutine<Unit> {
         it.invokeOnCancellation { this.cancel() }
         subscribe()
     }

--- a/kotlinx-coroutines-core/jvm/test/jdk8/future/AsFutureTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/jdk8/future/AsFutureTest.kt
@@ -18,7 +18,7 @@ class AsFutureTest : TestBase() {
         }
         expect(3)
         val future = deferred.asCompletableFuture()
-        assertEquals("OK", future.await())
+        assertEquals("OK", future.consume())
         finish(4)
     }
 
@@ -26,7 +26,7 @@ class AsFutureTest : TestBase() {
     fun testCompletedJobAsCompletableFuture() = runTest {
         val job = Job().apply { complete() }
         val future = job.asCompletableFuture()
-        assertEquals(Unit, future.await())
+        assertEquals(Unit, future.consume())
     }
 
     @Test
@@ -38,7 +38,7 @@ class AsFutureTest : TestBase() {
         }
         expect(2)
         val future = deferred.asCompletableFuture()
-        assertEquals("OK", future.await()) // await yields main thread to deferred coroutine
+        assertEquals("OK", future.consume()) // await yields main thread to deferred coroutine
         finish(4)
     }
 
@@ -49,7 +49,7 @@ class AsFutureTest : TestBase() {
         assertTrue(job.isActive)
         job.complete()
         assertFalse(job.isActive)
-        assertEquals(Unit, future.await())
+        assertEquals(Unit, future.consume())
     }
 
     @Test
@@ -92,7 +92,7 @@ class AsFutureTest : TestBase() {
             expect(1)
             future.get()
             expectUnreached()
-        } catch (e: CancellationException) {
+        } catch (_: CancellationException) {
             assertTrue(future.isCompletedExceptionally)
             finish(2)
         }

--- a/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureExceptionsTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureExceptionsTest.kt
@@ -2,7 +2,6 @@ package kotlinx.coroutines.future
 
 import kotlinx.coroutines.testing.*
 import kotlinx.coroutines.*
-import org.junit.Test
 import java.io.*
 import java.util.concurrent.*
 import kotlin.test.*
@@ -10,17 +9,17 @@ import kotlin.test.*
 class FutureExceptionsTest : TestBase() {
 
     @Test
-    fun testAwait() {
+    fun testConsume() {
         testException(IOException(), { it is IOException })
     }
 
     @Test
-    fun testAwaitChained() {
+    fun testConsumeChained() {
         testException(IOException(), { it is IOException }, { f -> f.thenApply { it + 1 } })
     }
 
     @Test
-    fun testAwaitDeepChain() {
+    fun testConsumeDeepChain() {
         testException(IOException(), { it is IOException },
             { f -> f
                 .thenApply { it + 1 }
@@ -28,22 +27,22 @@ class FutureExceptionsTest : TestBase() {
     }
 
     @Test
-    fun testAwaitCompletionException() {
+    fun testConsumeCompletionException() {
         testException(CompletionException("test", IOException()), { it is IOException })
     }
 
     @Test
-    fun testAwaitChainedCompletionException() {
+    fun testConsumeChainedCompletionException() {
         testException(CompletionException("test", IOException()), { it is IOException }, { f -> f.thenApply { it + 1 } })
     }
 
     @Test
-    fun testAwaitTestException() {
+    fun testConsumeTestException() {
         testException(TestException(), { it is TestException })
     }
 
     @Test
-    fun testAwaitChainedTestException() {
+    fun testConsumeChainedTestException() {
         testException(TestException(), { it is TestException }, { f -> f.thenApply { it + 1 } })
     }
 
@@ -59,7 +58,7 @@ class FutureExceptionsTest : TestBase() {
             val chained = transformer(future)
             future.completeExceptionally(exception)
             try {
-                chained.await()
+                chained.consume()
             } catch (e: Throwable) {
                 assertTrue(expected(e))
             }
@@ -75,7 +74,7 @@ class FutureExceptionsTest : TestBase() {
             }
 
             try {
-                chained.await()
+                chained.consume()
             } catch (e: Throwable) {
                 assertTrue(expected(e))
             }

--- a/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/jdk8/future/FutureTest.kt
@@ -1,33 +1,31 @@
 package kotlinx.coroutines.future
 
 import kotlinx.coroutines.testing.*
+import kotlinx.coroutines.testing.CountDownLatch
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import org.junit.*
-import org.junit.Test
 import java.lang.IllegalArgumentException
 import java.util.concurrent.*
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.*
 import java.util.concurrent.locks.*
-import java.util.function.*
+import kotlin.concurrent.atomics.*
 import kotlin.concurrent.withLock
 import kotlin.coroutines.*
 import kotlin.reflect.*
 import kotlin.test.*
 
+@OptIn(ExperimentalAtomicApi::class)
 class FutureTest : TestBase() {
-    @Before
+    @BeforeTest
     fun setup() {
         ignoreLostThreads("ForkJoinPool.commonPool-worker-")
     }
 
     @Test
-    fun testSimpleAwait() {
+    fun testSimpleConsume() {
         val future = GlobalScope.future {
             CompletableFuture.supplyAsync {
                 "O"
-            }.await() + "K"
+            }.consume() + "K"
         }
         assertEquals("OK", future.get())
     }
@@ -37,7 +35,7 @@ class FutureTest : TestBase() {
         val toAwait = CompletableFuture<String>()
         toAwait.complete("O")
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertEquals("OK", future.get())
     }
@@ -48,7 +46,7 @@ class FutureTest : TestBase() {
         completable.complete("O")
         val toAwait: CompletionStage<String> = completable
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertEquals("OK", future.get())
     }
@@ -57,7 +55,7 @@ class FutureTest : TestBase() {
     fun testWaitForFuture() {
         val toAwait = CompletableFuture<String>()
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertFalse(future.isDone)
         toAwait.complete("O")
@@ -69,7 +67,7 @@ class FutureTest : TestBase() {
         val completable = CompletableFuture<String>()
         val toAwait: CompletionStage<String> = completable
         val future = GlobalScope.future {
-            toAwait.await() + "K"
+            toAwait.consume() + "K"
         }
         assertFalse(future.isDone)
         completable.complete("O")
@@ -82,7 +80,7 @@ class FutureTest : TestBase() {
         toAwait.completeExceptionally(TestException("O"))
         val future = GlobalScope.future {
             try {
-                toAwait.await()
+                toAwait.consume()
             } catch (e: TestException) {
                 e.message!!
             } + "K"
@@ -91,14 +89,14 @@ class FutureTest : TestBase() {
     }
 
     @Test
-    // Test fast-path of CompletionStage.await() extension
+    // Test fast-path of CompletionStage.consume() extension
     fun testCompletedCompletionStageExceptionally() {
         val completable = CompletableFuture<String>()
         val toAwait: CompletionStage<String> = completable
         completable.completeExceptionally(TestException("O"))
         val future = GlobalScope.future {
             try {
-                toAwait.await()
+                toAwait.consume()
             } catch (e: TestException) {
                 e.message!!
             } + "K"
@@ -107,14 +105,14 @@ class FutureTest : TestBase() {
     }
 
     @Test
-    // Test slow-path of CompletionStage.await() extension
+    // Test slow-path of CompletionStage.consume() extension
     fun testWaitForFutureWithException() = runTest {
         expect(1)
         val toAwait = CompletableFuture<String>()
         val future = future(start = CoroutineStart.UNDISPATCHED) {
             try {
                 expect(2)
-                toAwait.await() // will suspend (slow path)
+                toAwait.consume() // will suspend (slow path)
             } catch (e: TestException) {
                 expect(4)
                 e.message!!
@@ -134,7 +132,7 @@ class FutureTest : TestBase() {
         val toAwait: CompletionStage<String> = completable
         val future = GlobalScope.future {
             try {
-                toAwait.await()
+                toAwait.consume()
             } catch (e: TestException) {
                 e.message!!
             } + "K"
@@ -147,7 +145,7 @@ class FutureTest : TestBase() {
     @Test
     fun testExceptionInsideCoroutine() {
         val future = GlobalScope.future {
-            if (CompletableFuture.supplyAsync { true }.await()) {
+            if (CompletableFuture.supplyAsync { true }.consume()) {
                 throw IllegalStateException("OK")
             }
             "fail"
@@ -162,13 +160,13 @@ class FutureTest : TestBase() {
     }
 
     @Test
-    fun testCancellableAwaitFuture() = runBlocking {
+    fun testCancellableConsumeFuture() = runBlocking {
         expect(1)
         val toAwait = CompletableFuture<String>()
         val job = launch(start = CoroutineStart.UNDISPATCHED) {
             expect(2)
             try {
-                toAwait.await() // suspends
+                toAwait.consume() // suspends
             } catch (e: CancellationException) {
                 expect(5) // should throw cancellation exception
                 throw e
@@ -184,25 +182,25 @@ class FutureTest : TestBase() {
 
     @Test
     fun testContinuationWrapped() {
-        val depth = AtomicInteger()
+        val depth = AtomicInt(0)
         val future = GlobalScope.future(wrapContinuation {
-            depth.andIncrement
+            depth.fetchAndIncrement()
             it()
-            depth.andDecrement
+            depth.fetchAndDecrement()
         }) {
-            assertEquals(1, depth.get(), "Part before first suspension must be wrapped")
+            assertEquals(1, depth.load(), "Part before first suspension must be wrapped")
             val result =
                     CompletableFuture.supplyAsync {
-                        while (depth.get() > 0);
-                        assertEquals(0, depth.get(), "Part inside suspension point should not be wrapped")
+                        while (depth.load() > 0);
+                        assertEquals(0, depth.load(), "Part inside suspension point should not be wrapped")
                         "OK"
-                    }.await()
-            assertEquals(1, depth.get(), "Part after first suspension should be wrapped")
+                    }.consume()
+            assertEquals(1, depth.load(), "Part after first suspension should be wrapped")
             CompletableFuture.supplyAsync {
-                while (depth.get() > 0);
-                assertEquals(0, depth.get(), "Part inside suspension point should not be wrapped")
+                while (depth.load() > 0);
+                assertEquals(0, depth.load(), "Part inside suspension point should not be wrapped")
                 "ignored"
-            }.await()
+            }.consume()
             result
         }
         assertEquals("OK", future.get())
@@ -274,9 +272,9 @@ class FutureTest : TestBase() {
     @Test
     fun testApiBridge() = runTest {
         val result = newSingleThreadContext("ctx").use {
-            val future = CompletableFuture.supplyAsync(Supplier { threadLocal.set("value") }, it.executor)
+            val future = CompletableFuture.supplyAsync({ threadLocal.set("value") }, it.executor)
             val job = async(it) {
-                future.await()
+                future.consume()
                 threadLocal.get()
             }
 
@@ -288,7 +286,7 @@ class FutureTest : TestBase() {
 
     @Test
     fun testFutureCancellation() = runTest {
-        val future = awaitFutureWithCancel(true)
+        val future = consumeFutureWithCancel(true)
         assertTrue(future.isCompletedExceptionally)
         assertFailsWith<CancellationException> { future.get() }
         finish(4)
@@ -296,13 +294,13 @@ class FutureTest : TestBase() {
 
     @Test
     fun testNoFutureCancellation() = runTest {
-        val future = awaitFutureWithCancel(false)
+        val future = consumeFutureWithCancel(false)
         assertFalse(future.isCompletedExceptionally)
         assertEquals(239, future.get())
         finish(4)
     }
 
-    private suspend fun CoroutineScope.awaitFutureWithCancel(cancellable: Boolean): CompletableFuture<Int> {
+    private suspend fun CoroutineScope.consumeFutureWithCancel(cancellable: Boolean): CompletableFuture<Int> {
         val latch = CountDownLatch(1)
         val future = CompletableFuture.supplyAsync {
             latch.await()
@@ -311,7 +309,7 @@ class FutureTest : TestBase() {
 
         val deferred = async {
             expect(2)
-            if (cancellable) future.await()
+            if (cancellable) future.consume()
             else future.asDeferred().await()
         }
         expect(1)
@@ -419,7 +417,7 @@ class FutureTest : TestBase() {
                         try {
                             CompletableFuture.supplyAsync {
                                 throw TestException()
-                            }.await()
+                            }.consume()
                         } catch (ignored: TestException) {
                             caught = true
                         }
@@ -447,7 +445,7 @@ class FutureTest : TestBase() {
         // Fast path in await and asDeferred.await() shall produce TestException
         expect(3)
         val dFast = fFast.asDeferred()
-        assertFailsWith<TestException> { fFast.await() }
+        assertFailsWith<TestException> { fFast.consume() }
         assertFailsWith<TestException> { dFast.await() }
         // Same test, but future has not completed yet, check the slow path
         expect(4)
@@ -461,7 +459,7 @@ class FutureTest : TestBase() {
         launch(start = CoroutineStart.UNDISPATCHED) {
             expect(5)
             // Slow path on await shall produce TestException, too
-            assertFailsWith<TestException> { fSlow.await() } // will suspend here
+            assertFailsWith<TestException> { fSlow.consume() } // will suspend here
             assertFailsWith<TestException> { dSlow.await() }
             finish(7)
         }
@@ -490,9 +488,9 @@ class FutureTest : TestBase() {
      * https://github.com/Kotlin/kotlinx.coroutines/issues/2456
      */
     @Test
-    fun testCompletedStageAwait() = runTest {
+    fun testCompletedStageConsume() = runTest {
         val stage = CompletableFuture.completedStage("OK")
-        assertEquals("OK", stage.await())
+        assertEquals("OK", stage.consume())
     }
 
     /**
@@ -506,7 +504,7 @@ class FutureTest : TestBase() {
     }
 
     @Test
-    fun testCompletedStateThenApplyAwait() = runTest {
+    fun testCompletedStateThenApplyConsume() = runTest {
         expect(1)
         val cf = CompletableFuture<String>()
         launch {
@@ -515,7 +513,7 @@ class FutureTest : TestBase() {
         }
         expect(2)
         val stage = cf.thenApply { it + "K" }
-        assertEquals("OK", stage.await())
+        assertEquals("OK", stage.consume())
         finish(4)
     }
 
@@ -529,7 +527,7 @@ class FutureTest : TestBase() {
         }
         expect(2)
         val stage = cf.thenApply { it + "K" }
-        assertFailsWith<CancellationException> { stage.await() }
+        assertFailsWith<CancellationException> { stage.consume() }
         finish(4)
     }
 
@@ -549,7 +547,7 @@ class FutureTest : TestBase() {
     }
 
     @Test
-    fun testCompletedStateThenApplyAsDeferredAwaitCancel() = runTest {
+    fun testCompletedStateThenApplyAsDeferredConsumeCancel() = runTest {
         expect(1)
         val cf = CompletableFuture<String>()
         expect(2)
@@ -559,7 +557,7 @@ class FutureTest : TestBase() {
             expect(3)
             deferred.cancel() // cancel the deferred!
         }
-        assertFailsWith<CancellationException> { stage.await() }
+        assertFailsWith<CancellationException> { stage.consume() }
         finish(4)
     }
 
@@ -574,19 +572,19 @@ class FutureTest : TestBase() {
     @Test
     fun testStackOverflow() = runTest {
         val future = CompletableFuture<Int>()
-        val completed = AtomicLong()
+        val completed = AtomicLong(0)
         val count = 10000L
         val children = ArrayList<Job>()
         for (i in 0 until count) {
             children += launch(Dispatchers.Default) {
                 future.asDeferred().await()
-                completed.incrementAndGet()
+                completed.fetchAndIncrement()
             }
         }
         future.complete(1)
         withTimeout(60_000) {
             children.forEach { it.join() }
-            assertEquals(count, completed.get())
+            assertEquals(count, completed.load())
         }
     }
 
@@ -601,7 +599,7 @@ class FutureTest : TestBase() {
     fun testStackOverflowOnExceptionalCompletion() = runTest {
         val future = CompletableFuture<Unit>()
         val didRun = AtomicBoolean(false)
-        future.whenComplete { _, _ -> didRun.set(true) }
+        future.whenComplete { _, _ -> didRun.store(true) }
         val deferreds = List(100000) { future.asDeferred() }
         future.completeExceptionally(TestException())
         deferreds.forEach {
@@ -610,6 +608,6 @@ class FutureTest : TestBase() {
             assertIs<TestException>(exception)
             assertTrue(exception.suppressedExceptions.isEmpty())
         }
-        assertTrue(didRun.get())
+        assertTrue(didRun.load())
     }
 }

--- a/ui/kotlinx-coroutines-swing/test/examples/SwingExampleApp.kt
+++ b/ui/kotlinx-coroutines-swing/test/examples/SwingExampleApp.kt
@@ -34,7 +34,7 @@ private fun createAndShowGUI() {
             // 'append' method and consequent 'jProgressBar.setValue' are called
             // within Swing event dispatch thread
             jTextArea.append(
-                    startLongAsyncOperation(i).await()
+                startLongAsyncOperation(i).consume()
             )
             jProgressBar.value = i * 10
         }


### PR DESCRIPTION
Fixes #4329
Fixes #4358

See the issue for the rationale.