### PR TITLE
Prevent SMARTCAST_IMPOSSIBLE error on 2.4 update

### DIFF
--- a/reactive/kotlinx-coroutines-rx2/test/ObservableAsFlowTest.kt
+++ b/reactive/kotlinx-coroutines-rx2/test/ObservableAsFlowTest.kt
@@ -128,7 +128,8 @@ class ObservableAsFlowTest : TestBase() {
         assertNotNull(observer)
         job.cancel()
         val disposable = Disposables.empty()
-        observer.onSubscribe(disposable)
+        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION") // It is necessary and Kotlin 2.4+ requires it here
+        observer!!.onSubscribe(disposable)
         assertTrue(disposable.isDisposed)
         finish(3)
     }

--- a/reactive/kotlinx-coroutines-rx3/test/ObservableAsFlowTest.kt
+++ b/reactive/kotlinx-coroutines-rx3/test/ObservableAsFlowTest.kt
@@ -128,7 +128,8 @@ class ObservableAsFlowTest : TestBase() {
         assertNotNull(observer)
         job.cancel()
         val disposable = Disposable.empty()
-        observer.onSubscribe(disposable)
+        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION") // It is necessary and Kotlin 2.4+ requires it here
+        observer!!.onSubscribe(disposable)
         assertTrue(disposable.isDisposed)
         finish(3)
     }


### PR DESCRIPTION
Updating Kotlin version to 2.4 will inevitably cause compilation error in code that currently compiles without any warnings. 