### PR TITLE
Fix ThreadContextElement scope lifetime across suspension in withContextUndispatched

### DIFF
--- a/kotlinx-coroutines-core/common/src/flow/internal/ChannelFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/ChannelFlow.kt
@@ -217,8 +217,8 @@ internal suspend fun <T, V> withContextUndispatched(
     value: V,
     countOrElement: Any = threadContextElements(newContext), // can be precomputed for speed
     block: suspend (V) -> T
-): T = withCoroutineContext(newContext, countOrElement) {
-    suspendCoroutineUninterceptedOrReturn { uCont ->
+): T = suspendCoroutineUninterceptedOrReturn { uCont ->
+    withCoroutineContext(newContext, countOrElement) {
         block.startCoroutineUninterceptedOrReturn(value, StackFrameContinuation(uCont, newContext))
     }
 }
@@ -232,7 +232,9 @@ private class StackFrameContinuation<T>(
         get() = uCont as? CoroutineStackFrame
 
     override fun resumeWith(result: Result<T>) {
-        uCont.resumeWith(result)
+        withContinuationContext(uCont, null) {
+            uCont.resumeWith(result)
+        }
     }
 
     override fun getStackTraceElement(): StackTraceElement? = null

--- a/kotlinx-coroutines-core/jvm/test/ThreadContextElementTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/ThreadContextElementTest.kt
@@ -285,6 +285,58 @@ class ThreadContextElementTest : TestBase() {
             myThreadLocal.set(null)
         }
     }
+
+    @Test
+    fun testUndispatchedFlowScopeLifetimeOnSuspension() = runTest {
+        val trackingStack = ArrayDeque<Int>()
+
+        class ScopedTrackingElement(val id: Int) : ThreadContextElement<Int> {
+            override val key: CoroutineContext.Key<*> get() = Key
+
+            companion object Key : CoroutineContext.Key<ScopedTrackingElement>
+
+            override fun updateThreadContext(context: CoroutineContext): Int {
+                trackingStack.addLast(id)
+                return id
+            }
+
+            override fun restoreThreadContext(context: CoroutineContext, oldState: Int) {
+                val popped = if (trackingStack.isNotEmpty()) trackingStack.removeLast() else null
+                assertEquals(id, popped, "Scope $id was restored out of order; top of stack was $popped")
+            }
+        }
+
+        try {
+            withContext(ScopedTrackingElement(1)) {
+                flow {
+                    emit(1)
+                    yield()
+                    emit(2)
+                }
+                    .flowOn(ScopedTrackingElement(2))
+                    .collect {
+                        yield()
+                    }
+            }
+            assertTrue(trackingStack.isEmpty(), "Expected all scopes to be closed, but stack was: $trackingStack")
+
+            withContext(ScopedTrackingElement(1)) {
+                flow {
+                    emit(1)
+                    yield()
+                    emit(2)
+                }
+                    .flowOn(ScopedTrackingElement(3))
+                    .flowOn(ScopedTrackingElement(2))
+                    .collect {
+                        yield()
+                    }
+            }
+            assertTrue(trackingStack.isEmpty(), "Expected all scopes to be closed, but stack was: $trackingStack")
+        } finally {
+            trackingStack.clear()
+        }
+    }
 }
 
 class MyData


### PR DESCRIPTION
Fixes #4754
Fixes #4755
Ref: https://github.com/spring-projects/spring-framework/issues/36929

### Problem

In 1.11.0, #4431 (commit `307d65b`) changed `withContextUndispatched` in `ChannelFlow.kt` so that `withCoroutineContext` enclosed `suspendCoroutineUninterceptedOrReturn`. 

Because `withCoroutineContext` became part of the suspending state machine, its `finally` block (invoking `restoreThreadContext`) does not run when `startCoroutineUninterceptedOrReturn` returns `COROUTINE_SUSPENDED`. Instead, restoration is deferred until the coroutine resumes. 

As a result:
- When an undispatched block suspends (e.g. during a `flowOn` collection where the collector or upstream suspends), the inner thread context element remains active on the thread across the suspension point.
- The outer coroutine's cleanup runs while the inner scope is still present, violating the LIFO stack order contract of `ThreadContextElement` (e.g., tripping `ObservationThreadLocalAccessor.restore` assertions in Spring Framework / Micrometer).

A naive revert of the nesting resolves the suspension leak, but causes `testThreadLocalFlowOn` to fail when `yield = true` and `extraFlowOnContext = EmptyCoroutineContext`. In that scenario, when the block finishes after suspension, `StackFrameContinuation.resumeWith` delegates directly to `uCont.resumeWith` while the dispatch machinery still has `newContext` active on the thread, so the caller continuation resumes with the wrong thread-local context.

### Solution

1. **Revert nesting in `withContextUndispatched`**: Enclose `withCoroutineContext` inside `suspendCoroutineUninterceptedOrReturn`. When `block.startCoroutineUninterceptedOrReturn` returns `COROUTINE_SUSPENDED`, `withCoroutineContext`'s `finally` block runs immediately, restoring the thread-local state on suspension.
2. **Transition context in `StackFrameContinuation.resumeWith`**: Wrap `uCont.resumeWith(result)` with `withContinuationContext(uCont, null)`. Reusing the pattern established in `UndispatchedCoroutine.afterResume`, this switches the thread context to `uCont.context` before resuming the caller continuation and restores it in `finally`.

### Testing

- Added `testUndispatchedFlowScopeLifetimeOnSuspension` to `ThreadContextElementTest.kt`, verifying that scoped elements are opened and closed in strict LIFO stack order across suspensions in both single and nested `flowOn` chains.
- Verified against the existing `testThreadLocalFlowOn` matrix test covering all combinations of dispatchers, `yield`, and outer thread-local contexts.