### PR TITLE
Temporarily set `-Xallow-pre-17-runtime-jdk`

### DIFF
--- a/kotlinx-coroutines-core/build.gradle.kts
+++ b/kotlinx-coroutines-core/build.gradle.kts
@@ -44,6 +44,10 @@ apply(plugin = "pub-conventions")
  ========================================================================== */
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xallow-pre-17-runtime-jdk")
+    }
+
     sourceSets {
         // using the source set names from <https://kotlinlang.org/docs/multiplatform-hierarchy.html#see-the-full-hierarchy-template>
         groupSourceSets("concurrent", listOf("jvm", "native"), listOf("common"))


### PR DESCRIPTION
Bumping `jdk_toolchain_version=11` up to 17 and setting additional `jvmToolchain(jdkToolchainVersion)` in `:kotlinx-coroutines-core` still runs the compiler with JDK 11 taken from `JAVA_HOME`, which must be addressed separately.

Main PR to Kotlin: https://github.com/JetBrains/kotlin/pull/7833

^[KT-88174](https://youtrack.jetbrains.com/issue/KT-88174)
